### PR TITLE
feat: single-instance 플러그인 적용

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
 ]
@@ -4443,6 +4444,21 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,10 @@ pub fn run() {
                 .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
                 .build(),
         )
+        // single-instance 플러그인: 이미 실행 중인 인스턴스가 있으면 두 번째 실행을 차단.
+        .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {
+            log::info!("다른 인스턴스 실행이 감지되어 차단되었습니다");
+        }))
         // autostart 플러그인: 시스템 시작 시 앱 자동 실행 (macOS: LaunchAgent)
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,


### PR DESCRIPTION
## Summary
- `tauri-plugin-single-instance` 플러그인을 추가하여 앱이 중복 실행되는 것을 방지
- 이미 실행 중인 인스턴스가 있으면 두 번째 실행을 차단하고 로그 출력

## Test plan
- [ ] 앱 실행 후 다시 실행 시도 시 두 번째 인스턴스가 차단되는지 확인
- [ ] 로그에 차단 메시지가 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)