### PR TITLE
fix(tray): Rust 1.98 RGBA 순회 경고 수정

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -728,7 +728,9 @@ mod tests {
     fn has_antialiased_edge(image: &Image<'_>) -> bool {
         image
             .rgba()
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .any(|pixel| pixel[3] > 0 && pixel[3] < u8::MAX)
     }
 
@@ -752,14 +754,22 @@ mod tests {
     }
 
     fn visible_pixel_ratio(image: &Image<'_>) -> f64 {
-        let visible = image.rgba().chunks_exact(4).filter(|pixel| pixel[3] >= 128).count();
+        let visible = image
+            .rgba()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .filter(|pixel| pixel[3] >= 128)
+            .count();
         visible as f64 / (image.width() * image.height()) as f64
     }
 
     fn contains_opaque_color(image: &Image<'_>, expected: [u8; 3]) -> bool {
         image
             .rgba()
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .any(|pixel| pixel[0..3] == expected && pixel[3] == u8::MAX)
     }
 


### PR DESCRIPTION
## 원인
- Rust stable 1.98에서 chunks_exact_to_as_chunks Clippy lint가 추가됨
- CI가 -D warnings를 사용해 macOS와 Windows 데스크톱 job이 동일하게 실패함

## 수정
- 트레이 아이콘 RGBA 테스트의 4바이트 순회 3곳을 as_chunks::<4>()로 변경
- 테스트 동작과 프로덕션 런타임 코드는 변경하지 않음

## 검증
- JUNGLE_BELL_DATA_API_URL=https://jungle-bell.sijun-yang.com npm run verify:desktop
- Rust 테스트 204개 통과
- 로컬 cargo clippy -D warnings 통과