### PR TITLE
refactor: extract pure functions from checker/scheduler for testability

### DIFF
--- a/src-tauri/src/checker.rs
+++ b/src-tauri/src/checker.rs
@@ -16,8 +16,10 @@ use tokio::sync::Mutex;
 use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
 use tauri_plugin_updater::UpdaterExt;
 
+use chrono::{DateTime, Utc};
+
 use crate::config::TimeOfDay;
-use crate::state::{self, AppState};
+use crate::state::{self, AppState, DailyPhase};
 use crate::tray;
 
 /// checker.js의 API 조회 결과.
@@ -77,6 +79,29 @@ pub fn log_from_js(level: String, message: String) {
     }
 }
 
+/// 순수 로직: 체커 보고를 앱 상태에 반영하고 phase를 재계산.
+///
+/// API 에러 시 `data_loaded`만 설정하고 `None` 반환.
+/// 그 외에는 `apply_report` + `compute_daily_phase`를 수행하고
+/// `Some((phase, remaining))` 반환.
+pub(crate) fn process_report(
+    state: &mut AppState,
+    report: &AttendanceReport,
+    now: DateTime<Utc>,
+) -> Option<(DailyPhase, Option<i64>)> {
+    if report.api_error {
+        state.data_loaded = true;
+        return None;
+    }
+
+    apply_report(state, report);
+
+    let (phase, remaining) =
+        state::compute_daily_phase(&state.config, now, state.morning_checked, state.evening_checked);
+    state.phase = phase;
+    Some((phase, remaining))
+}
+
 /// Tauri 커맨드: API 조회 결과를 수신.
 /// `trigger_check()`가 이벤트를 보내면, JS가 이 커맨드를 invoke로 호출한다.
 #[tauri::command]
@@ -85,30 +110,22 @@ pub async fn report_attendance_status(
     state: tauri::State<'_, Arc<Mutex<AppState>>>,
     status: AttendanceReport,
 ) -> Result<(), String> {
-    // API 오류 시 출석 상태는 갱신하지 않되, 로딩 상태는 해제
     if status.api_error {
         info!("[checker] API error received, skipping state update");
-        let mut s = state.lock().await;
-        s.data_loaded = true;
-        return Ok(());
-    }
-
-    {
+    } else {
         let s = state.lock().await;
         info!(
             "[checker] report: needs_login={} morning={} evening={} current_phase={:?}",
             status.needs_login, status.morning_done, status.evening_done, s.phase,
         );
+        drop(s);
     }
 
     let mut s = state.lock().await;
-    apply_report(&mut s, &status);
-
-    // 즉시 상태 재계산 + 트레이 갱신
     let now = chrono::Utc::now();
-    let (phase, remaining) = state::compute_daily_phase(&s.config, now, s.morning_checked, s.evening_checked);
-    s.phase = phase;
-    tray::update_tray(&app, phase, remaining, s.needs_login);
+    if let Some((phase, remaining)) = process_report(&mut s, &status, now) {
+        tray::update_tray(&app, phase, remaining, s.needs_login);
+    }
 
     Ok(())
 }
