### PR TITLE
ci: draft PR을 CI 대상에서 제외

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   push:
     branches: [main]
   workflow_dispatch:
@@ -15,6 +16,7 @@ permissions:
 
 jobs:
   hygiene:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -29,6 +31,7 @@ jobs:
       - run: prek run --all-files --group hygiene --show-diff-on-failure
 
   web:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -46,6 +49,7 @@ jobs:
         working-directory: frontend
 
   server:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -80,6 +84,7 @@ jobs:
         run: docker build --target worker-runtime --file server/Dockerfile .
 
   desktop:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: desktop (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -112,7 +117,7 @@ jobs:
 
   required:
     name: required
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     needs: [hygiene, web, server, desktop]
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/frontend/src/tests/contracts/ci-prek-contract.test.ts
+++ b/frontend/src/tests/contracts/ci-prek-contract.test.ts
@@ -54,7 +54,20 @@ test('CI는 hygiene와 제품 검증을 고정 required 잡으로 집계한다',
         ciWorkflow,
         /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/u,
     );
-    assert.match(ciWorkflow, /if: \$\{\{ always\(\) \}\}/u);
+    assert.match(
+        ciWorkflow,
+        /types: \[opened, synchronize, reopened, ready_for_review, converted_to_draft\]/u,
+    );
+    assert.equal(
+        ciWorkflow.split(
+            "if: github.event_name != 'pull_request' || github.event.pull_request.draft == false",
+        ).length - 1,
+        4,
+    );
+    assert.match(
+        ciWorkflow,
+        /if: \$\{\{ always\(\) && \(github\.event_name != 'pull_request' \|\| github\.event\.pull_request\.draft == false\) \}\}/u,
+    );
     assert.match(ciWorkflow, /needs: \[hygiene, web, server, desktop\]/u);
     assert.match(ciWorkflow, /test "\$HYGIENE_RESULT" = "success"/u);
     assert.match(ciWorkflow, /test "\$WEB_RESULT" = "success"/u);


### PR DESCRIPTION
Draft PR에서는 모든 CI job과 required 집계를 건너뜁니다. ready_for_review 전환 시 검증을 시작하고, converted_to_draft 전환 시 기존 실행을 취소할 수 있도록 이벤트를 추가합니다.