### PR TITLE
fix: skip trigger_check on webview reload tick to prevent Load failed

### DIFF
--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -50,7 +50,7 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
             );
         }
         loop {
-            let tick_secs = {
+            let (tick_secs, did_reload) = {
                 let now = Utc::now();
                 let kst_now = now.with_timezone(&kst());
                 let mut s = shared_state.lock().await;
@@ -161,6 +161,9 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                 // 주기적으로 출석 페이지로 다시 이동시킴 (15분 간격).
                 // needs_login 상태에서도 리로드하여 사용자가 attendance 창에서
                 // 로그인한 경우 세션이 자동 복구되도록 함.
+                // 리로드 시 checker.js가 자동으로 initial check를 수행하므로
+                // trigger_check를 건너뛰어 "Load failed" 레이스 컨디션을 방지.
+                let did_reload;
                 {
                     let now = Instant::now();
                     let should_reload = match s.last_reload {
@@ -172,6 +175,7 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                             false
                         }
                     };
+                    did_reload = should_reload;
                     if should_reload {
                         s.last_reload = Some(now);
                         if let Some(checker) = app_handle.get_webview_window("checker") {
@@ -208,7 +212,7 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                         _ => TICK_INTERVAL_IDLE,
                     }
                 };
-                if let Some(secs) = remaining {
+                let interval = if let Some(secs) = remaining {
                     let secs = secs as u64;
                     if secs > 0 && secs < base_interval {
                         secs + 1 // 전환 직후에 깨어나기
@@ -217,7 +221,8 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                     }
                 } else {
                     base_interval
-                }
+                };
+                (interval, did_reload)
             };
 
             {
@@ -230,7 +235,10 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
 
             // Rust가 오케스트레이터: 매 틱마다 JS 스냅샷 수집을 트리거.
             // 결과는 report_attendance_status 커맨드를 통해 비동기로 돌아온다.
-            checker::trigger_check(&app_handle);
+            // 리로드한 틱에서는 건너뜀 — 새 페이지의 checker.js가 initial check를 수행.
+            if !did_reload {
+                checker::trigger_check(&app_handle);
+            }
 
             tokio::time::sleep(tokio::time::Duration::from_secs(tick_secs)).await;
         }


### PR DESCRIPTION
Every 15 minutes the scheduler reloads the checker WebView for session refresh and simultaneously fires trigger_check. The dying page's JS receives the event, attempts a fetch mid-navigation, and fails with "Load failed". Since the newly loaded page runs an initial check automatically, the trigger_check on reload ticks is redundant.