@@ -410,4 +427,102 @@ pub async fn set_debug_mode(state: tauri::State<'_, Arc<Mutex<AppState>>>, enabl
     log::set_max_level(level);
     log::info!("[settings] 로그 레벨 전환: {}", level);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{FixedOffset, TimeZone};
+    use crate::config::Config;
+
+    /// KST 시각을 UTC DateTime으로 변환하는 헬퍼.
+    fn kst_time(h: u32, m: u32, s: u32) -> DateTime<Utc> {
+        FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 17, h, m, s)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn default_state() -> AppState {
+        AppState::new(Config::default())
+    }
+
+    #[test]
+    fn process_report_api_error_sets_data_loaded() {
+        let mut state = default_state();
+        let report = AttendanceReport {
+            needs_login: false,
+            morning_done: false,
+            evening_done: false,
+            api_error: true,
+        };
+        let result = process_report(&mut state, &report, kst_time(9, 0, 0));
+        assert!(result.is_none());
+        assert!(state.data_loaded);
+    }
+
+    #[test]
+    fn process_report_needs_login() {
+        let mut state = default_state();
+        let report = AttendanceReport {
+            needs_login: true,
+            morning_done: false,
+            evening_done: false,
+            api_error: false,
+        };
+        let result = process_report(&mut state, &report, kst_time(9, 0, 0));
+        assert!(result.is_some());
+        let (phase, remaining) = result.unwrap();
+        // needs_login=true이지만 phase는 시간에 따라 계산됨
+        assert_eq!(phase, DailyPhase::NeedStart);
+        assert!(remaining.is_some());
+        assert!(state.needs_login);
+    }
+
+    #[test]
+    fn process_report_morning_done() {
+        let mut state = default_state();
+        let report = AttendanceReport {
+            needs_login: false,
+            morning_done: true,
+            evening_done: false,
+            api_error: false,
+        };
+        // KST 12:00 — 체크인 완료, 체크아웃 전 → Studying
+        let result = process_report(&mut state, &report, kst_time(12, 0, 0));
+        let (phase, _) = result.unwrap();
+        assert_eq!(phase, DailyPhase::Studying);
+        assert!(state.morning_checked);
+        assert!(!state.evening_checked);
+    }
+
+    #[test]
+    fn process_report_both_done() {
+        let mut state = default_state();
+        let report = AttendanceReport {
+            needs_login: false,
+            morning_done: true,
+            evening_done: true,
+            api_error: false,
+        };
+        let result = process_report(&mut state, &report, kst_time(23, 30, 0));
+        let (phase, _) = result.unwrap();
+        assert_eq!(phase, DailyPhase::Complete);
+    }
+
+    #[test]
+    fn process_report_checkin_overdue() {
+        let mut state = default_state();
+        let report = AttendanceReport {
+            needs_login: false,
+            morning_done: false,
+            evening_done: false,
+            api_error: false,
+        };
+        // KST 11:00 — morning_end(10:00) 지남, 미체크인 → StartOverdue
+        let result = process_report(&mut state, &report, kst_time(11, 0, 0));
+        let (phase, _) = result.unwrap();
+        assert_eq!(phase, DailyPhase::StartOverdue);
+    }
 }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use chrono::{Datelike, Timelike, Utc};
+use chrono::{DateTime, Datelike, FixedOffset, Timelike, Utc};
 use log::{debug, info};
 use tokio::sync::Mutex;
 use tokio::time::Instant;
@@ -20,6 +20,7 @@ use tauri::Manager;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::checker;
+use crate::config::Config;
 use crate::state::{self, kst, AppState, DailyPhase};
 use crate::tray;
 
@@ -31,6 +32,170 @@ const TICK_INTERVAL_IDLE: u64 = 300;
 /// 체커 WebView 리로드 간격 (초). 세션/토큰 갱신 목적.
 /// 액세스 토큰이 1시간 만료이므로 15분 간격으로 리로드하여 갱신.
 const RELOAD_INTERVAL_NORMAL: u64 = 15 * 60; // 15분
