### PR TITLE
ci(release): 초안 검증 조회 권한 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/frontend/src/tests/contracts/release-channel.test.ts
+++ b/frontend/src/tests/contracts/release-channel.test.ts
@@ -158,6 +158,11 @@ test('데스크톱 릴리스는 exact SHA의 CI 통과 후 서명·공개 환경
     assert.match(releaseWorkflow, /max-parallel:\s*1/u);
     assert.match(releaseWorkflow, /tauri-apps\/tauri-action@[0-9a-f]{40}/u);
     assert.match(releaseWorkflow, /^\s*verify-draft-release:\s*$/mu);
+    const verifyDraftRelease = releaseWorkflow.slice(
+        releaseWorkflow.indexOf('  verify-draft-release:'),
+        releaseWorkflow.indexOf('  publish-release:'),
+    );
+    assert.match(verifyDraftRelease, /permissions:\s*\n\s+contents:\s*write/u);
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_aarch64\.tar\.gz/u);
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64\.tar\.gz/u);
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64-setup\.exe/u);


### PR DESCRIPTION
## 변경 사항
- verify-draft-release 작업에 contents: write 권한을 부여해 draft release 조회를 허용
- 작업별 권한 회귀 테스트 추가

## 검증
- npm run test -- --run src/tests/contracts/release-channel.test.ts
- npm run format:check
- push hook frontend check