### PR TITLE
CI 검증과 데스크톱 릴리스 게이트 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,26 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
+  hygiene:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+        with:
+          prek-version: "0.4.14"
+          install-only: true
+      - run: prek validate-config prek.toml
+      - run: prek run --all-files --group hygiene --show-diff-on-failure
+
   web:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -30,11 +44,6 @@ jobs:
         working-directory: frontend
       - run: npm run verify:web
         working-directory: frontend
-      - uses: actions/upload-artifact@v7
-        with:
-          name: app-assets
-          path: frontend/dist/web
-          retention-days: 1
 
   server:
     runs-on: ubuntu-24.04
@@ -100,3 +109,22 @@ jobs:
         working-directory: frontend
       - run: npm run verify:desktop
         working-directory: frontend
+
+  required:
+    name: required
+    if: ${{ always() }}
+    needs: [hygiene, web, server, desktop]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI job to succeed
+        env:
+          HYGIENE_RESULT: ${{ needs.hygiene.result }}
+          WEB_RESULT: ${{ needs.web.result }}
+          SERVER_RESULT: ${{ needs.server.result }}
+          DESKTOP_RESULT: ${{ needs.desktop.result }}
+        run: |
+          test "$HYGIENE_RESULT" = "success"
+          test "$WEB_RESULT" = "success"
+          test "$SERVER_RESULT" = "success"
+          test "$DESKTOP_RESULT" = "success"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,54 +1,137 @@
-name: Release
-run-name: Release ${{ inputs.tag }}
+name: Desktop Release
+run-name: Desktop Release ${{ inputs.tag }}
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag name (e.g. v0.2.2-beta.1)'
+        description: 'Tag name (e.g. v0.5.7 or v0.5.8-beta.1)'
         required: true
         type: string
 
+concurrency:
+  group: desktop-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
-  get-release-info:
-    runs-on: ubuntu-latest
+  prepare-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
-      contents: write
+      actions: read
+      contents: read
     outputs:
       tag: ${{ steps.info.outputs.tag }}
+      sha: ${{ steps.info.outputs.sha }}
+      version: ${{ steps.info.outputs.version }}
       release_id: ${{ steps.info.outputs.release_id }}
       is_prerelease: ${{ steps.info.outputs.is_prerelease }}
+      ci_run_id: ${{ steps.info.outputs.ci_run_id }}
     steps:
-      - name: Validate draft release
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Validate tag, draft release, and exact-SHA CI
         id: info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG: ${{ inputs.tag }}
+          DISPATCH_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
 
+          if [ "$DISPATCH_REF" != "refs/heads/main" ]; then
+            echo "Desktop releases must be dispatched from main." >&2
+            exit 1
+          fi
+
           TAG="$INPUT_TAG"
+          SHA=$(git rev-parse "refs/tags/$TAG^{commit}")
+
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "Release tag $TAG does not point to a commit on main." >&2
+            exit 1
+          fi
+
+          git checkout --detach "$SHA"
+          VERSION=$(node scripts/verify-release-version.mjs "$TAG")
+
           RELEASE_INFO=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
             --json databaseId,isDraft,isPrerelease,tagName)
-          RELEASE_ID=$(echo "$RELEASE_INFO" | jq -r '.databaseId')
-          IS_DRAFT=$(echo "$RELEASE_INFO" | jq -r '.isDraft')
-          IS_PRERELEASE=$(echo "$RELEASE_INFO" | jq -r '.isPrerelease')
+          RELEASE_ID=$(jq -r '.databaseId' <<<"$RELEASE_INFO")
+          IS_DRAFT=$(jq -r '.isDraft' <<<"$RELEASE_INFO")
+          IS_PRERELEASE=$(jq -r '.isPrerelease' <<<"$RELEASE_INFO")
+          RELEASE_TAG=$(jq -r '.tagName' <<<"$RELEASE_INFO")
 
           if [ "$IS_DRAFT" != "true" ]; then
             echo "The v2 updater manifest may only be assembled inside a draft release." >&2
             exit 1
           fi
