### PR TITLE
feat: 자동 시작(autostart) 플러그인 적용

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -251,6 +251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,11 +863,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -867,7 +898,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -979,7 +1010,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2086,12 +2117,13 @@ name = "jungle-bell"
 version = "0.0.3-beta.1"
 dependencies = [
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "log",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -3233,6 +3265,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4182,7 +4225,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4233,7 +4276,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4303,6 +4346,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4396,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -4869,7 +4926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5791,6 +5848,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -5903,7 +5969,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri-plugin-autostart = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -135,20 +135,28 @@ pub fn get_app_version(app: tauri::AppHandle) -> String {
 
 /// Tauri 커맨드: 자동 시작 설정 조회.
 #[tauri::command]
-pub fn get_auto_start(app: tauri::AppHandle) -> Result<bool, String> {
-    app.autolaunch().is_enabled().map_err(|e| e.to_string())
+pub async fn get_auto_start(state: tauri::State<'_, Arc<Mutex<AppState>>>) -> Result<bool, String> {
+    Ok(state.lock().await.config.auto_start)
 }
 
-/// Tauri 커맨드: 자동 시작 설정 변경.
+/// Tauri 커맨드: 자동 시작 설정 변경 및 저장.
 #[tauri::command]
-pub fn set_auto_start(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+pub async fn set_auto_start(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<Mutex<AppState>>>,
+    enabled: bool,
+) -> Result<(), String> {
     log::info!("자동 시작 설정 변경: {}", enabled);
     let autolaunch = app.autolaunch();
     if enabled {
-        autolaunch.enable().map_err(|e| e.to_string())
+        autolaunch.enable().map_err(|e| e.to_string())?;
     } else {
-        autolaunch.disable().map_err(|e| e.to_string())
+        autolaunch.disable().map_err(|e| e.to_string())?;
     }
+    let mut s = state.lock().await;
+    s.config.auto_start = enabled;
+    s.config.save();
+    Ok(())
 }
 
 /// Tauri 커맨드: 업데이트 확인 후 결과를 시스템 다이얼로그로 표시.

--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -147,15 +147,16 @@ pub async fn set_auto_start(
     enabled: bool,
 ) -> Result<(), String> {
     log::info!("자동 시작 설정 변경: {}", enabled);
-    let autolaunch = app.autolaunch();
-    if enabled {
-        autolaunch.enable().map_err(|e| e.to_string())?;
-    } else {
-        autolaunch.disable().map_err(|e| e.to_string())?;
+    // 앱 설정을 먼저 저장한 후 OS 설정을 변경한다.
+    // OS 변경에 실패하더라도 다음 실행 시 setup에서 Config 기준으로 재동기화된다.
+    {
+        let mut s = state.lock().await;
+        s.config.auto_start = enabled;
+        s.config.save();
     }
-    let mut s = state.lock().await;
-    s.config.auto_start = enabled;
-    s.config.save();
+    let autolaunch = app.autolaunch();
+    let result = if enabled { autolaunch.enable() } else { autolaunch.disable() };
+    result.map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use tauri::Emitter;
 use tokio::sync::Mutex;
 
+use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
 use tauri_plugin_updater::UpdaterExt;
 
 use crate::state::{self, AppState};
@@ -130,6 +131,24 @@ pub async fn set_auto_update(
 #[tauri::command]
 pub fn get_app_version(app: tauri::AppHandle) -> String {
     app.package_info().version.to_string()
+}
+
+/// Tauri 커맨드: 자동 시작 설정 조회.
+#[tauri::command]
+pub fn get_auto_start(app: tauri::AppHandle) -> Result<bool, String> {
+    app.autolaunch().is_enabled().map_err(|e| e.to_string())
+}
+
+/// Tauri 커맨드: 자동 시작 설정 변경.
+#[tauri::command]
+pub fn set_auto_start(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    log::info!("자동 시작 설정 변경: {}", enabled);
+    let autolaunch = app.autolaunch();
+    if enabled {
+        autolaunch.enable().map_err(|e| e.to_string())
+    } else {
+        autolaunch.disable().map_err(|e| e.to_string())
+    }
 }
 
 /// Tauri 커맨드: 업데이트 확인 후 결과를 시스템 다이얼로그로 표시.

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -27,6 +27,9 @@ pub struct Config {
     /// 앱 시작 시 자동 업데이트 확인 여부 (기본 true)
     #[serde(default = "default_true")]
     pub auto_update: bool,
+    /// 시스템 시작 시 앱 자동 실행 여부 (기본 true)
+    #[serde(default = "default_true")]
+    pub auto_start: bool,
 }
 
 fn default_true() -> bool {
@@ -86,6 +89,7 @@ impl Default for Config {
             evening_start: TimeOfDay { hour: 23, minute: 0 },
             evening_end: TimeOfDay { hour: 4, minute: 0 },
             auto_update: true,
+            auto_start: true,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,11 @@ pub fn run() {
                 ))
                 .build(),
         )
+        // autostart 플러그인: 시스템 시작 시 앱 자동 실행 (macOS: LaunchAgent)
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         // opener 플러그인: 시스템 브라우저로 URL 열기 (설정 페이지에서 사용)
         .plugin(tauri_plugin_opener::init())
         // updater 플러그인: 자동 업데이트 지원
@@ -58,6 +63,8 @@ pub fn run() {
             checker::set_auto_update,
             checker::get_app_version,
             checker::check_and_notify_update,
+            checker::get_auto_start,
+            checker::set_auto_start,
         ])
         // setup(): 앱 초기화 후 이벤트 루프 시작 전에 한 번 실행.
         .setup(move |app| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,21 @@ pub fn run() {
         ])
         // setup(): 앱 초기화 후 이벤트 루프 시작 전에 한 번 실행.
         .setup(move |app| {
+            // 자동 시작: Config 값을 기준으로 OS 상태를 동기화.
+            // 기본값이 true이므로 첫 설치 시 자동으로 등록됨.
+            {
+                use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
+                let auto_start = shared_state.try_lock().map(|s| s.config.auto_start).unwrap_or(true);
+                let autolaunch = app.autolaunch();
+                if auto_start {
+                    if let Err(e) = autolaunch.enable() {
+                        log::warn!("자동 시작 등록 실패: {}", e);
+                    }
+                } else if let Err(e) = autolaunch.disable() {
+                    log::warn!("자동 시작 해제 실패: {}", e);
+                }
+            }
+
             tray::setup_tray(app)?;
 
             // 숨겨진 WebView로 LMS 출석 페이지를 로드.

--- a/src/index.html
+++ b/src/index.html
@@ -50,8 +50,13 @@
 
         const autoStartToggle = document.getElementById('auto-start-toggle');
         autoStartToggle.checked = await invoke('get_auto_start');
-        autoStartToggle.addEventListener('change', () => {
-          invoke('set_auto_start', { enabled: autoStartToggle.checked }).catch(console.error);
+        autoStartToggle.addEventListener('change', async () => {
+          try {
+            await invoke('set_auto_start', { enabled: autoStartToggle.checked });
+          } catch (e) {
+            console.error(e);
+            autoStartToggle.checked = !autoStartToggle.checked;
+          }
         });
 
         const toggle = document.getElementById('auto-update-toggle');

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,15 @@
     <tr><th>학습 시작</th><td>04:00 ~ 10:00</td></tr>
     <tr><th>학습 종료</th><td>23:00 ~ 04:00</td></tr>
     <tr>
+      <th>자동 시작</th>
+      <td>
+        <label class="toggle">
+          <input type="checkbox" id="auto-start-toggle" />
+          <span class="toggle-slider"></span>
+        </label>
+      </td>
+    </tr>
+    <tr>
       <th>자동 업데이트</th>
       <td>
         <label class="toggle">
@@ -38,6 +47,12 @@
     window.addEventListener('DOMContentLoaded', async () => {
       try {
         document.getElementById('app-version').textContent = 'v' + await invoke('get_app_version');
+
+        const autoStartToggle = document.getElementById('auto-start-toggle');
+        autoStartToggle.checked = await invoke('get_auto_start');
+        autoStartToggle.addEventListener('change', () => {
+          invoke('set_auto_start', { enabled: autoStartToggle.checked }).catch(console.error);
+        });
 
         const toggle = document.getElementById('auto-update-toggle');
         toggle.checked = await invoke('get_auto_update');


### PR DESCRIPTION
## Summary

- `tauri-plugin-autostart` v2 적용 (macOS: LaunchAgent, Windows: 레지스트리)
- 첫 설치 시 자동 시작 기본 활성화 (Config 기본값 `true`)
- 앱 시작 시 Config → OS autolaunch 상태 동기화
- 설정 창에 자동 시작 토글 UI 추가

## Test plan

- [ ] 첫 설치 후 시스템 재시작 시 앱이 자동 실행되는지 확인
- [ ] 설정 창에서 자동 시작 토글 off → 재시작 시 앱이 자동 실행되지 않는지 확인
- [ ] 설정 창에서 자동 시작 토글 on → 재시작 시 앱이 자동 실행되는지 확인
- [ ] 앱 재시작 후 토글 상태가 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)