### PR TITLE
fix: 앱 시작 시 로딩 상태 아이콘을 오렌지로 변경

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -127,7 +127,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     app.manage(tray_state);
 
     let _tray = TrayIconBuilder::with_id("main-tray")
-        .icon(icon_for_phase(DailyPhase::Idle, false))
+        .icon(Image::from_bytes(ICON_WARNING).expect("invalid icon PNG"))
         .tooltip("Jungle Bell")
         .menu(&menu)
         .on_menu_event(move |app, event| match event.id().as_ref() {


### PR DESCRIPTION
## Summary
- 앱 시작 시 초기 트레이 아이콘이 흰색(Idle)으로 표시되다가 체커 첫 보고 후 즉시 빨간색으로 전환되는 문제 수정
- 데이터 로딩 전(`data_loaded: false`) 상태에서도 오렌지 아이콘(ICON_WARNING)을 표시하도록 초기값 변경
- 로그인은 되어있지만 출석 상태를 아직 불러오지 않은 경우, 빨간색 대신 오렌지(노랑)로 표시

## Test plan
- [ ] 앱 시작 직후 트레이 아이콘이 오렌지 색으로 표시되는지 확인
- [ ] 체커가 상태를 불러온 후 적절한 색상(흰색/오렌지/빨간색)으로 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)