+          if [ "$RELEASE_TAG" != "$TAG" ]; then
+            echo "Draft release tag $RELEASE_TAG does not match $TAG." >&2
+            exit 1
+          fi
 
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
-          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+          EXPECTED_PRERELEASE=false
+          if [[ "$VERSION" == *-* ]]; then
+            EXPECTED_PRERELEASE=true
+          fi
+          if [ "$IS_PRERELEASE" != "$EXPECTED_PRERELEASE" ]; then
+            echo "Draft prerelease setting does not match version $VERSION." >&2
+            exit 1
+          fi
+
+          CI_RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml \
+            --branch main --commit "$SHA" --event push --status success --limit 20 \
+            --json databaseId,headSha,headBranch,event,conclusion,url)
+          CI_RUN_ID=$(jq -r --arg sha "$SHA" '
+            [.[] | select(
+              .headSha == $sha
+              and .headBranch == "main"
+              and .event == "push"
+              and .conclusion == "success"
+            )][0].databaseId // empty
+          ' <<<"$CI_RUNS")
+          if [ -z "$CI_RUN_ID" ]; then
+            echo "No successful main CI run exists for release SHA $SHA." >&2
+            exit 1
+          fi
+
+          REQUIRED_RESULT=$(gh run view "$CI_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json jobs --jq '[.jobs[] | select(.name == "required")][0].conclusion // ""')
+          if [ "$REQUIRED_RESULT" != "success" ]; then
+            echo "CI run $CI_RUN_ID does not contain a successful required job." >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$TAG"
+            echo "sha=$SHA"
+            echo "version=$VERSION"
+            echo "release_id=$RELEASE_ID"
+            echo "is_prerelease=$IS_PRERELEASE"
+            echo "ci_run_id=$CI_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
 
   publish-tauri:
-    needs: [get-release-info]
+    needs: [prepare-release]
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 45
+    environment: desktop-signing
     permissions:
       contents: write
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - platform: macos-latest
@@ -57,17 +140,16 @@ jobs:
             args: --target x86_64-apple-darwin
           - platform: windows-latest
             args: '--bundles nsis'
-
-    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.get-release-info.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
+          persist-credentials: false
 
-      - name: setup node
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -87,16 +169,16 @@ jobs:
           prefix-key: "v${{ vars.CACHE_VERSION }}"
           cache-on-failure: false
 
-      - name: Build and upload to release
-        uses: tauri-apps/tauri-action@v0
+      - name: Build and upload to draft release
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           JUNGLE_BELL_DATA_API_URL: https://jungle-bell.sijun-yang.com
         with:
-          releaseId: ${{ needs.get-release-info.outputs.release_id }}
-          tagName: ${{ needs.get-release-info.outputs.tag }}
+          releaseId: ${{ needs.prepare-release.outputs.release_id }}
+          tagName: ${{ needs.prepare-release.outputs.tag }}
           args: ${{ matrix.args }}
           projectPath: desktop
           tauriScript: npm run --prefix ../frontend tauri
@@ -108,7 +190,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.get-release-info.outputs.tag }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
         run: |
           set -euo pipefail
           VER="${TAG#v}"
@@ -129,47 +211,51 @@ jobs:
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber "$ASSET"
 
   publish-installer-scripts:
-    needs: [publish-tauri, get-release-info]
-    runs-on: ubuntu-latest
+    needs: [publish-tauri, prepare-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.get-release-info.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
+          persist-credentials: false
 
       - name: Render and upload installer scripts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.get-release-info.outputs.tag }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
-          VER="${TAG#v}"
           mkdir -p out
-          sed "s/__VERSION__/${VER}/g" install/jungle-bell.sh.tmpl  > out/jungle-bell.sh
-          sed "s/__VERSION__/${VER}/g" install/jungle-bell.ps1.tmpl > out/jungle-bell.ps1
+          sed "s/__VERSION__/${VERSION}/g" install/jungle-bell.sh.tmpl > out/jungle-bell.sh
+          sed "s/__VERSION__/${VERSION}/g" install/jungle-bell.ps1.tmpl > out/jungle-bell.ps1
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
             out/jungle-bell.sh out/jungle-bell.ps1
 
   publish-v2-updater-manifest:
-    needs: [publish-tauri, get-release-info]
-    runs-on: ubuntu-latest
+    needs: [publish-tauri, prepare-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
       - name: Promote updater manifest to the v2 channel
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.get-release-info.outputs.tag }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
 
-          VERSION="${TAG#v}"
           MANIFEST_DIR="$(mktemp -d)"
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern latest.json --dir "$MANIFEST_DIR"
 
-          jq -e --arg version "$VERSION" '
+          jq -e --arg version "$VERSION" \
+            --arg prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/" '
             . as $manifest
             | ($manifest.version == $version)
               and ([
@@ -178,7 +264,7 @@ jobs:
                 "windows-x86_64"
               ] | all(. as $platform
                 | ($manifest.platforms[$platform].signature | type == "string" and length > 0)
-                  and ($manifest.platforms[$platform].url | type == "string" and length > 0)
+                  and ($manifest.platforms[$platform].url | type == "string" and startswith($prefix))
               ))
           ' "$MANIFEST_DIR/latest.json"
 
@@ -191,35 +277,154 @@ jobs:
             --jq '[.assets[].name] | (index("latest-v2.json") != null) and (index("latest.json") == null)' \
             | grep -qx true
 
+  verify-draft-release:
+    needs: [publish-v2-updater-manifest, publish-installer-scripts, prepare-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable tag and complete draft assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+          SHA: ${{ needs.prepare-release.outputs.sha }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          IS_PRERELEASE: ${{ needs.prepare-release.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+
+          CURRENT_SHA=$(git rev-parse "refs/tags/$TAG^{commit}")
+          if [ "$CURRENT_SHA" != "$SHA" ]; then
+            echo "Release tag moved from $SHA to $CURRENT_SHA." >&2
+            exit 1
+          fi
+
+          RELEASE_INFO=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets,isDraft,isPrerelease)
+          jq -e --argjson prerelease "$IS_PRERELEASE" '
+            .isDraft == true and .isPrerelease == $prerelease
+          ' <<<"$RELEASE_INFO"
+          ASSET_NAMES=$(jq -c '[.assets[].name]' <<<"$RELEASE_INFO")
+          for required_asset in \
+            jungle-bell.sh \
+            jungle-bell.ps1 \
+            latest-v2.json \
+            "Jungle.Bell_${VERSION}_aarch64.tar.gz" \
+            "Jungle.Bell_${VERSION}_x64.tar.gz" \
+            "Jungle.Bell_${VERSION}_x64-setup.exe"; do
+            jq -e --arg name "$required_asset" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+          done
+          jq -e 'index("latest.json") == null' <<<"$ASSET_NAMES" >/dev/null
+
+          MANIFEST_DIR="$(mktemp -d)"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern latest-v2.json --dir "$MANIFEST_DIR"
+          jq -e --arg version "$VERSION" \
+            --arg prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/" '
+            .version == $version
+              and ([
+                "darwin-aarch64",
+                "darwin-x86_64",
+                "windows-x86_64"
+              ] | all(. as $platform
+                | (.platforms[$platform].signature | type == "string" and length > 0)
+                  and (.platforms[$platform].url | type == "string" and startswith($prefix))
+              ))
+          ' "$MANIFEST_DIR/latest-v2.json"
+
+          while IFS= read -r asset_url; do
+            asset_name="${asset_url##*/}"
+            jq -e --arg name "$asset_name" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+            jq -e --arg name "${asset_name}.sig" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+          done < <(jq -r '.platforms[].url' "$MANIFEST_DIR/latest-v2.json")
+
   publish-release:
-    needs: [publish-v2-updater-manifest, publish-installer-scripts, get-release-info]
-    runs-on: ubuntu-latest
+    needs: [verify-draft-release, prepare-release]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: desktop-release
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.get-release-info.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Publish release
+      - name: Revalidate and publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare-release.outputs.tag }}
+          SHA: ${{ needs.prepare-release.outputs.sha }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          IS_PRERELEASE: ${{ needs.prepare-release.outputs.is_prerelease }}
         run: |
           set -euo pipefail
 
-          TAG="${{ needs.get-release-info.outputs.tag }}"
-          IS_PRERELEASE="${{ needs.get-release-info.outputs.is_prerelease }}"
-          REPO="${{ github.repository }}"
+          CURRENT_SHA=$(git rev-parse "refs/tags/$TAG^{commit}")
+          if [ "$CURRENT_SHA" != "$SHA" ]; then
+            echo "Release tag moved from $SHA to $CURRENT_SHA." >&2
+            exit 1
+          fi
+
+          RELEASE_INFO=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets,body,isDraft,isPrerelease)
+          jq -e --argjson prerelease "$IS_PRERELEASE" '
+            .isDraft == true
+              and .isPrerelease == $prerelease
+          ' <<<"$RELEASE_INFO"
+          ASSET_NAMES=$(jq -c '[.assets[].name]' <<<"$RELEASE_INFO")
+          for required_asset in \
+            jungle-bell.sh \
+            jungle-bell.ps1 \
+            latest-v2.json \
+            "Jungle.Bell_${VERSION}_aarch64.tar.gz" \
+            "Jungle.Bell_${VERSION}_x64.tar.gz" \
+            "Jungle.Bell_${VERSION}_x64-setup.exe"; do
+            jq -e --arg name "$required_asset" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+          done
+          jq -e 'index("latest.json") == null' <<<"$ASSET_NAMES" >/dev/null
+
+          MANIFEST_DIR="$(mktemp -d)"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern latest-v2.json --dir "$MANIFEST_DIR"
+          jq -e --arg version "$VERSION" \
+            --arg prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/" '
+            .version == $version
+              and ([
+                "darwin-aarch64",
+                "darwin-x86_64",
+                "windows-x86_64"
+              ] | all(. as $platform
+                | (.platforms[$platform].signature | type == "string" and length > 0)
+                  and (.platforms[$platform].url | type == "string" and startswith($prefix))
+              ))
+          ' "$MANIFEST_DIR/latest-v2.json"
+
+          while IFS= read -r asset_url; do
+            asset_name="${asset_url##*/}"
+            jq -e --arg name "$asset_name" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+            jq -e --arg name "${asset_name}.sig" 'index($name) != null' <<<"$ASSET_NAMES" >/dev/null
+          done < <(jq -r '.platforms[].url' "$MANIFEST_DIR/latest-v2.json")
 
           if [ "$IS_PRERELEASE" = "true" ]; then
-            gh release edit "$TAG" --repo "$REPO" --draft=false
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false
           else
             BODY_FILE="$(mktemp)"
             CLEAN_BODY_FILE="$(mktemp)"
             NOTES_FILE="$(mktemp)"
 
-            gh release view "$TAG" --repo "$REPO" --json body --jq '.body // ""' > "$BODY_FILE"
-            sed '/<!-- jungle-bell-install-help:start -->/,/<!-- jungle-bell-install-help:end -->/d' "$BODY_FILE" > "$CLEAN_BODY_FILE"
+            jq -r '.body // ""' <<<"$RELEASE_INFO" > "$BODY_FILE"
+            sed '/<!-- jungle-bell-install-help:start -->/,/<!-- jungle-bell-install-help:end -->/d' \
+              "$BODY_FILE" > "$CLEAN_BODY_FILE"
 
             {
               cat "$CLEAN_BODY_FILE"
@@ -229,5 +434,6 @@ jobs:
               cat install/release-install-help.md
             } > "$NOTES_FILE"
 
-            gh release edit "$TAG" --repo "$REPO" --notes-file "$NOTES_FILE" --draft=false --latest
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --notes-file "$NOTES_FILE" --draft=false --latest
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,32 @@
 - Node.js 24
 - Java 21
 - Rust stable과 `rustfmt`, `clippy`
+- prek 0.4.9 이상
 - 서버를 로컬에서 실행할 경우 Docker
 - Tauri가 요구하는 운영체제별 빌드 도구
+
+## Git 훅 설치
+
+저장소 루트에서 prek의 `pre-commit`, `pre-push` 훅을 설치합니다.
+
+```bash
+prek install
+```
+
+`pre-commit`은 staged diff, 설정 파일, 프론트엔드 포맷·lint와 Rust 포맷을 빠르게 검사합니다. `main` 브랜치에는 직접 커밋할 수 없습니다. `pre-push`는 변경 경로에 따라 프론트엔드 check, 서버 Gradle check, 데스크톱 test·clippy를 실행합니다.
+
+설정과 기본 위생 검사를 수동으로 확인하려면 다음 명령을 실행합니다.
+
+```bash
+prek validate-config prek.toml
+prek run --all-files --group hygiene
+```
+
+모든 `pre-push` 검사를 수동으로 실행하려면 다음 명령을 사용합니다.
+
+```bash
+prek run --all-files --stage pre-push
+```
 
 ## 저장소 구조
 
@@ -83,6 +107,20 @@ cd server
 
 문서만 변경했더라도 링크, 이미지 경로와 Markdown 렌더링을 확인하고 `git diff --check`를 실행합니다.
 
+## CI와 릴리스 경계
+
+Pull Request와 `main` push에서는 GitHub Actions의 `CI` 워크플로가 hygiene, 웹, 서버,
+macOS·Windows 데스크톱 검증을 실행합니다. 브랜치 규칙에는 고정 집계 잡인
+`CI / required`를 필수 체크로 사용합니다.
+
+서버 배포는 GitHub Actions에서 수행하지 않습니다. 운영망 접근 권한이 있는 로컬 환경에서
+[OCI 운영 서버 배포 가이드](server/deploy/guide_oci_production_deployment.md)를 따라 수동으로
+배포합니다.
+
+데스크톱 릴리스는 `main`에서 `Desktop Release` 워크플로를 수동 실행합니다. 릴리스 태그가
+가리키는 정확한 SHA의 `CI / required` 성공과 버전 일치를 확인한 뒤 초안 릴리스에 서명
+산출물을 올리고, `desktop-release` 환경 승인을 거쳐 공개합니다.
+
 ## 기술 문서
 
 - [플랫폼 아키텍처](docs/explanation-platform-architecture.md)
@@ -93,6 +131,7 @@ cd server
 
 ## Pull Request 전 확인
 
+- `prek install`로 로컬 Git 훅을 설치합니다.
 - 변경 범위에 해당하는 테스트와 검증 명령을 통과시킵니다.
 - 사용자 동작이나 플랫폼 계약이 바뀌면 관련 문서를 함께 수정합니다.
 - 비밀값, 개인 세션 파일, 로그와 캡처용 임시 파일을 커밋하지 않습니다.

--- a/frontend/src/tests/contracts/ci-prek-contract.test.ts
+++ b/frontend/src/tests/contracts/ci-prek-contract.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+
+import {test} from 'vitest';
+
+const repoRoot = new URL('../../../../', import.meta.url);
+const repoSource = (path: string) => readFileSync(new URL(path, repoRoot), 'utf8');
+const prekConfig = repoSource('prek.toml');
+const ciWorkflow = repoSource('.github/workflows/ci.yml');
+const prekHooks = prekConfig.split('[[repos.hooks]]').slice(1);
+const prekHook = (id: string) => {
+    const hook = prekHooks.find((candidate) => candidate.includes(`id = "${id}"`));
+    assert.ok(hook, `${id} prek hook을 찾을 수 없다`);
+    return hook;
+};
+
+test('prek는 빠른 pre-commit과 경로별 pre-push 검사를 설치한다', () => {
+    assert.match(prekConfig, /minimum_prek_version = "0\.4\.9"/u);
+    assert.match(prekConfig, /default_install_hook_types = \["pre-commit", "pre-push"\]/u);
+    assert.match(prekHook('staged-diff-check'), /git diff --cached --check/u);
+    assert.match(prekHook('no-commit-to-branch'), /"--branch", "main"/u);
+    assert.match(prekHook('frontend-format'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('frontend-lint'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('desktop-rustfmt'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('frontend-check'), /stages = \["pre-push"\]/u);
+    assert.match(prekHook('frontend-check'), /files = "\^\(frontend\|desktop\)\/"/u);
+    assert.match(prekHook('server-check'), /stages = \["pre-push"\]/u);
+    assert.match(prekHook('desktop-test'), /JUNGLE_BELL_DATA_API_URL/u);
+    assert.match(prekHook('desktop-clippy'), /JUNGLE_BELL_DATA_API_URL/u);
+    assert.doesNotMatch(prekConfig, /campus-observer/u);
+
+    const localHooks = prekConfig.slice(prekConfig.indexOf('repo = "local"'));
+    const localHookDefinitions = localHooks.split('[[repos.hooks]]').slice(1);
+    assert.ok(localHookDefinitions.length > 0);
+    for (const hook of localHookDefinitions) {
+        assert.match(hook, /language = "system"/u);
+        assert.match(hook, /pass_filenames = false/u);
+    }
+});
+
+test('CI는 hygiene와 제품 검증을 고정 required 잡으로 집계한다', () => {
+    assert.match(ciWorkflow, /^  hygiene:\s*$/mu);
+    assert.match(
+        ciWorkflow,
+        /j178\/prek-action@[0-9a-f]{40}[\s\S]*prek-version: "0\.4\.14"[\s\S]*install-only: true/u,
+    );
+    assert.match(ciWorkflow, /prek validate-config prek\.toml/u);
+    assert.match(ciWorkflow, /prek run --all-files --group hygiene/u);
+    assert.match(ciWorkflow, /^  web:\s*$/mu);
+    assert.match(ciWorkflow, /^  server:\s*$/mu);
+    assert.match(ciWorkflow, /^  desktop:\s*$/mu);
+    assert.match(ciWorkflow, /^  required:\s*$/mu);
+    assert.match(
+        ciWorkflow,
+        /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u,
+    );
+    assert.match(ciWorkflow, /if: \$\{\{ always\(\) \}\}/u);
+    assert.match(ciWorkflow, /needs: \[hygiene, web, server, desktop\]/u);
+    assert.match(ciWorkflow, /test "\$HYGIENE_RESULT" = "success"/u);
+    assert.match(ciWorkflow, /test "\$WEB_RESULT" = "success"/u);
+    assert.match(ciWorkflow, /test "\$SERVER_RESULT" = "success"/u);
+    assert.match(ciWorkflow, /test "\$DESKTOP_RESULT" = "success"/u);
+    assert.doesNotMatch(ciWorkflow, /actions\/upload-artifact/u);
+    assert.doesNotMatch(ciWorkflow, /campus-observer/u);
+    assert.doesNotMatch(ciWorkflow, /^\s+paths(?:-ignore)?:/mu);
+});

--- a/frontend/src/tests/contracts/release-channel.test.ts
+++ b/frontend/src/tests/contracts/release-channel.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
 import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
 
 import {test} from 'vitest';
 
@@ -71,6 +73,21 @@ test('Gradle·Vite·Tauri 릴리스 버전은 같은 허용 SemVer다', () => {
     assert.doesNotMatch(repoSource('server/Dockerfile'), /SNAPSHOT/u);
 });
 
+test('릴리스 입력 검증기는 현재 버전 태그만 허용한다', () => {
+    const frontendPackage = JSON.parse(repoSource('frontend/package.json')) as {
+        version?: string;
+    };
+    const canonicalVersion = frontendPackage.version;
+    assert.ok(canonicalVersion);
+
+    const script = fileURLToPath(new URL('scripts/verify-release-version.mjs', repoRoot));
+    const acceptedVersion = execFileSync(process.execPath, [script, `v${canonicalVersion}`], {
+        encoding: 'utf8',
+    }).trim();
+    assert.equal(acceptedVersion, canonicalVersion);
+    assert.throws(() => execFileSync(process.execPath, [script, 'v999.0.0'], {stdio: 'pipe'}));
+});
+
 test('리뉴얼 앱은 기존 앱과 다른 식별자와 v2 업데이트 채널을 사용한다', () => {
     assert.equal(tauriConfig.identifier, 'dev.sijun-yang.jungle-bell.v2');
     assert.notEqual(tauriConfig.identifier, 'dev.sijun-yang.jungle-bell');
@@ -112,6 +129,41 @@ test('v2 업데이트 매니페스트는 초안 릴리스 안에서만 생성해
     assert.ok(publishRelease >= 0);
     assert.match(
         releaseWorkflow.slice(publishRelease),
-        /needs:\s*\[[^\]]*publish-v2-updater-manifest[^\]]*\]/,
+        /needs:\s*\[[^\]]*verify-draft-release[^\]]*\]/,
     );
+});
+
+test('데스크톱 릴리스는 exact SHA의 CI 통과 후 서명·공개 환경을 거친다', () => {
+    assert.match(releaseWorkflow, /^permissions:\s*\n\s+contents:\s*read\s*$/mu);
+    assert.match(releaseWorkflow, /group:\s*desktop-release/u);
+    assert.match(releaseWorkflow, /cancel-in-progress:\s*false/u);
+    assert.match(releaseWorkflow, /^\s*prepare-release:\s*$/mu);
+    assert.match(releaseWorkflow, /actions:\s*read/u);
+    assert.match(releaseWorkflow, /git merge-base --is-ancestor "\$SHA" origin\/main/u);
+    assert.match(
+        releaseWorkflow,
+        /git checkout --detach "\$SHA"[\s\S]*node scripts\/verify-release-version\.mjs "\$TAG"/u,
+    );
+    assert.match(releaseWorkflow, /gh run list[\s\S]*--workflow ci\.yml/u);
+    assert.match(releaseWorkflow, /headSha/u);
+    assert.match(releaseWorkflow, /\.name == "required"/u);
+    assert.match(releaseWorkflow, /ref:\s*\$\{\{ needs\.prepare-release\.outputs\.sha \}\}/u);
+    assert.match(releaseWorkflow, /node-version:\s*24/u);
+    assert.match(releaseWorkflow, /environment:\s*desktop-signing/u);
+    assert.match(releaseWorkflow, /max-parallel:\s*1/u);
+    assert.match(releaseWorkflow, /tauri-apps\/tauri-action@[0-9a-f]{40}/u);
+    assert.match(releaseWorkflow, /^\s*verify-draft-release:\s*$/mu);
+    assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_aarch64\.tar\.gz/u);
+    assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64\.tar\.gz/u);
+    assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64-setup\.exe/u);
+
+    const publishRelease = releaseWorkflow.indexOf('publish-release:');
+    assert.ok(publishRelease >= 0);
+    const publishSource = releaseWorkflow.slice(publishRelease);
+    assert.match(publishSource, /environment:\s*desktop-release/u);
+    assert.match(publishSource, /contents:\s*write/u);
+    assert.match(publishSource, /git rev-parse "refs\/tags\/\$TAG\^\{commit\}"/u);
+    assert.match(publishSource, /gh release download "\$TAG"[\s\S]*latest-v2\.json/u);
+    assert.match(publishSource, /"darwin-aarch64"[\s\S]*"windows-x86_64"/u);
+    assert.match(publishSource, /"\$\{asset_name\}\.sig"/u);
 });

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,131 @@
+#:schema https://www.schemastore.org/prek.json
+
+minimum_prek_version = "0.4.9"
+default_install_hook_types = ["pre-commit", "pre-push"]
+
+[[repos]]
+repo = "builtin"
+
+[[repos.hooks]]
+id = "check-added-large-files"
+args = ["--maxkb=2500"]
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-case-conflict"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-json"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-merge-conflict"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-symlinks"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-toml"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "check-yaml"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "detect-private-key"
+stages = ["pre-commit"]
+groups = ["hygiene"]
+
+[[repos.hooks]]
+id = "no-commit-to-branch"
+args = ["--branch", "main"]
+always_run = true
+stages = ["pre-commit"]
+
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "staged-diff-check"
+name = "staged diff check"
+entry = "git diff --cached --check"
+language = "system"
+pass_filenames = false
+always_run = true
+stages = ["pre-commit"]
+
+[[repos.hooks]]
+id = "frontend-format"
+name = "frontend format"
+entry = "npm --prefix frontend run format:check"
+language = "system"
+pass_filenames = false
+files = "^frontend/"
+stages = ["pre-commit"]
+
+[[repos.hooks]]
+id = "frontend-lint"
+name = "frontend lint"
+entry = "npm --prefix frontend run lint"
+language = "system"
+pass_filenames = false
+files = "^frontend/"
+stages = ["pre-commit"]
+
+[[repos.hooks]]
+id = "desktop-rustfmt"
+name = "desktop rustfmt"
+entry = "cargo fmt --manifest-path desktop/Cargo.toml --check"
+language = "system"
+pass_filenames = false
+files = "^desktop/.*\\.rs$"
+stages = ["pre-commit"]
+
+[[repos.hooks]]
+id = "frontend-check"
+name = "frontend check"
+entry = "npm --prefix frontend run check"
+language = "system"
+pass_filenames = false
+files = "^(frontend|desktop)/"
+stages = ["pre-push"]
+
+[[repos.hooks]]
+id = "server-check"
+name = "server check"
+entry = "./server/gradlew --no-daemon -p server check"
+language = "system"
+pass_filenames = false
+files = "^server/"
+stages = ["pre-push"]
+
+[[repos.hooks]]
+id = "desktop-test"
+name = "desktop test"
+entry = "cargo test --manifest-path desktop/Cargo.toml --all-targets"
+language = "system"
+pass_filenames = false
+files = "^desktop/"
+stages = ["pre-push"]
+env = { JUNGLE_BELL_DATA_API_URL = "https://jungle-bell.sijun-yang.com" }
+
+[[repos.hooks]]
+id = "desktop-clippy"
+name = "desktop clippy"
+entry = "cargo clippy --manifest-path desktop/Cargo.toml --all-targets -- -D warnings"
+language = "system"
+pass_filenames = false
+files = "^desktop/"
+stages = ["pre-push"]
+env = { JUNGLE_BELL_DATA_API_URL = "https://jungle-bell.sijun-yang.com" }

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+import {readFileSync} from 'node:fs';
+
+const repoRoot = new URL('../', import.meta.url);
+const readSource = (path) => readFileSync(new URL(path, repoRoot), 'utf8');
+const readJson = (path) => JSON.parse(readSource(path));
+
+const matchedVersion = (path, pattern, label) => {
+    const match = readSource(path).match(pattern);
+    if (!match?.[1]) throw new Error(`${label} version was not found`);
+    return match[1];
+};
+
+const tag = process.argv[2];
+const tagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:alpha|beta|rc)\.(0|[1-9]\d*))?$/u;
+
+try {
+    const tagMatch = tag?.match(tagPattern);
+    if (!tagMatch) {
+        throw new Error('tag must match vX.Y.Z or vX.Y.Z-(alpha|beta|rc).N');
+    }
+
+    const expectedVersion = tag.slice(1);
+    const frontendPackage = readJson('frontend/package.json');
+    const frontendPackageLock = readJson('frontend/package-lock.json');
+    const tauriConfig = readJson('desktop/tauri.conf.json');
+    const versions = new Map([
+        ['frontend/package.json', frontendPackage.version],
+        ['frontend/package-lock.json root', frontendPackageLock.version],
+        ['frontend/package-lock.json workspace', frontendPackageLock.packages?.['']?.version],
+        [
+            'server/build.gradle.kts',
+            matchedVersion(
+                'server/build.gradle.kts',
+                /allprojects\s*\{[\s\S]*?version\s*=\s*"([^"]+)"/u,
+                'Gradle',
+            ),
+        ],
+        [
+            'desktop/Cargo.toml',
+            matchedVersion(
+                'desktop/Cargo.toml',
+                /^\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/mu,
+                'Cargo manifest',
+            ),
+        ],
+        [
+            'desktop/Cargo.lock',
+            matchedVersion(
+                'desktop/Cargo.lock',
+                /\[\[package\]\]\nname = "jungle-bell"\nversion = "([^"]+)"/u,
+                'Cargo lock',
+            ),
+        ],
+        ['desktop/tauri.conf.json', tauriConfig.version],
+    ]);
+
+    for (const [label, version] of versions) {
+        if (version !== expectedVersion) {
+            throw new Error(`${label} has version ${String(version)}, expected ${expectedVersion}`);
+        }
+    }
+
+    process.stdout.write(`${expectedVersion}\n`);
+} catch (error) {
+    console.error(`[release-version] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+}


### PR DESCRIPTION
## 변경 사항
- prek pre-commit·pre-push 훅과 CI hygiene·required 집계 잡 추가
- 데스크톱 릴리스를 exact-SHA CI 통과, 직렬 matrix, 초안 자산 재검증, 공개 환경 승인 구조로 강화
- 서버 배포는 기존 로컬 수동 절차로 유지하고 campus-observer는 필수 CI에서 제외

## 검증
- frontend verify:web: 101 files, 507 tests 통과
- desktop verify:desktop: UI build, Rust 204 tests, clippy 통과
- server Gradle check·bootJar, Compose 검증 통과
- API·Worker Docker target build 통과
- prek 0.4.9 validate/hygiene와 설치된 pre-commit·pre-push 통과
- actionlint 1.7.12와 계약 테스트 8개 통과