### PR TITLE
Update actions/checkout for Node 24 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: setup node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- update the release workflow from actions/checkout@v4 to actions/checkout@v5
- keep the existing setup-node and tauri release steps unchanged
- resolve the GitHub Actions Node.js 20 deprecation warning for the Windows publish job

## Testing
- git diff --check