+
+/// 알림 판단 결과.
+pub(crate) struct NotificationDecision {
+    pub send: bool,
+    pub message: Option<(&'static str, String)>,
+}
+
+/// 일일 리셋 판단: KST 날짜가 바뀌고 morning_start 이후이면 리셋 수행.
+///
+/// 리셋이 수행되면 `true` 반환.
+pub(crate) fn check_daily_reset(state: &mut AppState, kst_now: DateTime<FixedOffset>) -> bool {
+    let current_day = kst_now.ordinal();
+    let current_hour = kst_now.hour();
+
+    if let Some(last_day) = state.last_reset_day {
+        if current_day != last_day && current_hour >= state.config.morning_start.hour {
+            state.morning_checked = false;
+            state.evening_checked = false;
+            state.last_reset_day = Some(current_day);
+            return true;
+        }
+    } else {
+        state.last_reset_day = Some(current_day);
+    }
+    false
+}
+
+/// 알림 발송 여부 판단 (순수 함수).
+///
+/// `secs_since_last`: 마지막 알림 이후 경과 초. `None`이면 알림 미발송 상태.
+pub(crate) fn should_notify(
+    config: &Config,
+    phase: DailyPhase,
+    remaining: Option<i64>,
+    needs_login: bool,
+    kst_now: DateTime<FixedOffset>,
+    secs_since_last: Option<u64>,
+) -> NotificationDecision {
+    if !config.notification_enabled || needs_login {
+        return NotificationDecision { send: false, message: None };
+    }
+
+    let actionable = matches!(
+        phase,
+        DailyPhase::NeedStart | DailyPhase::StartOverdue | DailyPhase::NeedEnd
+    );
+    if !actionable {
+        return NotificationDecision { send: false, message: None };
+    }
+
+    let kst_mins = (kst_now.hour() * 60 + kst_now.minute()) as i32;
+    let notif_start_mins =
+        (config.notification_start.hour * 60 + config.notification_start.minute) as i32;
+    let notif_end_mins =
+        (config.notification_end.hour * 60 + config.notification_end.minute) as i32;
+    let evening_start_mins =
+        (config.evening_start.hour * 60 + config.evening_start.minute) as i32;
+
+    let in_window = match phase {
+        DailyPhase::NeedStart | DailyPhase::StartOverdue => {
+            kst_mins >= notif_start_mins
+        }
+        DailyPhase::NeedEnd => {
+            if notif_end_mins <= evening_start_mins {
+                // 자정 넘김 (예: 23:00~01:00)
+                kst_mins >= evening_start_mins || kst_mins < notif_end_mins
+            } else {
+                kst_mins >= evening_start_mins && kst_mins < notif_end_mins
+            }
+        }
+        _ => false,
+    };
+
+    if !in_window {
+        return NotificationDecision { send: false, message: None };
+    }
+
+    // 쓰로틀링
+    let interval_secs = config.notification_interval_mins as u64 * 60;
+    let throttled = match secs_since_last {
+        Some(elapsed) => elapsed < interval_secs,
+        None => false, // 첫 알림
+    };
+
+    if throttled {
+        return NotificationDecision { send: false, message: None };
+    }
+
+    let (title, body) = notification_message(phase, remaining);
+    NotificationDecision {
+        send: true,
+        message: Some((title, body)),
+    }
+}
+
+/// 적응형 틱 간격 계산 (순수 함수).
+pub(crate) fn compute_tick_interval(
+    data_loaded: bool,
+    needs_login: bool,
+    attendance_open: bool,
+    login_retry_active: bool,
+    phase: DailyPhase,
+    remaining: Option<i64>,
+) -> u64 {
+    let base_interval = if !data_loaded {
+        5
+    } else if needs_login {
+        if attendance_open || login_retry_active {
+            10
+        } else {
+            600
+        }
+    } else {
+        match phase {
+            DailyPhase::NeedStart | DailyPhase::StartOverdue | DailyPhase::NeedEnd => TICK_INTERVAL_ACTIVE,
+            _ => TICK_INTERVAL_IDLE,
+        }
+    };
+
+    if let Some(secs) = remaining {
+        let secs = secs as u64;
+        if secs > 0 && secs < base_interval {
+            secs + 1
+        } else {
+            base_interval
+        }
+    } else {
+        base_interval
+    }
+}
+
+/// phase와 남은 시간으로 알림 제목·본문 생성.
+pub(crate) fn notification_message(phase: DailyPhase, remaining: Option<i64>) -> (&'static str, String) {
+    match phase {
+        DailyPhase::NeedStart => {
+            let body = if let Some(secs) = remaining {
+                let mins = secs / 60;
+                if mins >= 60 {
+                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
+                } else {
+                    format!("마감까지 {}분 남았습니다.", mins)
+                }
+            } else {
+                "출석 체크를 해주세요.".into()
+            };
+            ("출석 체크 시간입니다", body)
+        }
+        DailyPhase::StartOverdue => ("출석 체크 지각!", "빨리 체크인하세요.".into()),
+        DailyPhase::NeedEnd => {
+            let body = if let Some(secs) = remaining {
+                let mins = secs / 60;
+                if mins >= 60 {
+                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
+                } else {
+                    format!("마감까지 {}분 남았습니다.", mins)
+                }
+            } else {
+                "학습 종료 체크를 해주세요.".into()
+            };
+            ("학습 종료 체크가 필요합니다", body)
+        }
+        _ => ("Jungle Bell", "출석 상태를 확인하세요.".into()),
+    }
+}
 
 /// 백그라운드 스케줄러 루프 시작.
 pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<AppState>>) {
@@ -56,20 +221,8 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                 let mut s = shared_state.lock().await;
 
                 // --- 일일 리셋 ---
-                // KST 날짜가 바뀌고 morning_start 이후이면
-                // 어제의 체크인/체크아웃 상태를 초기화.
-                let current_day = kst_now.ordinal();
-                let current_hour = kst_now.hour();
-
-                if let Some(last_day) = s.last_reset_day {
-                    if current_day != last_day && current_hour >= s.config.morning_start.hour {
-                        info!("[scheduler] daily reset at KST={}", kst_now.format("%Y-%m-%d %H:%M:%S"));
-                        s.morning_checked = false;
-                        s.evening_checked = false;
-                        s.last_reset_day = Some(current_day);
-                    }
-                } else {
-                    s.last_reset_day = Some(current_day);
+                if check_daily_reset(&mut s, kst_now) {
+                    info!("[scheduler] daily reset at KST={}", kst_now.format("%Y-%m-%d %H:%M:%S"));
                 }
 
                 // --- 상태 계산 ---
@@ -105,48 +258,13 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                     tray::update_tray(&app_handle, phase, remaining, s.needs_login);
 
                     // --- 네이티브 알림 ---
-                    if s.config.notification_enabled && !s.needs_login {
-                        let should_notify = matches!(
-                            s.phase,
-                            DailyPhase::NeedStart | DailyPhase::StartOverdue | DailyPhase::NeedEnd
-                        );
-                        let kst_mins = (kst_now.hour() * 60 + kst_now.minute()) as i32;
-                        let notif_start_mins =
-                            (s.config.notification_start.hour * 60 + s.config.notification_start.minute) as i32;
-                        let notif_end_mins =
-                            (s.config.notification_end.hour * 60 + s.config.notification_end.minute) as i32;
-                        let evening_start_mins =
-                            (s.config.evening_start.hour * 60 + s.config.evening_start.minute) as i32;
-
-                        let in_notification_window = match s.phase {
-                            DailyPhase::NeedStart | DailyPhase::StartOverdue => {
-                                // 아침: notification_start 이후만
-                                kst_mins >= notif_start_mins
-                            }
-                            DailyPhase::NeedEnd => {
-                                // 저녁: evening_start ~ notification_end (자정 넘김 처리)
-                                if notif_end_mins <= evening_start_mins {
-                                    // 예: 23:00~01:00 → 자정 넘김
-                                    kst_mins >= evening_start_mins || kst_mins < notif_end_mins
-                                } else {
-                                    kst_mins >= evening_start_mins && kst_mins < notif_end_mins
-                                }
-                            }
-                            _ => false,
-                        };
-
-                        if should_notify && in_notification_window {
-                            let interval_secs = s.config.notification_interval_mins as u64 * 60;
-                            let should_send = match s.last_notification {
-                                Some(last) => last.elapsed() >= std::time::Duration::from_secs(interval_secs),
-                                None => true,
-                            };
-                            if should_send {
-                                let (title, body) = notification_message(s.phase, remaining);
-                                let _ = app_handle.notification().builder().title(title).body(body).show();
-                                s.last_notification = Some(Instant::now());
-                                info!("[scheduler] notification sent: phase={:?}", s.phase);
-                            }
+                    let secs_since_last = s.last_notification.map(|last| last.elapsed().as_secs());
+                    let decision = should_notify(&s.config, phase, remaining, s.needs_login, kst_now, secs_since_last);
+                    if decision.send {
+                        if let Some((title, body)) = decision.message {
+                            let _ = app_handle.notification().builder().title(title).body(body).show();
+                            s.last_notification = Some(Instant::now());
+                            info!("[scheduler] notification sent: phase={:?}", phase);
                         }
                     }
 
@@ -157,10 +275,6 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                 }
 
                 // --- 체커 WebView 주기적 리로드 ---
-                // API 호출은 WebView 쿠키를 사용하므로 세션/토큰 갱신을 위해
-                // 주기적으로 출석 페이지로 다시 이동시킴 (15분 간격).
-                // needs_login 상태에서도 리로드하여 사용자가 attendance 창에서
-                // 로그인한 경우 세션이 자동 복구되도록 함.
                 {
                     let now = Instant::now();
                     let should_reload = match s.last_reload {
@@ -190,34 +304,9 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
                 }
 
                 // --- 적응형 틱 간격 ---
-                // 로그인 필요 시: 출석 페이지 열림 또는 재시도 윈도우 활성이면 빠르게 폴링,
-                // 그 외에는 불필요한 요청을 보내지 않음.
-                // 액션 필요 시 60초, 대기 시 300초.
                 let attendance_open = app_handle.get_webview_window("attendance").is_some();
-                let base_interval = if !s.data_loaded {
-                    5 // 첫 체커 보고까지 빠르게 폴링
-                } else if s.needs_login {
-                    if attendance_open || s.login_retry_until.is_some() {
-                        10 // 출석 페이지 열림 또는 재시도 윈도우 활성: 빠르게 확인
-                    } else {
-                        600 // 로그인 필요하지만 재시도 없음: 대기
-                    }
-                } else {
-                    match s.phase {
-                        DailyPhase::NeedStart | DailyPhase::StartOverdue | DailyPhase::NeedEnd => TICK_INTERVAL_ACTIVE,
-                        _ => TICK_INTERVAL_IDLE,
-                    }
-                };
-                if let Some(secs) = remaining {
-                    let secs = secs as u64;
-                    if secs > 0 && secs < base_interval {
-                        secs + 1 // 전환 직후에 깨어나기
-                    } else {
-                        base_interval
-                    }
-                } else {
-                    base_interval
-                }
+                let login_retry_active = s.login_retry_until.is_some();
+                compute_tick_interval(s.data_loaded, s.needs_login, attendance_open, login_retry_active, s.phase, remaining)
             };
 
             {
@@ -229,7 +318,6 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
             }
 
             // Rust가 오케스트레이터: 매 틱마다 JS 스냅샷 수집을 트리거.
-            // 결과는 report_attendance_status 커맨드를 통해 비동기로 돌아온다.
             checker::trigger_check(&app_handle);
 
             tokio::time::sleep(tokio::time::Duration::from_secs(tick_secs)).await;
@@ -237,36 +325,249 @@ pub fn start_scheduler(app_handle: tauri::AppHandle, shared_state: Arc<Mutex<App
     });
 }
 
-/// phase와 남은 시간으로 알림 제목·본문 생성.
-fn notification_message(phase: DailyPhase, remaining: Option<i64>) -> (&'static str, String) {
-    match phase {
-        DailyPhase::NeedStart => {
-            let body = if let Some(secs) = remaining {
-                let mins = secs / 60;
-                if mins >= 60 {
-                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
-                } else {
-                    format!("마감까지 {}분 남았습니다.", mins)
-                }
-            } else {
-                "출석 체크를 해주세요.".into()
-            };
-            ("출석 체크 시간입니다", body)
-        }
-        DailyPhase::StartOverdue => ("출석 체크 지각!", "빨리 체크인하세요.".into()),
-        DailyPhase::NeedEnd => {
-            let body = if let Some(secs) = remaining {
-                let mins = secs / 60;
-                if mins >= 60 {
-                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
-                } else {
-                    format!("마감까지 {}분 남았습니다.", mins)
-                }
-            } else {
-                "학습 종료 체크를 해주세요.".into()
-            };
-            ("학습 종료 체크가 필요합니다", body)
-        }
-        _ => ("Jungle Bell", "출석 상태를 확인하세요.".into()),
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use crate::config::Config;
+
+    fn kst_dt(h: u32, m: u32, s: u32) -> DateTime<FixedOffset> {
+        FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 17, h, m, s)
+            .unwrap()
+    }
+
+    fn default_state() -> AppState {
+        AppState::new(Config::default())
+    }
+
+    // --- check_daily_reset ---
+
+    #[test]
+    fn daily_reset_first_call_sets_day() {
+        let mut state = default_state();
+        assert!(state.last_reset_day.is_none());
+        let reset = check_daily_reset(&mut state, kst_dt(9, 0, 0));
+        assert!(!reset);
+        assert!(state.last_reset_day.is_some());
+    }
+
+    #[test]
+    fn daily_reset_same_day_no_reset() {
+        let mut state = default_state();
+        let kst = kst_dt(9, 0, 0);
+        check_daily_reset(&mut state, kst);
+        state.morning_checked = true;
+        state.evening_checked = true;
+
+        let reset = check_daily_reset(&mut state, kst);
+        assert!(!reset);
+        assert!(state.morning_checked);
+    }
+
+    #[test]
+    fn daily_reset_next_day_after_morning_start() {
+        let mut state = default_state();
+        let day1 = kst_dt(9, 0, 0);
+        check_daily_reset(&mut state, day1);
+        state.morning_checked = true;
+        state.evening_checked = true;
+
+        // 다음 날 05:00 (morning_start=04:00 이후)
+        let day2 = FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 18, 5, 0, 0)
+            .unwrap();
+        let reset = check_daily_reset(&mut state, day2);
+        assert!(reset);
+        assert!(!state.morning_checked);
+        assert!(!state.evening_checked);
+    }
+
+    #[test]
+    fn daily_reset_next_day_before_morning_start_no_reset() {
+        let mut state = default_state();
+        let day1 = kst_dt(9, 0, 0);
+        check_daily_reset(&mut state, day1);
+        state.morning_checked = true;
+
+        // 다음 날 02:00 (morning_start=04:00 이전)
+        let day2 = FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 18, 2, 0, 0)
+            .unwrap();
+        let reset = check_daily_reset(&mut state, day2);
+        assert!(!reset);
+        assert!(state.morning_checked);
+    }
+
+    // --- should_notify ---
+
+    #[test]
+    fn notify_disabled() {
+        let mut config = Config::default();
+        config.notification_enabled = false;
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(3600), false, kst_dt(9, 30, 0), None);
+        assert!(!d.send);
+    }
+
+    #[test]
+    fn notify_needs_login() {
+        let config = Config::default();
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(3600), true, kst_dt(9, 30, 0), None);
+        assert!(!d.send);
+    }
+
+    #[test]
+    fn notify_non_actionable_phase() {
+        let config = Config::default();
+        let d = should_notify(&config, DailyPhase::Studying, Some(3600), false, kst_dt(12, 0, 0), None);
+        assert!(!d.send);
+    }
+
+    #[test]
+    fn notify_before_window() {
+        let config = Config::default(); // notification_start=09:00
+        // KST 08:00 — 아침 알림 윈도우 전
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(7200), false, kst_dt(8, 0, 0), None);
+        assert!(!d.send);
+    }
+
+    #[test]
+    fn notify_in_window_first_time() {
+        let config = Config::default(); // notification_start=09:00
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(3600), false, kst_dt(9, 30, 0), None);
+        assert!(d.send);
+        assert!(d.message.is_some());
+    }
+
+    #[test]
+    fn notify_throttled() {
+        let config = Config::default(); // interval=15분
+        // 마지막 알림 5분 전 → 쓰로틀
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(3600), false, kst_dt(9, 30, 0), Some(300));
+        assert!(!d.send);
+    }
+
+    #[test]
+    fn notify_after_throttle_expires() {
+        let config = Config::default(); // interval=15분=900초
+        let d = should_notify(&config, DailyPhase::NeedStart, Some(3600), false, kst_dt(9, 30, 0), Some(901));
+        assert!(d.send);
+    }
+
+    #[test]
+    fn notify_evening_across_midnight() {
+        let config = Config::default(); // evening_start=23:00, notification_end=01:00
+        // KST 00:30 — 자정 넘긴 저녁 윈도우 내
+        let kst_0030 = FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 18, 0, 30, 0)
+            .unwrap();
+        let d = should_notify(&config, DailyPhase::NeedEnd, Some(12600), false, kst_0030, None);
+        assert!(d.send);
+    }
+
+    #[test]
+    fn notify_evening_after_window() {
+        let config = Config::default(); // notification_end=01:00
+        // KST 01:30 — 윈도우 밖
+        let kst_0130 = FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 18, 1, 30, 0)
+            .unwrap();
+        let d = should_notify(&config, DailyPhase::NeedEnd, Some(9000), false, kst_0130, None);
+        assert!(!d.send);
+    }
+
+    // --- compute_tick_interval ---
+
+    #[test]
+    fn tick_not_loaded() {
+        assert_eq!(compute_tick_interval(false, false, false, false, DailyPhase::Idle, None), 5);
+    }
+
+    #[test]
+    fn tick_needs_login_attendance_open() {
+        assert_eq!(compute_tick_interval(true, true, true, false, DailyPhase::Idle, None), 10);
+    }
+
+    #[test]
+    fn tick_needs_login_retry_active() {
+        assert_eq!(compute_tick_interval(true, true, false, true, DailyPhase::Idle, None), 10);
+    }
+
+    #[test]
+    fn tick_needs_login_no_retry() {
+        assert_eq!(compute_tick_interval(true, true, false, false, DailyPhase::Idle, None), 600);
+    }
+
+    #[test]
+    fn tick_active_phase() {
+        assert_eq!(
+            compute_tick_interval(true, false, false, false, DailyPhase::NeedStart, Some(3600)),
+            TICK_INTERVAL_ACTIVE
+        );
+    }
+
+    #[test]
+    fn tick_idle_phase() {
+        assert_eq!(
+            compute_tick_interval(true, false, false, false, DailyPhase::Studying, Some(1800)),
+            TICK_INTERVAL_IDLE
+        );
+    }
+
+    #[test]
+    fn tick_remaining_overrides_base() {
+        // remaining=30 < base=60 → 31
+        assert_eq!(
+            compute_tick_interval(true, false, false, false, DailyPhase::NeedStart, Some(30)),
+            31
+        );
+    }
+
+    #[test]
+    fn tick_remaining_zero_no_override() {
+        assert_eq!(
+            compute_tick_interval(true, false, false, false, DailyPhase::NeedStart, Some(0)),
+            TICK_INTERVAL_ACTIVE
+        );
+    }
+
+    // --- notification_message ---
+
+    #[test]
+    fn message_need_start_with_remaining() {
+        let (title, body) = notification_message(DailyPhase::NeedStart, Some(5400));
+        assert_eq!(title, "출석 체크 시간입니다");
+        assert!(body.contains("1시간 30분"));
+    }
+
+    #[test]
+    fn message_need_start_minutes_only() {
+        let (_, body) = notification_message(DailyPhase::NeedStart, Some(1800));
+        assert!(body.contains("30분"));
+        assert!(!body.contains("시간"));
+    }
+
+    #[test]
+    fn message_start_overdue() {
+        let (title, body) = notification_message(DailyPhase::StartOverdue, None);
+        assert_eq!(title, "출석 체크 지각!");
+        assert!(body.contains("빨리"));
+    }
+
+    #[test]
+    fn message_need_end() {
+        let (title, _) = notification_message(DailyPhase::NeedEnd, Some(3600));
+        assert_eq!(title, "학습 종료 체크가 필요합니다");
+    }
+
+    #[test]
+    fn message_fallback() {
+        let (title, _) = notification_message(DailyPhase::Idle, None);
+        assert_eq!(title, "Jungle Bell");
     }
 }

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -165,34 +165,25 @@ pub(crate) fn compute_tick_interval(
 
 /// phase와 남은 시간으로 알림 제목·본문 생성.
 pub(crate) fn notification_message(phase: DailyPhase, remaining: Option<i64>) -> (&'static str, String) {
+    let format_remaining = |secs: i64| {
+        let mins = secs / 60;
+        if mins >= 60 {
+            format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
+        } else {
+            format!("마감까지 {}분 남았습니다.", mins)
+        }
+    };
+
     match phase {
-        DailyPhase::NeedStart => {
-            let body = if let Some(secs) = remaining {
-                let mins = secs / 60;
-                if mins >= 60 {
-                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
-                } else {
-                    format!("마감까지 {}분 남았습니다.", mins)
-                }
-            } else {
-                "출석 체크를 해주세요.".into()
-            };
-            ("출석 체크 시간입니다", body)
-        }
+        DailyPhase::NeedStart => (
+            "출석 체크 시간입니다",
+            remaining.map(&format_remaining).unwrap_or_else(|| "출석 체크를 해주세요.".into()),
+        ),
         DailyPhase::StartOverdue => ("출석 체크 지각!", "빨리 체크인하세요.".into()),
-        DailyPhase::NeedEnd => {
-            let body = if let Some(secs) = remaining {
-                let mins = secs / 60;
-                if mins >= 60 {
-                    format!("마감까지 {}시간 {}분 남았습니다.", mins / 60, mins % 60)
-                } else {
-                    format!("마감까지 {}분 남았습니다.", mins)
-                }
-            } else {
-                "학습 종료 체크를 해주세요.".into()
-            };
-            ("학습 종료 체크가 필요합니다", body)
-        }
+        DailyPhase::NeedEnd => (
+            "학습 종료 체크가 필요합니다",
+            remaining.map(&format_remaining).unwrap_or_else(|| "학습 종료 체크를 해주세요.".into()),
+        ),
         _ => ("Jungle Bell", "출석 상태를 확인하세요.".into()),
     }
 }


### PR DESCRIPTION
Separate core business logic (attendance state processing, daily reset, notification decisions, tick interval calculation) from Tauri side effects so they can be verified with unit tests.

- checker: extract process_report(state, report, now)
- scheduler: extract check_daily_reset, should_notify, compute_tick_interval
- scheduler: make notification_message pub(crate)
- Add 31 unit tests covering all extracted functions