### PR TITLE
Upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: setup node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- upgrade release workflow from actions/checkout v5 to v6
- keep the rest of the release workflow unchanged

## Testing
- not run (workflow change only)