### PR TITLE
ci(release): draft 릴리스 조회 권한 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read
-      contents: read
+      contents: write
     outputs:
       tag: ${{ steps.info.outputs.tag }}
       sha: ${{ steps.info.outputs.sha }}

--- a/frontend/src/tests/contracts/release-channel.test.ts
+++ b/frontend/src/tests/contracts/release-channel.test.ts
@@ -139,6 +139,11 @@ test('데스크톱 릴리스는 exact SHA의 CI 통과 후 서명·공개 환경
     assert.match(releaseWorkflow, /cancel-in-progress:\s*false/u);
     assert.match(releaseWorkflow, /^\s*prepare-release:\s*$/mu);
     assert.match(releaseWorkflow, /actions:\s*read/u);
+    const prepareRelease = releaseWorkflow.slice(
+        releaseWorkflow.indexOf('  prepare-release:'),
+        releaseWorkflow.indexOf('  publish-tauri:'),
+    );
+    assert.match(prepareRelease, /permissions:\s*\n\s+actions:\s*read\s*\n\s+contents:\s*write/u);
     assert.match(releaseWorkflow, /git merge-base --is-ancestor "\$SHA" origin\/main/u);
     assert.match(
         releaseWorkflow,


### PR DESCRIPTION
## 원인
`prepare-release`의 `contents: read` 토큰이 draft 릴리스를 조회하지 못해 v0.5.8 릴리스 검증이 중단됐습니다.

## 변경
- `prepare-release` job에만 `contents: write` 부여
- 권한 계약 회귀 테스트 추가

## 검증
- `npm test -- src/tests/contracts/release-channel.test.ts`
- `npm run format:check`
- 실패 실행: https://github.com/YangSiJun528/jungle-bell/actions/runs/32553706395