### PR TITLE
fix(release): 업데이트 매니페스트 검증 스코프 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,14 +328,15 @@ jobs:
             --pattern latest-v2.json --dir "$MANIFEST_DIR"
           jq -e --arg version "$VERSION" \
             --arg prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/" '
-            .version == $version
+            . as $manifest
+            | ($manifest.version == $version)
               and ([
                 "darwin-aarch64",
                 "darwin-x86_64",
                 "windows-x86_64"
               ] | all(. as $platform
-                | (.platforms[$platform].signature | type == "string" and length > 0)
-                  and (.platforms[$platform].url | type == "string" and startswith($prefix))
+                | ($manifest.platforms[$platform].signature | type == "string" and length > 0)
+                  and ($manifest.platforms[$platform].url | type == "string" and startswith($prefix))
               ))
           ' "$MANIFEST_DIR/latest-v2.json"
 
@@ -398,14 +399,15 @@ jobs:
             --pattern latest-v2.json --dir "$MANIFEST_DIR"
           jq -e --arg version "$VERSION" \
             --arg prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/" '
-            .version == $version
+            . as $manifest
+            | ($manifest.version == $version)
               and ([
                 "darwin-aarch64",
                 "darwin-x86_64",
                 "windows-x86_64"
               ] | all(. as $platform
-                | (.platforms[$platform].signature | type == "string" and length > 0)
-                  and (.platforms[$platform].url | type == "string" and startswith($prefix))
+                | ($manifest.platforms[$platform].signature | type == "string" and length > 0)
+                  and ($manifest.platforms[$platform].url | type == "string" and startswith($prefix))
               ))
           ' "$MANIFEST_DIR/latest-v2.json"
 

--- a/frontend/src/tests/contracts/release-channel.test.ts
+++ b/frontend/src/tests/contracts/release-channel.test.ts
@@ -166,6 +166,9 @@ test('데스크톱 릴리스는 exact SHA의 CI 통과 후 서명·공개 환경
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_aarch64\.tar\.gz/u);
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64\.tar\.gz/u);
     assert.match(releaseWorkflow, /Jungle\.Bell_\$\{VERSION\}_x64-setup\.exe/u);
+    assert.equal(releaseWorkflow.match(/\. as \$manifest/gu)?.length, 3);
+    assert.equal(releaseWorkflow.match(/\$manifest\.platforms\[\$platform\]/gu)?.length, 6);
+    assert.doesNotMatch(releaseWorkflow, /\(\.platforms\[\$platform\]/u);
 
     const publishRelease = releaseWorkflow.indexOf('publish-release:');
     assert.ok(publishRelease >= 0);


### PR DESCRIPTION
## 변경 사항
- jq 플랫폼 순회 전에 매니페스트 루트 객체를 변수로 고정
- 초안 검증과 최종 게시 검증에 동일하게 적용
- jq 스코프 회귀 테스트 추가

## 검증
- release-channel 계약 테스트 6개 통과
- frontend 포맷 검사 통과
- 실제 v0.5.8 latest-v2.json 검증 통과
- push hook frontend check 통과