### PR TITLE
feat(laundry): 건조기 오류·일시 정지 알림 추가

### DIFF
--- a/server/core/src/main/kotlin/app/junglebell/server/domain/automation/AutomationEngine.kt
+++ b/server/core/src/main/kotlin/app/junglebell/server/domain/automation/AutomationEngine.kt
@@ -239,9 +239,17 @@ class AutomationEngine(
         var created = 0
         for (watch in automation.activeLaundryWatches()) {
             val appliance = appliances["${watch.machineId}:${watch.appliance}"] ?: continue
-            val decision = laundryNotificationDecision(watch, appliance, now)
+            val recovered = watch.attentionUnresolved &&
+                (watch.attentionRecovered ||
+                    (watch.sessionId == appliance.sessionId && appliance.operationalStatus == "RUNNING"))
+            val evaluatedWatch = if (recovered) {
+                automation.markLaundryWatchResumed(watch.id, now)
+                watch.copy(attentionUnresolved = false)
+            } else watch
+            val transitionAttentionStatus = laundryTransitionAttentionStatus(evaluatedWatch, appliance)
+            val decision = laundryNotificationDecision(evaluatedWatch, appliance, now, transitionAttentionStatus)
             if (decision == null) {
-                if (laundryWatchShouldCompleteSilently(watch, appliance)) {
+                if (laundryWatchShouldCompleteSilently(evaluatedWatch, appliance)) {
                     automation.completeLaundryWatch(watch.id, now)
                 }
                 continue
@@ -499,11 +507,18 @@ internal fun laundryNotificationDecision(
     watch: ActiveLaundryWatch,
     appliance: LaundryAppliance,
     now: Long,
+    transitionAttentionStatus: String? = null,
 ): LaundryDecision? {
     val terminal = appliance.operationalStatus in setOf("COMPLETED", "IDLE") ||
         appliance.projection?.status == "CONFIRMED_COMPLETED"
-    val sessionMatches = watch.sessionId == appliance.sessionId || watch.sessionId == null && terminal
+    val hasDurableAttention = watch.appliance == "dryer" &&
+        transitionAttentionStatus in setOf("ERROR", "PAUSED")
+    val snapshotSessionMatches = watch.sessionId != null && watch.sessionId == appliance.sessionId
+    val durableSessionMismatch = hasDurableAttention && !snapshotSessionMatches
+    val sessionMatches = snapshotSessionMatches ||
+        (watch.sessionId == null && terminal) || hasDurableAttention
     if (!sessionMatches) return null
+    if (watch.attentionUnresolved && appliance.operationalStatus in setOf("ERROR", "PAUSED", "IDLE")) return null
 
     val remainingMinutes = projectedRemainingMinutes(appliance, now)
     val estimatedCompletionReached = appliance.projection?.status == "AWAITING_COMPLETION_CONFIRMATION" ||
@@ -511,7 +526,16 @@ internal fun laundryNotificationDecision(
     val machine = Regex("\\d+$").find(watch.machineId)?.value?.let { "${it}번" } ?: watch.machineId
     val device = if (watch.appliance == "washer") "세탁기" else "건조기"
     val action = if (watch.appliance == "washer") "세탁" else "건조"
+    val attentionStatus = when {
+        watch.appliance != "dryer" -> null
+        durableSessionMismatch -> transitionAttentionStatus
+        appliance.operationalStatus == "ERROR" || transitionAttentionStatus == "ERROR" -> "ERROR"
+        appliance.operationalStatus == "PAUSED" || transitionAttentionStatus == "PAUSED" -> "PAUSED"
+        else -> null
+    }
+    val attentionErrorCode = appliance.errorCode.takeUnless { durableSessionMismatch }
     val copy = when {
+        attentionStatus != null -> laundryAttentionCopy(machine, attentionStatus, attentionErrorCode)
         watch.notificationMode == "before-completion" &&
             appliance.operationalStatus == "RUNNING" &&
             remainingMinutes in 1..watch.notifyBeforeMinutes -> LaundryNotificationCopy(
@@ -532,7 +556,9 @@ internal fun laundryNotificationDecision(
         else -> return null
     }
     val id = UUID.randomUUID()
-    val expiresAt = now + if (copy.kind == "laundry-completed") {
+    val attentionIncidentId = watch.pendingAttentionIncidentId
+        ?: "snapshot:${appliance.observedAt}"
+    val expiresAt = now + if (copy.kind in setOf("laundry-completed", "laundry-attention")) {
         Duration.ofHours(6).toMillis()
     } else {
         Duration.ofHours(2).toMillis()
@@ -541,7 +567,11 @@ internal fun laundryNotificationDecision(
         notification = NotificationRecord(
             id = id,
             userId = watch.userId,
-            sourceEventId = "${copy.kind}:${watch.id}:${watch.sessionId ?: "none"}:${watch.notificationMode}",
+            sourceEventId = if (copy.kind == "laundry-attention") {
+                "laundry-attention:${watch.id}:${watch.sessionId ?: "none"}:$attentionIncidentId"
+            } else {
+                "${copy.kind}:${watch.id}:${watch.sessionId ?: "none"}:${watch.notificationMode}"
+            },
             kind = copy.kind,
             title = copy.title,
             body = copy.body,
@@ -556,7 +586,10 @@ internal fun laundryNotificationDecision(
                 "appliance" to watch.appliance,
                 "sessionId" to watch.sessionId,
                 "notificationMode" to watch.notificationMode,
-                "remainingMinutes" to remainingMinutes,
+                "attentionStatus" to attentionStatus,
+                "attentionIncidentId" to attentionIncidentId.takeIf { attentionStatus != null },
+                "errorCode" to attentionErrorCode,
+                "remainingMinutes" to remainingMinutes.takeUnless { durableSessionMismatch },
                 "createdAtEpochMs" to now,
                 "expiresAtEpochMs" to expiresAt,
             ),
@@ -564,11 +597,58 @@ internal fun laundryNotificationDecision(
             dueAtEpochMs = now,
             expiresAtEpochMs = expiresAt,
         ),
-        completeWatch = true,
+        completeWatch = when (copy.kind) {
+            "laundry-completed" -> true
+            "laundry-completion-expected" -> terminal
+            else -> false
+        },
     )
 }
 
+internal fun laundryTransitionAttentionStatus(
+    watch: ActiveLaundryWatch,
+    appliance: LaundryAppliance,
+): String? {
+    if (
+        watch.appliance != "dryer" || watch.attentionUnresolved || watch.sessionId == null
+    ) return null
+    val pendingStatus = watch.pendingAttentionStatus?.takeIf { it in setOf("ERROR", "PAUSED") } ?: return null
+    val replacedSession = appliance.sessionId != null && appliance.sessionId != watch.sessionId
+    if (replacedSession) return pendingStatus
+    if (appliance.operationalStatus in setOf("ERROR", "PAUSED")) return pendingStatus
+    if (appliance.operationalStatus != "IDLE") return null
+    val terminalState = appliance.state.raw ?: appliance.state.code
+    return pendingStatus.takeIf { terminalState in setOf("POWER_OFF", "INITIAL") }
+}
+
 private data class LaundryNotificationCopy(val kind: String, val title: String, val body: String)
+
+private fun laundryAttentionCopy(
+    machine: String,
+    status: String,
+    errorCode: String?,
+): LaundryNotificationCopy = when {
+    status == "PAUSED" -> LaundryNotificationCopy(
+        kind = "laundry-attention",
+        title = "건조기가 일시 정지됐습니다",
+        body = "$machine 건조기 상태를 확인해 주세요.",
+    )
+    errorCode == "EMPTY_WATER_ALERT_ERROR" -> LaundryNotificationCopy(
+        kind = "laundry-attention",
+        title = "건조기가 멈췄습니다",
+        body = "$machine 건조기 물통을 비우고 건조 상태를 확인해 주세요.",
+    )
+    errorCode == "DOOR_OPEN_ERROR" -> LaundryNotificationCopy(
+        kind = "laundry-attention",
+        title = "건조기가 멈췄습니다",
+        body = "$machine 건조기 문을 닫고 건조 상태를 확인해 주세요.",
+    )
+    else -> LaundryNotificationCopy(
+        kind = "laundry-attention",
+        title = "건조기가 멈췄습니다",
+        body = "$machine 건조기에 오류가 발생했습니다. 건조 상태를 확인해 주세요.",
+    )
+}
 
 private fun projectedRemainingMinutes(appliance: LaundryAppliance, now: Long): Int {
     val estimatedFinishAt = appliance.estimatedFinishAt ?: return appliance.projection?.remainingMinutes
@@ -579,7 +659,7 @@ private fun projectedRemainingMinutes(appliance: LaundryAppliance, now: Long): I
     return if (seconds <= 0) 0 else ((seconds + 59) / 60).toInt()
 }
 
-private fun laundryWatchShouldCompleteSilently(
+internal fun laundryWatchShouldCompleteSilently(
     watch: ActiveLaundryWatch,
     appliance: LaundryAppliance,
 ): Boolean {

--- a/server/core/src/main/kotlin/app/junglebell/server/domain/automation/AutomationStore.kt
+++ b/server/core/src/main/kotlin/app/junglebell/server/domain/automation/AutomationStore.kt
@@ -11,6 +11,7 @@ interface AutomationStore {
     fun recentMealPublications(since: Instant): List<MealPublication>
     fun mealSubscriberUserIds(period: String): List<UUID>
     fun activeLaundryWatches(): List<ActiveLaundryWatch>
+    fun markLaundryWatchResumed(id: String, now: Long): Boolean
     fun completeLaundryWatch(id: String, now: Long): Boolean
     fun claimPushDeliveries(now: Long, leaseToken: String, limit: Int): List<PushDelivery>
     fun settlePush(
@@ -61,6 +62,11 @@ data class ActiveLaundryWatch(
     val sessionId: String?,
     val notificationMode: String,
     val notifyBeforeMinutes: Int,
+    val attentionUnresolved: Boolean = false,
+    val attentionUnresolvedAtEpochMs: Long? = null,
+    val pendingAttentionStatus: String? = null,
+    val pendingAttentionIncidentId: String? = null,
+    val attentionRecovered: Boolean = false,
 )
 
 data class PushDelivery(

--- a/server/core/src/main/kotlin/app/junglebell/server/domain/automation/JdbcAutomationStore.kt
+++ b/server/core/src/main/kotlin/app/junglebell/server/domain/automation/JdbcAutomationStore.kt
@@ -109,11 +109,73 @@ class JdbcAutomationStore(private val jdbc: JdbcClient) : AutomationStore {
 
     override fun activeLaundryWatches(): List<ActiveLaundryWatch> = jdbc.sql(
         """
-        SELECT id, user_id, machine_id, appliance, session_id,
-               notification_mode, notify_before_minutes
-        FROM laundry_watch
-        WHERE status = 'active'
-        ORDER BY created_at_epoch_ms, id
+        SELECT watch.id, watch.user_id, watch.machine_id, watch.appliance, watch.session_id,
+               watch.notification_mode, watch.notify_before_minutes, watch.attention_unresolved,
+               watch.attention_unresolved_at_epoch_ms,
+               (
+                   SELECT CASE incident.type
+                       WHEN 'ERROR_ENTERED' THEN 'ERROR'
+                       WHEN 'PAUSED' THEN 'PAUSED'
+                       ELSE NULL
+                   END
+                   FROM laundry_event incident
+                   WHERE watch.appliance = 'dryer'
+                     AND incident.machine_id = watch.machine_id
+                     AND incident.appliance = watch.appliance
+                     AND incident.session_id = watch.session_id
+                     AND incident.observed_at >= TO_TIMESTAMP(watch.created_at_epoch_ms / 1000.0)
+                     AND incident.type IN ('ERROR_ENTERED', 'PAUSED')
+                     AND NOT EXISTS (
+                         SELECT 1
+                         FROM laundry_event recovery
+                         WHERE recovery.machine_id = incident.machine_id
+                           AND recovery.appliance = incident.appliance
+                           AND recovery.session_id = incident.session_id
+                           AND recovery.type IN ('STARTED', 'COMPLETED')
+                           AND recovery.observed_at >= incident.observed_at
+                     )
+                   ORDER BY CASE incident.type WHEN 'ERROR_ENTERED' THEN 2 ELSE 1 END DESC,
+                       incident.observed_at DESC, incident.id DESC
+                   LIMIT 1
+               ) AS pending_attention_status,
+               (
+                   SELECT incident.id::text
+                   FROM laundry_event incident
+                   WHERE watch.appliance = 'dryer'
+                     AND incident.machine_id = watch.machine_id
+                     AND incident.appliance = watch.appliance
+                     AND incident.session_id = watch.session_id
+                     AND incident.observed_at >= TO_TIMESTAMP(watch.created_at_epoch_ms / 1000.0)
+                     AND incident.type IN ('ERROR_ENTERED', 'PAUSED')
+                     AND NOT EXISTS (
+                         SELECT 1
+                         FROM laundry_event recovery
+                         WHERE recovery.machine_id = incident.machine_id
+                           AND recovery.appliance = incident.appliance
+                           AND recovery.session_id = incident.session_id
+                           AND recovery.type IN ('STARTED', 'COMPLETED')
+                           AND recovery.observed_at >= incident.observed_at
+                     )
+                   ORDER BY incident.observed_at, incident.id
+                   LIMIT 1
+               ) AS pending_attention_incident_id,
+               COALESCE(
+                   watch.attention_unresolved AND watch.attention_unresolved_at_epoch_ms IS NOT NULL AND EXISTS (
+                       SELECT 1
+                       FROM laundry_event recovery
+                       WHERE watch.appliance = 'dryer'
+                         AND recovery.machine_id = watch.machine_id
+                         AND recovery.appliance = watch.appliance
+                         AND recovery.session_id = watch.session_id
+                         AND recovery.type IN ('STARTED', 'COMPLETED')
+                         AND recovery.observed_at >=
+                             TO_TIMESTAMP(watch.attention_unresolved_at_epoch_ms / 1000.0)
+                   ),
+                   false
+               ) AS attention_recovered
+        FROM laundry_watch watch
+        WHERE watch.status = 'active'
+        ORDER BY watch.created_at_epoch_ms, watch.id
         """.trimIndent(),
     ).query { row, _ ->
         ActiveLaundryWatch(
@@ -124,13 +186,30 @@ class JdbcAutomationStore(private val jdbc: JdbcClient) : AutomationStore {
             sessionId = row.getString("session_id"),
             notificationMode = row.getString("notification_mode"),
             notifyBeforeMinutes = row.getInt("notify_before_minutes"),
+            attentionUnresolved = row.getBoolean("attention_unresolved"),
+            attentionUnresolvedAtEpochMs = row.getObject("attention_unresolved_at_epoch_ms")
+                ?.let { row.getLong("attention_unresolved_at_epoch_ms") },
+            pendingAttentionStatus = row.getString("pending_attention_status"),
+            pendingAttentionIncidentId = row.getString("pending_attention_incident_id"),
+            attentionRecovered = row.getBoolean("attention_recovered"),
         )
     }.list()
+
+    override fun markLaundryWatchResumed(id: String, now: Long): Boolean = jdbc.sql(
+        """
+        UPDATE laundry_watch
+        SET attention_unresolved = false, attention_unresolved_at_epoch_ms = NULL,
+            updated_at_epoch_ms = :now
+        WHERE id = :id AND status = 'active' AND attention_unresolved
+        RETURNING id
+        """.trimIndent(),
+    ).param("now", now).param("id", id).query(String::class.java).optional().isPresent
 
     override fun completeLaundryWatch(id: String, now: Long): Boolean = jdbc.sql(
         """
         UPDATE laundry_watch
-        SET status = 'completed', updated_at_epoch_ms = :now
+        SET status = 'completed', attention_unresolved = false,
+            attention_unresolved_at_epoch_ms = NULL, updated_at_epoch_ms = :now
         WHERE id = :id AND status = 'active'
         RETURNING id
         """.trimIndent(),

--- a/server/core/src/main/kotlin/app/junglebell/server/domain/notification/JdbcNotificationStore.kt
+++ b/server/core/src/main/kotlin/app/junglebell/server/domain/notification/JdbcNotificationStore.kt
@@ -67,12 +67,32 @@ class JdbcNotificationStore(
         completeWatch: Boolean,
         now: Long,
     ): Boolean {
+        val active = jdbc.sql(
+            """
+            SELECT id FROM laundry_watch
+            WHERE id = :watchId AND user_id = :userId AND status = 'active'
+            FOR UPDATE
+            """.trimIndent(),
+        ).param("watchId", watchId).param("userId", record.userId)
+            .query(String::class.java).optional().isPresent
+        if (!active) return false
+
         val created = create(record)
-        if (completeWatch) {
+        if (record.kind == "laundry-attention") {
             jdbc.sql(
                 """
                 UPDATE laundry_watch
-                SET status = 'completed', updated_at_epoch_ms = :now
+                SET attention_unresolved = true, attention_unresolved_at_epoch_ms = :now,
+                    updated_at_epoch_ms = :now
+                WHERE id = :watchId AND status = 'active' AND NOT attention_unresolved
+                """.trimIndent(),
+            ).param("now", now).param("watchId", watchId).update()
+        } else if (completeWatch) {
+            jdbc.sql(
+                """
+                UPDATE laundry_watch
+                SET status = 'completed', attention_unresolved = false,
+                    attention_unresolved_at_epoch_ms = NULL, updated_at_epoch_ms = :now
                 WHERE id = :watchId AND status = 'active'
                 RETURNING id
                 """.trimIndent(),

--- a/server/core/src/main/kotlin/app/junglebell/server/domain/publicapi/JdbcPublicDataStore.kt
+++ b/server/core/src/main/kotlin/app/junglebell/server/domain/publicapi/JdbcPublicDataStore.kt
@@ -38,6 +38,7 @@ class JdbcPublicDataStore(
         observation: MinuteObservation,
     ) {
         saveLaundryVersion(version, firstSeenAt)
+        saveLaundryCurrent(version, firstSeenAt, observation.changed)
         saveLaundryEvents(version.events)
         saveObservation(observation)
         recordSourceSuccess("laundry", version.sourceVersionSha, Instant.parse(version.observedAt))
@@ -128,17 +129,59 @@ class JdbcPublicDataStore(
             .param("lastSeenAt", Timestamp.from(Instant.parse(version.observedAt))).update()
     }
 
+    private fun saveLaundryCurrent(version: LaundryVersion, firstSeenAt: Instant, changed: Boolean) {
+        val json = objectMapper.writeValueAsString(version)
+        jdbc.sql(
+            """
+            INSERT INTO laundry_current(source, sha, normalized, first_seen_at, last_seen_at)
+            SELECT 'laundry', immutable.sha,
+                   CASE WHEN :changed THEN CAST(:normalized AS jsonb) ELSE immutable.normalized END,
+                   CASE WHEN :changed THEN :firstSeenAt ELSE immutable.first_seen_at END,
+                   :lastSeenAt
+            FROM laundry_version immutable
+            WHERE immutable.sha = :sha
+            ON CONFLICT (source) DO UPDATE SET
+                sha = CASE WHEN :changed THEN EXCLUDED.sha ELSE laundry_current.sha END,
+                normalized = CASE
+                    WHEN :changed THEN EXCLUDED.normalized
+                    ELSE laundry_current.normalized
+                END,
+                first_seen_at = CASE
+                    WHEN :changed THEN EXCLUDED.first_seen_at
+                    ELSE laundry_current.first_seen_at
+                END,
+                last_seen_at = EXCLUDED.last_seen_at
+            """.trimIndent(),
+        ).param("sha", version.sourceVersionSha).param("normalized", json)
+            .param("firstSeenAt", Timestamp.from(firstSeenAt))
+            .param("lastSeenAt", Timestamp.from(Instant.parse(version.observedAt)))
+            .param("changed", changed).update()
+    }
+
     override fun latestLaundryVersion(): LaundryVersion? = jdbc.sql(
         """
-        SELECT normalized::text
-        FROM laundry_version
-        WHERE EXISTS (
-            SELECT 1
-            FROM jsonb_array_elements(normalized -> 'machines') AS machine
-            WHERE jsonb_typeof(machine -> 'washer') = 'object'
-               OR jsonb_typeof(machine -> 'dryer') = 'object'
+        WITH candidates AS (
+            SELECT normalized, 0 AS priority, last_seen_at
+            FROM laundry_current
+            WHERE source = 'laundry' AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(normalized -> 'machines') AS machine
+                WHERE jsonb_typeof(machine -> 'washer') = 'object'
+                   OR jsonb_typeof(machine -> 'dryer') = 'object'
+            )
+            UNION ALL
+            SELECT normalized, 1 AS priority, last_seen_at
+            FROM laundry_version
+            WHERE EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(normalized -> 'machines') AS machine
+                WHERE jsonb_typeof(machine -> 'washer') = 'object'
+                   OR jsonb_typeof(machine -> 'dryer') = 'object'
+            )
         )
-        ORDER BY last_seen_at DESC
+        SELECT normalized::text
+        FROM candidates
+        ORDER BY priority, last_seen_at DESC
         LIMIT 1
         """.trimIndent(),
     ).query(String::class.java).optional().map { objectMapper.readValue(it, LaundryVersion::class.java) }.orElse(null)

--- a/server/core/src/main/resources/schema.sql
+++ b/server/core/src/main/resources/schema.sql
@@ -24,6 +24,14 @@ CREATE TABLE IF NOT EXISTS laundry_version (
 CREATE INDEX IF NOT EXISTS laundry_version_latest
     ON laundry_version (last_seen_at DESC);
 
+CREATE TABLE IF NOT EXISTS laundry_current (
+    source text PRIMARY KEY CHECK (source = 'laundry'),
+    sha text NOT NULL REFERENCES laundry_version(sha) CHECK (sha ~ '^[0-9a-f]{64}$'),
+    normalized jsonb NOT NULL CHECK (jsonb_typeof(normalized) = 'object'),
+    first_seen_at timestamptz NOT NULL,
+    last_seen_at timestamptz NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS minute_observation (
     source text NOT NULL,
     minute_epoch bigint NOT NULL,

--- a/server/core/src/main/resources/schema.sql
+++ b/server/core/src/main/resources/schema.sql
@@ -270,6 +270,8 @@ CREATE TABLE IF NOT EXISTS laundry_watch (
         CHECK (notification_mode IN ('before-completion', 'estimated-completion', 'confirmed-completion')),
     notify_before_minutes integer NOT NULL CHECK (notify_before_minutes BETWEEN 0 AND 180),
     notify_when_available boolean NOT NULL,
+    attention_unresolved boolean NOT NULL DEFAULT false,
+    attention_unresolved_at_epoch_ms bigint,
     status text NOT NULL CHECK (status IN ('active', 'completed', 'cancelled')),
     created_at_epoch_ms bigint NOT NULL,
     updated_at_epoch_ms bigint NOT NULL CHECK (updated_at_epoch_ms >= created_at_epoch_ms)
@@ -278,6 +280,12 @@ CREATE TABLE IF NOT EXISTS laundry_watch (
 ALTER TABLE laundry_watch
     ADD COLUMN IF NOT EXISTS notification_mode text NOT NULL DEFAULT 'confirmed-completion'
     CHECK (notification_mode IN ('before-completion', 'estimated-completion', 'confirmed-completion'));
+
+ALTER TABLE laundry_watch
+    ADD COLUMN IF NOT EXISTS attention_unresolved boolean NOT NULL DEFAULT false;
+
+ALTER TABLE laundry_watch
+    ADD COLUMN IF NOT EXISTS attention_unresolved_at_epoch_ms bigint;
 
 UPDATE laundry_watch
 SET notification_mode = 'before-completion'

--- a/server/core/src/test/kotlin/app/junglebell/server/common/store/JdbcStoreIntegrationTest.kt
+++ b/server/core/src/test/kotlin/app/junglebell/server/common/store/JdbcStoreIntegrationTest.kt
@@ -135,6 +135,174 @@ class JdbcStoreIntegrationTest {
     }
 
     @Test
+    fun `laundry attention is deduplicated and tracks unresolved state`() {
+        val userId = createUser()
+        val watch = LaundryWatch(
+            id = "jbw_${"b".repeat(64)}",
+            machineId = "워시타워_1",
+            appliance = "dryer",
+            sessionId = "dryer-session-1",
+            notificationMode = "confirmed-completion",
+            notifyBeforeMinutes = 0,
+            status = "active",
+            createdAtEpochMs = 1_000,
+            updatedAtEpochMs = 1_000,
+        )
+        assertTrue(JdbcPersonalStore(jdbc).createWatch(userId, watch))
+        val mapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
+        val notifications = JdbcNotificationStore(jdbc, mapper)
+        val automation = JdbcAutomationStore(jdbc)
+        val sessionId = checkNotNull(watch.sessionId)
+
+        insertLaundryEvent(watch.machineId, watch.appliance, sessionId, "ERROR_ENTERED", 500)
+        assertEquals(null, automation.activeLaundryWatches().single { it.id == watch.id }.pendingAttentionStatus)
+        insertLaundryEvent(watch.machineId, watch.appliance, "different-session", "ERROR_ENTERED", 1_200)
+        assertEquals(null, automation.activeLaundryWatches().single { it.id == watch.id }.pendingAttentionStatus)
+        insertLaundryEvent(watch.machineId, watch.appliance, sessionId, "STOPPED_UNEXPECTEDLY", 1_500)
+        assertEquals(null, automation.activeLaundryWatches().single { it.id == watch.id }.pendingAttentionStatus)
+        val firstIncidentId = insertLaundryEvent(
+            watch.machineId,
+            watch.appliance,
+            sessionId,
+            "ERROR_ENTERED",
+            2_000,
+        )
+        var lifecycle = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertEquals("ERROR", lifecycle.pendingAttentionStatus)
+        assertEquals(firstIncidentId.toString(), lifecycle.pendingAttentionIncidentId)
+        assertFalse(lifecycle.attentionRecovered)
+        insertLaundryEvent(watch.machineId, watch.appliance, sessionId, "PAUSED", 2_500)
+        assertEquals("ERROR", automation.activeLaundryWatches().single { it.id == watch.id }.pendingAttentionStatus)
+        insertLaundryEvent(watch.machineId, watch.appliance, sessionId, "STARTED", 3_000)
+        lifecycle = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertEquals(null, lifecycle.pendingAttentionStatus)
+        assertEquals(null, lifecycle.pendingAttentionIncidentId)
+        assertFalse(lifecycle.attentionRecovered)
+        val alertedIncidentId = insertLaundryEvent(
+            watch.machineId,
+            watch.appliance,
+            sessionId,
+            "PAUSED",
+            4_000,
+        )
+        lifecycle = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertEquals("PAUSED", lifecycle.pendingAttentionStatus)
+        assertEquals(alertedIncidentId.toString(), lifecycle.pendingAttentionIncidentId)
+        assertFalse(lifecycle.attentionRecovered)
+
+        val attention = NotificationRecord(
+            UUID.randomUUID(), userId,
+            "laundry-attention:${watch.id}:${watch.sessionId}:$alertedIncidentId",
+            "laundry-attention", "건조기가 멈췄습니다", "상태를 확인해 주세요.", "/#/laundry",
+            emptyMap(), 5_000, 5_000, 20_000,
+        )
+
+        assertTrue(notifications.createFromLaundryWatch(attention, watch.id, completeWatch = false, now = 5_000))
+        lifecycle = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertTrue(lifecycle.attentionUnresolved)
+        assertEquals(5_000L, lifecycle.attentionUnresolvedAtEpochMs)
+        assertFalse(lifecycle.attentionRecovered)
+        assertFalse(
+            notifications.createFromLaundryWatch(
+                attention.copy(id = UUID.randomUUID()),
+                watch.id,
+                completeWatch = false,
+                now = 6_000,
+            ),
+        )
+        assertEquals(
+            1,
+            jdbc.sql("SELECT count(*) FROM notification WHERE user_id = :userId AND source_event_id = :sourceEventId")
+                .param("userId", userId).param("sourceEventId", attention.sourceEventId)
+                .query(Int::class.java).single(),
+        )
+
+        insertLaundryEvent(watch.machineId, watch.appliance, sessionId, "STARTED", 7_000)
+        lifecycle = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertTrue(lifecycle.attentionUnresolved)
+        assertTrue(lifecycle.attentionRecovered)
+        assertTrue(automation.markLaundryWatchResumed(watch.id, 7_000))
+        assertFalse(automation.activeLaundryWatches().single { it.id == watch.id }.attentionUnresolved)
+        assertEquals(null, automation.activeLaundryWatches().single { it.id == watch.id }.pendingAttentionStatus)
+        val nextIncidentId = insertLaundryEvent(
+            watch.machineId,
+            watch.appliance,
+            sessionId,
+            "ERROR_ENTERED",
+            8_000,
+        )
+        val nextAttention = attention.copy(
+            id = UUID.randomUUID(),
+            sourceEventId = "laundry-attention:${watch.id}:${watch.sessionId}:$nextIncidentId",
+        )
+        assertTrue(
+            notifications.createFromLaundryWatch(
+                nextAttention,
+                watch.id,
+                completeWatch = false,
+                now = 9_000,
+            ),
+        )
+        val repeatedIncident = automation.activeLaundryWatches().single { it.id == watch.id }
+        assertTrue(repeatedIncident.attentionUnresolved)
+        assertEquals("ERROR", repeatedIncident.pendingAttentionStatus)
+        assertEquals(nextIncidentId.toString(), repeatedIncident.pendingAttentionIncidentId)
+        assertEquals(9_000L, repeatedIncident.attentionUnresolvedAtEpochMs)
+        assertEquals(
+            2,
+            jdbc.sql("SELECT count(*) FROM notification WHERE user_id = :userId AND kind = 'laundry-attention'")
+                .param("userId", userId).query(Int::class.java).single(),
+        )
+
+        assertTrue(automation.completeLaundryWatch(watch.id, 10_000))
+        assertEquals("completed", JdbcPersonalStore(jdbc).watches(userId).single { it.id == watch.id }.status)
+        assertFalse(
+            notifications.createFromLaundryWatch(
+                attention.copy(id = UUID.randomUUID(), sourceEventId = "attention-after-completion"),
+                watch.id,
+                completeWatch = false,
+                now = 11_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate terminal notification still completes an active laundry watch`() {
+        val userId = createUser()
+        val watch = LaundryWatch(
+            id = "jbw_${"c".repeat(64)}",
+            machineId = "워시타워_2",
+            appliance = "dryer",
+            sessionId = "dryer-session-2",
+            notificationMode = "estimated-completion",
+            notifyBeforeMinutes = 0,
+            status = "active",
+            createdAtEpochMs = 1_000,
+            updatedAtEpochMs = 1_000,
+        )
+        assertTrue(JdbcPersonalStore(jdbc).createWatch(userId, watch))
+        val mapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
+        val notifications = JdbcNotificationStore(jdbc, mapper)
+        val expected = NotificationRecord(
+            UUID.randomUUID(), userId, "laundry-completion-expected:${watch.id}:${watch.sessionId}:estimated-completion",
+            "laundry-completion-expected", "건조 완료 예상", "상태를 확인해 주세요.", "/#/laundry",
+            emptyMap(), 2_000, 2_000, 20_000,
+        )
+
+        assertTrue(notifications.createFromLaundryWatch(expected, watch.id, completeWatch = false, now = 2_000))
+        assertEquals("active", JdbcPersonalStore(jdbc).watches(userId).single { it.id == watch.id }.status)
+        assertFalse(
+            notifications.createFromLaundryWatch(
+                expected.copy(id = UUID.randomUUID()),
+                watch.id,
+                completeWatch = true,
+                now = 3_000,
+            ),
+        )
+        assertEquals("completed", JdbcPersonalStore(jdbc).watches(userId).single { it.id == watch.id }.status)
+    }
+
+    @Test
     fun `legacy attendance notification kinds are normalized when read`() {
         val userId = createUser()
         val mapper = JsonMapper.builder().addModule(KotlinModule.Builder().build()).build()
@@ -360,6 +528,36 @@ class JdbcStoreIntegrationTest {
     }
 
     private fun randomHash(): String = UUID.randomUUID().toString().replace("-", "").repeat(2)
+
+    private fun insertLaundryEvent(
+        machineId: String,
+        appliance: String,
+        sessionId: String,
+        type: String,
+        observedAtEpochMs: Long,
+    ): UUID {
+        val id = UUID.randomUUID()
+        val currentState = when (type) {
+            "ERROR_ENTERED" -> "ERROR"
+            "PAUSED" -> "PAUSE"
+            "COMPLETED" -> "END"
+            "STOPPED_UNEXPECTEDLY" -> "POWER_OFF"
+            else -> "RUNNING"
+        }
+        jdbc.sql(
+            """
+            INSERT INTO laundry_event(
+                id, machine_id, appliance, session_id, type, observed_at,
+                current_state, detail
+            ) VALUES (:id, :machineId, :appliance, :sessionId, :type, :observedAt,
+                :currentState, '{}'::jsonb)
+            """.trimIndent(),
+        ).param("id", id).param("machineId", machineId).param("appliance", appliance)
+            .param("sessionId", sessionId).param("type", type)
+            .param("observedAt", java.sql.Timestamp.from(java.time.Instant.ofEpochMilli(observedAtEpochMs)))
+            .param("currentState", currentState).update()
+        return id
+    }
 
     private fun createDesktop(userId: UUID, installationId: String, tokenHash: String, expiresAt: Long): UUID {
         val sessionId = UUID.randomUUID()

--- a/server/core/src/test/kotlin/app/junglebell/server/domain/automation/AutomationEngineTest.kt
+++ b/server/core/src/test/kotlin/app/junglebell/server/domain/automation/AutomationEngineTest.kt
@@ -3,6 +3,8 @@ package app.junglebell.server.domain.automation
 import app.junglebell.server.domain.notification.NotificationRecord
 import app.junglebell.server.domain.notification.NotificationStore
 import app.junglebell.server.domain.publicapi.LaundryAppliance
+import app.junglebell.server.domain.publicapi.LaundryMachine
+import app.junglebell.server.domain.publicapi.LaundryVersion
 import app.junglebell.server.domain.publicapi.NormalizedEnum
 import app.junglebell.server.domain.publicapi.PublicDataStore
 import org.mockito.ArgumentMatchers.anyInt
@@ -313,7 +315,7 @@ class AutomationEngineTest {
 
         assertEquals("laundry-finishing", decision?.notification?.kind)
         assertEquals("세탁 종료 10분 전", decision?.notification?.title)
-        assertEquals(true, decision?.completeWatch)
+        assertEquals(false, decision?.completeWatch)
         assertNull(
             laundryNotificationDecision(
                 watch(mode = "before-completion", notifyBeforeMinutes = 5),
@@ -335,7 +337,7 @@ class AutomationEngineTest {
 
         assertEquals("laundry-completion-expected", decision?.notification?.kind)
         assertEquals("세탁 완료 예상", decision?.notification?.title)
-        assertEquals(true, decision?.completeWatch)
+        assertEquals(false, decision?.completeWatch)
         assertNull(
             laundryNotificationDecision(
                 watch(mode = "confirmed-completion"),
@@ -343,6 +345,18 @@ class AutomationEngineTest {
                 now,
             ),
         )
+    }
+
+    @Test
+    fun `laundry estimated completion mode completes the watch at a terminal state`() {
+        val decision = laundryNotificationDecision(
+            watch(mode = "estimated-completion"),
+            appliance(operationalStatus = "IDLE", remainingMinutes = 0, estimatedFinishAt = null),
+            Instant.parse("2026-08-19T10:00:00Z").toEpochMilli(),
+        )
+
+        assertEquals("laundry-completion-expected", decision?.notification?.kind)
+        assertEquals(true, decision?.completeWatch)
     }
 
     @Test
@@ -382,25 +396,565 @@ class AutomationEngineTest {
         )
     }
 
-    private fun watch(mode: String, notifyBeforeMinutes: Int = 0) = ActiveLaundryWatch(
+    @Test
+    fun `dryer errors and pauses share one attention notification identity`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        val dryerWatch = watch(
+            mode = "confirmed-completion",
+            appliance = "dryer",
+            pendingAttentionIncidentId = "incident-1",
+        )
+        val error = laundryNotificationDecision(
+            dryerWatch,
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "ERROR",
+                remainingMinutes = 49,
+                estimatedFinishAt = null,
+                errorCode = "EMPTY_WATER_ALERT_ERROR",
+            ),
+            now,
+        )
+        val paused = laundryNotificationDecision(
+            dryerWatch,
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "PAUSED",
+                remainingMinutes = 49,
+                estimatedFinishAt = null,
+            ),
+            now,
+        )
+        val repeatedError = laundryNotificationDecision(
+            dryerWatch,
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "ERROR",
+                remainingMinutes = 44,
+                estimatedFinishAt = null,
+                errorCode = "EMPTY_WATER_ALERT_ERROR",
+                observedAt = "2026-08-19T10:02:00Z",
+            ),
+            now,
+        )
+        val doorOpen = laundryNotificationDecision(
+            dryerWatch,
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "ERROR",
+                remainingMinutes = 44,
+                estimatedFinishAt = null,
+                errorCode = "DOOR_OPEN_ERROR",
+            ),
+            now,
+        )
+        val genericError = laundryNotificationDecision(
+            dryerWatch,
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "ERROR",
+                remainingMinutes = 44,
+                estimatedFinishAt = null,
+                errorCode = "UNKNOWN_ERROR",
+            ),
+            now,
+        )
+        val nextIncident = laundryNotificationDecision(
+            dryerWatch.copy(pendingAttentionIncidentId = "incident-2"),
+            appliance(
+                appliance = "dryer",
+                operationalStatus = "ERROR",
+                remainingMinutes = 40,
+                estimatedFinishAt = null,
+                observedAt = "2026-08-19T10:10:00Z",
+            ),
+            now,
+        )
+
+        assertEquals("laundry-attention", error?.notification?.kind)
+        assertEquals("건조기가 멈췄습니다", error?.notification?.title)
+        assertEquals("1번 건조기 물통을 비우고 건조 상태를 확인해 주세요.", error?.notification?.body)
+        assertEquals("ERROR", error?.notification?.payload?.get("attentionStatus"))
+        assertEquals("EMPTY_WATER_ALERT_ERROR", error?.notification?.payload?.get("errorCode"))
+        assertEquals(false, error?.completeWatch)
+        assertEquals("laundry-attention", paused?.notification?.kind)
+        assertEquals("건조기가 일시 정지됐습니다", paused?.notification?.title)
+        assertEquals(error?.notification?.sourceEventId, paused?.notification?.sourceEventId)
+        assertEquals(error?.notification?.sourceEventId, repeatedError?.notification?.sourceEventId)
+        assertEquals(false, error?.notification?.sourceEventId == nextIncident?.notification?.sourceEventId)
+        assertEquals("1번 건조기 문을 닫고 건조 상태를 확인해 주세요.", doorOpen?.notification?.body)
+        assertEquals(
+            "1번 건조기에 오류가 발생했습니다. 건조 상태를 확인해 주세요.",
+            genericError?.notification?.body,
+        )
+        assertEquals(false, paused?.completeWatch)
+
+        for (mode in listOf("before-completion", "estimated-completion", "confirmed-completion")) {
+            for (status in listOf("ERROR", "PAUSED")) {
+                val decision = laundryNotificationDecision(
+                    watch(
+                        mode = mode,
+                        notifyBeforeMinutes = if (mode == "before-completion") 10 else 0,
+                        appliance = "dryer",
+                    ),
+                    appliance(
+                        appliance = "dryer",
+                        operationalStatus = status,
+                        remainingMinutes = 0,
+                        estimatedFinishAt = "2026-08-19T10:00:00Z",
+                    ),
+                    now,
+                )
+                assertEquals("laundry-attention", decision?.notification?.kind, "$mode/$status")
+                assertEquals(false, decision?.completeWatch, "$mode/$status")
+            }
+        }
+    }
+
+    @Test
+    fun `laundry attention only applies to the selected dryer session`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        assertNull(
+            laundryNotificationDecision(
+                watch(mode = "confirmed-completion"),
+                appliance(operationalStatus = "ERROR", remainingMinutes = 30, estimatedFinishAt = null),
+                now,
+            ),
+        )
+        val differentSession = appliance(
+            appliance = "dryer",
+            operationalStatus = "ERROR",
+            remainingMinutes = 30,
+            estimatedFinishAt = null,
+            sessionId = "session-2",
+        )
+        assertEquals(
+            true,
+            laundryWatchShouldCompleteSilently(
+                watch(mode = "confirmed-completion", appliance = "dryer"),
+                differentSession,
+            ),
+        )
+        for (state in listOf("COOLING", "WRINKLE_CARE")) {
+            assertNull(
+                laundryNotificationDecision(
+                    watch(mode = "confirmed-completion", appliance = "dryer"),
+                    appliance(
+                        appliance = "dryer",
+                        remainingMinutes = 0,
+                        estimatedFinishAt = null,
+                        stateCode = state,
+                    ),
+                    now,
+                ),
+                state,
+            )
+        }
+        assertNull(
+            laundryNotificationDecision(
+                watch(mode = "confirmed-completion", appliance = "dryer"),
+                appliance(
+                    appliance = "dryer",
+                    operationalStatus = "ERROR",
+                    remainingMinutes = 30,
+                    estimatedFinishAt = null,
+                    sessionId = "session-2",
+                ),
+                now,
+            ),
+        )
+    }
+
+    @Test
+    fun `unresolved dryer attention suppresses idle completion and completes silently`() {
+        val watch = watch(
+            mode = "confirmed-completion",
+            appliance = "dryer",
+            attentionUnresolved = true,
+        )
+        val idle = appliance(
+            appliance = "dryer",
+            operationalStatus = "IDLE",
+            remainingMinutes = 0,
+            estimatedFinishAt = null,
+        )
+
+        assertNull(
+            laundryNotificationDecision(
+                watch,
+                idle,
+                Instant.parse("2026-08-19T10:00:00Z").toEpochMilli(),
+            ),
+        )
+        assertEquals(true, laundryWatchShouldCompleteSilently(watch, idle))
+        for (status in listOf("ERROR", "PAUSED")) {
+            assertNull(
+                laundryNotificationDecision(
+                    watch,
+                    appliance(
+                        appliance = "dryer",
+                        operationalStatus = status,
+                        remainingMinutes = 30,
+                        estimatedFinishAt = null,
+                    ),
+                    Instant.parse("2026-08-19T10:00:00Z").toEpochMilli(),
+                ),
+                status,
+            )
+        }
+
+        val completed = appliance(
+            appliance = "dryer",
+            operationalStatus = "COMPLETED",
+            remainingMinutes = 0,
+            estimatedFinishAt = null,
+        )
+        assertEquals(
+            "laundry-completed",
+            laundryNotificationDecision(
+                watch,
+                completed,
+                Instant.parse("2026-08-19T10:00:00Z").toEpochMilli(),
+            )?.notification?.kind,
+        )
+    }
+
+    @Test
+    fun `unresolved idle attention completes without another notification`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        val automation = mock(AutomationStore::class.java)
+        val notifications = mock(NotificationStore::class.java)
+        val publicData = mock(PublicDataStore::class.java)
+        val idle = appliance(
+            appliance = "dryer",
+            operationalStatus = "IDLE",
+            remainingMinutes = 0,
+            estimatedFinishAt = null,
+        )
+        `when`(automation.activeLaundryWatches()).thenReturn(
+            listOf(
+                watch(
+                    mode = "confirmed-completion",
+                    appliance = "dryer",
+                    attentionUnresolved = true,
+                ),
+            ),
+        )
+        `when`(publicData.latestLaundryVersion()).thenReturn(
+            LaundryVersion(
+                sourceVersionSha = "sha",
+                observedAt = idle.observedAt,
+                machines = listOf(LaundryMachine("워시타워_1", null, idle)),
+                events = emptyList(),
+                unknownEnums = emptyList(),
+            ),
+        )
+        val engine = AutomationEngine(
+            automation,
+            notifications,
+            publicData,
+            mock(PushSender::class.java),
+            Clock.fixed(Instant.ofEpochMilli(now), ZoneOffset.UTC),
+        )
+
+        assertEquals(0, engine.applyLaundryWatches(now))
+        verify(automation).completeLaundryWatch("watch-1", now)
+        assertEquals(
+            emptyList(),
+            mockingDetails(notifications).invocations.filter { it.method.name == "createFromLaundryWatch" },
+        )
+    }
+
+    @Test
+    fun `an error or pause transition immediately followed by idle still emits attention`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        val cases = listOf("ERROR", "PAUSED")
+
+        for (expectedStatus in cases) {
+            val automation = mock(AutomationStore::class.java)
+            val notifications = mock(NotificationStore::class.java)
+            val publicData = mock(PublicDataStore::class.java)
+            val idle = appliance(
+                appliance = "dryer",
+                operationalStatus = "IDLE",
+                remainingMinutes = 0,
+                estimatedFinishAt = null,
+                sessionId = if (expectedStatus == "ERROR") "stale-session" else "session-1",
+            )
+            `when`(automation.activeLaundryWatches()).thenReturn(
+                listOf(
+                    watch(
+                        mode = "confirmed-completion",
+                        appliance = "dryer",
+                        pendingAttentionStatus = expectedStatus,
+                    ),
+                ),
+            )
+            `when`(publicData.latestLaundryVersion()).thenReturn(
+                LaundryVersion(
+                    sourceVersionSha = "sha-$expectedStatus",
+                    observedAt = idle.observedAt,
+                    machines = listOf(LaundryMachine("워시타워_1", null, idle)),
+                    events = emptyList(),
+                    unknownEnums = emptyList(),
+                ),
+            )
+            val engine = AutomationEngine(
+                automation,
+                notifications,
+                publicData,
+                mock(PushSender::class.java),
+                Clock.fixed(Instant.ofEpochMilli(now), ZoneOffset.UTC),
+            )
+
+            assertEquals(0, engine.applyLaundryWatches(now))
+            val notification = mockingDetails(notifications).invocations
+                .single { it.method.name == "createFromLaundryWatch" }
+                .arguments[0] as NotificationRecord
+            assertEquals("laundry-attention", notification.kind, expectedStatus)
+            assertEquals(expectedStatus, notification.payload["attentionStatus"], expectedStatus)
+            assertEquals(
+                emptyList(),
+                mockingDetails(automation).invocations.filter { it.method.name == "completeLaundryWatch" },
+            )
+        }
+    }
+
+    @Test
+    fun `idle transition attention rejects unrelated or normal stop events`() {
+        val dryerWatch = watch(
+            mode = "confirmed-completion",
+            appliance = "dryer",
+            pendingAttentionStatus = "ERROR",
+        )
+        val idle = appliance(
+            appliance = "dryer",
+            operationalStatus = "IDLE",
+            remainingMinutes = 0,
+            estimatedFinishAt = null,
+        )
+        assertEquals("ERROR", laundryTransitionAttentionStatus(dryerWatch, idle))
+        assertEquals(
+            "PAUSED",
+            laundryTransitionAttentionStatus(
+                dryerWatch.copy(pendingAttentionStatus = "PAUSED"),
+                idle,
+            ),
+        )
+        assertNull(
+            laundryTransitionAttentionStatus(
+                dryerWatch.copy(pendingAttentionStatus = null),
+                idle,
+            ),
+        )
+        assertEquals(
+            "ERROR",
+            laundryTransitionAttentionStatus(
+                dryerWatch,
+                idle.copy(sessionId = "session-2"),
+            ),
+        )
+        assertNull(
+            laundryTransitionAttentionStatus(
+                dryerWatch.copy(attentionUnresolved = true),
+                idle,
+            ),
+        )
+        assertNull(
+            laundryTransitionAttentionStatus(
+                dryerWatch,
+                appliance(
+                    appliance = "dryer",
+                    operationalStatus = "RUNNING",
+                    remainingMinutes = 30,
+                    estimatedFinishAt = "2026-08-19T10:30:00Z",
+                ),
+            ),
+        )
+        for (status in listOf("RUNNING", "COMPLETED")) {
+            assertEquals(
+                "ERROR",
+                laundryTransitionAttentionStatus(
+                    dryerWatch,
+                    appliance(
+                        appliance = "dryer",
+                        operationalStatus = status,
+                        remainingMinutes = if (status == "RUNNING") 30 else 0,
+                        estimatedFinishAt = if (status == "RUNNING") "2026-08-19T10:30:00Z" else null,
+                        sessionId = "replacement-session",
+                    ),
+                ),
+                status,
+            )
+        }
+    }
+
+    @Test
+    fun `durable attention does not use an unrelated snapshot error copy`() {
+        val watch = watch(
+            mode = "confirmed-completion",
+            appliance = "dryer",
+            pendingAttentionStatus = "PAUSED",
+        )
+        val staleError = appliance(
+            appliance = "dryer",
+            operationalStatus = "ERROR",
+            remainingMinutes = 30,
+            estimatedFinishAt = null,
+            errorCode = "DOOR_OPEN_ERROR",
+            sessionId = "different-session",
+        )
+        val transitionStatus = laundryTransitionAttentionStatus(watch, staleError)
+        val decision = laundryNotificationDecision(
+            watch,
+            staleError,
+            Instant.parse("2026-08-19T10:00:00Z").toEpochMilli(),
+            transitionStatus,
+        )
+
+        assertEquals("건조기가 일시 정지됐습니다", decision?.notification?.title)
+        assertEquals(null, decision?.notification?.payload?.get("errorCode"))
+        assertEquals(null, decision?.notification?.payload?.get("remainingMinutes"))
+    }
+
+    @Test
+    fun `running after attention marks the watch resumed`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        val automation = mock(AutomationStore::class.java)
+        val notifications = mock(NotificationStore::class.java)
+        val publicData = mock(PublicDataStore::class.java)
+        val dryer = appliance(
+            appliance = "dryer",
+            operationalStatus = "RUNNING",
+            remainingMinutes = 30,
+            estimatedFinishAt = "2026-08-19T10:30:00Z",
+        )
+        `when`(automation.activeLaundryWatches()).thenReturn(
+            listOf(
+                watch(
+                    mode = "confirmed-completion",
+                    appliance = "dryer",
+                    attentionUnresolved = true,
+                ),
+            ),
+        )
+        `when`(publicData.latestLaundryVersion()).thenReturn(
+            LaundryVersion(
+                sourceVersionSha = "sha",
+                observedAt = dryer.observedAt,
+                machines = listOf(LaundryMachine("워시타워_1", null, dryer)),
+                events = emptyList(),
+                unknownEnums = emptyList(),
+            ),
+        )
+        val engine = AutomationEngine(
+            automation,
+            notifications,
+            publicData,
+            mock(PushSender::class.java),
+            Clock.fixed(Instant.ofEpochMilli(now), ZoneOffset.UTC),
+        )
+
+        assertEquals(0, engine.applyLaundryWatches(now))
+        verify(automation).markLaundryWatchResumed("watch-1", now)
+    }
+
+    @Test
+    fun `a durable recovery restores terminal notifications after attention`() {
+        val now = Instant.parse("2026-08-19T10:00:00Z").toEpochMilli()
+        for ((mode, expectedKind) in listOf(
+            "confirmed-completion" to "laundry-completed",
+            "estimated-completion" to "laundry-completion-expected",
+        )) {
+            val automation = mock(AutomationStore::class.java)
+            val notifications = mock(NotificationStore::class.java)
+            val publicData = mock(PublicDataStore::class.java)
+            val idle = appliance(
+                appliance = "dryer",
+                operationalStatus = "IDLE",
+                remainingMinutes = 0,
+                estimatedFinishAt = null,
+            )
+            `when`(automation.activeLaundryWatches()).thenReturn(
+                listOf(
+                    watch(
+                        mode = mode,
+                        appliance = "dryer",
+                        attentionUnresolved = true,
+                        attentionRecovered = true,
+                    ),
+                ),
+            )
+            `when`(publicData.latestLaundryVersion()).thenReturn(
+                LaundryVersion(
+                    sourceVersionSha = "sha-$mode",
+                    observedAt = idle.observedAt,
+                    machines = listOf(LaundryMachine("워시타워_1", null, idle)),
+                    events = emptyList(),
+                    unknownEnums = emptyList(),
+                ),
+            )
+            val engine = AutomationEngine(
+                automation,
+                notifications,
+                publicData,
+                mock(PushSender::class.java),
+                Clock.fixed(Instant.ofEpochMilli(now), ZoneOffset.UTC),
+            )
+
+            assertEquals(0, engine.applyLaundryWatches(now))
+            verify(automation).markLaundryWatchResumed("watch-1", now)
+            val invocation = mockingDetails(notifications).invocations
+                .single { it.method.name == "createFromLaundryWatch" }
+            assertEquals(expectedKind, (invocation.arguments[0] as NotificationRecord).kind, mode)
+            assertEquals(true, invocation.arguments[2], mode)
+        }
+    }
+
+    private fun watch(
+        mode: String,
+        notifyBeforeMinutes: Int = 0,
+        appliance: String = "washer",
+        attentionUnresolved: Boolean = false,
+        attentionUnresolvedAtEpochMs: Long? = null,
+        pendingAttentionStatus: String? = null,
+        pendingAttentionIncidentId: String? = null,
+        attentionRecovered: Boolean = false,
+    ) = ActiveLaundryWatch(
         id = "watch-1",
         userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
         machineId = "워시타워_1",
-        appliance = "washer",
+        appliance = appliance,
         sessionId = "session-1",
         notificationMode = mode,
         notifyBeforeMinutes = notifyBeforeMinutes,
+        attentionUnresolved = attentionUnresolved,
+        attentionUnresolvedAtEpochMs = attentionUnresolvedAtEpochMs,
+        pendingAttentionStatus = pendingAttentionStatus,
+        pendingAttentionIncidentId = pendingAttentionIncidentId,
+        attentionRecovered = attentionRecovered,
     )
 
     private fun appliance(
+        appliance: String = "washer",
         operationalStatus: String = "RUNNING",
         remainingMinutes: Int,
         estimatedFinishAt: String?,
+        errorCode: String? = null,
+        sessionId: String = "session-1",
+        observedAt: String = "2026-08-19T09:52:00Z",
+        stateCode: String = when (operationalStatus) {
+            "ERROR" -> "ERROR"
+            "PAUSED" -> "PAUSE"
+            "COMPLETED" -> "END"
+            "IDLE" -> "POWER_OFF"
+            else -> if (appliance == "washer") "WASHING" else "RUNNING"
+        },
     ) = LaundryAppliance(
         machineId = "워시타워_1",
-        appliance = "washer",
-        observedAt = "2026-08-19T09:52:00Z",
-        state = NormalizedEnum("WASHING", null, true),
+        appliance = appliance,
+        observedAt = observedAt,
+        state = NormalizedEnum(stateCode, null, true),
         operationalStatus = operationalStatus,
         remainingMinutes = remainingMinutes,
         totalMinutes = 60,
@@ -408,8 +962,8 @@ class AutomationEngineTest {
         estimatedFinishAt = estimatedFinishAt,
         remoteControlEnabled = null,
         cycleCount = null,
-        sessionId = "session-1",
-        errorCode = null,
+        sessionId = sessionId,
+        errorCode = errorCode,
     )
 
     private fun attendanceRecordAt(

--- a/server/core/src/test/kotlin/app/junglebell/server/domain/publicapi/JdbcPublicDataStoreIntegrationTest.kt
+++ b/server/core/src/test/kotlin/app/junglebell/server/domain/publicapi/JdbcPublicDataStoreIntegrationTest.kt
@@ -184,7 +184,79 @@ class JdbcPublicDataStoreIntegrationTest {
         assertEquals(validSha, store.latestLaundryVersion()?.sourceVersionSha)
     }
 
-    private fun observation(at: Instant, sha: String) = MinuteObservation(
+    @Test
+    fun `current laundry context follows sha occurrences without rewriting immutable versions`() {
+        fun version(sha: String, at: Instant, sessionId: String) = LaundryVersion(
+            sourceVersionSha = sha,
+            observedAt = at.toString(),
+            machines = listOf(
+                LaundryMachine(
+                    "워시타워_context",
+                    null,
+                    LaundryAppliance(
+                        machineId = "워시타워_context",
+                        appliance = "dryer",
+                        observedAt = at.toString(),
+                        state = NormalizedEnum("POWER_OFF", null, true),
+                        operationalStatus = "IDLE",
+                        remainingMinutes = 0,
+                        totalMinutes = 60,
+                        startedAt = "1970-01-01T00:00:00Z",
+                        estimatedFinishAt = null,
+                        remoteControlEnabled = false,
+                        cycleCount = null,
+                        sessionId = sessionId,
+                        errorCode = null,
+                    ),
+                ),
+            ),
+            events = emptyList(),
+            unknownEnums = emptyList(),
+        )
+
+        val shaA = randomSha()
+        val shaB = randomSha()
+        val firstAt = Instant.parse("2199-01-01T00:00:00Z")
+        val consecutiveAt = firstAt.plusSeconds(60)
+        val middleAt = firstAt.plusSeconds(120)
+        val reappearedAt = firstAt.plusSeconds(180)
+        val repeatedAt = firstAt.plusSeconds(240)
+
+        store.recordLaundrySuccess(
+            version(shaA, firstAt, "first-a"),
+            firstAt,
+            observation(firstAt, shaA),
+        )
+        jdbc.sql("DELETE FROM laundry_current WHERE source = 'laundry'").update()
+        store.recordLaundrySuccess(
+            version(shaA, consecutiveAt, "drifted-a"),
+            firstAt,
+            observation(consecutiveAt, shaA, changed = false),
+        )
+        assertEquals("first-a", store.latestLaundryVersion()?.machines?.single()?.dryer?.sessionId)
+
+        store.recordLaundrySuccess(
+            version(shaB, middleAt, "middle-b"),
+            middleAt,
+            observation(middleAt, shaB),
+        )
+        store.recordLaundrySuccess(
+            version(shaA, reappearedAt, "second-a"),
+            reappearedAt,
+            observation(reappearedAt, shaA),
+        )
+        assertEquals("second-a", store.latestLaundryVersion()?.machines?.single()?.dryer?.sessionId)
+        assertEquals("first-a", store.laundryVersion(shaA)?.machines?.single()?.dryer?.sessionId)
+
+        store.recordLaundrySuccess(
+            version(shaA, repeatedAt, "drifted-second-a"),
+            reappearedAt,
+            observation(repeatedAt, shaA, changed = false),
+        )
+        assertEquals("second-a", store.latestLaundryVersion()?.machines?.single()?.dryer?.sessionId)
+    }
+
+    private fun observation(at: Instant, sha: String, changed: Boolean = true) = MinuteObservation(
         source = "laundry",
         minuteEpoch = at.epochSecond / 60,
         scheduledAt = at.toString(),
@@ -192,7 +264,7 @@ class JdbcPublicDataStoreIntegrationTest {
         status = "SUCCESS",
         versionSha = sha,
         versionFirstSeenAt = at.toString(),
-        changed = true,
+        changed = changed,
         durationMs = 1,
         httpStatus = 200,
         error = null,

--- a/server/worker/src/test/kotlin/app/junglebell/server/worker/collector/LaundryNormalizerTest.kt
+++ b/server/worker/src/test/kotlin/app/junglebell/server/worker/collector/LaundryNormalizerTest.kt
@@ -65,4 +65,67 @@ class LaundryNormalizerTest {
             normalizer.normalize(raw, "d".repeat(64), observedAt, null)
         }
     }
+
+    @Test
+    fun `records error and pause transitions before the dryer powers off`() {
+        val running = normalizer.normalize(
+            dryerRaw("RUNNING", remainingMinutes = 49),
+            "running",
+            observedAt,
+            null,
+        )
+        val error = normalizer.normalize(
+            dryerRaw("RUNNING", remainingMinutes = 49, error = "EMPTY_WATER_ALERT_ERROR"),
+            "error",
+            observedAt.plusSeconds(60),
+            running,
+        )
+        val idleAfterError = normalizer.normalize(
+            dryerRaw("POWER_OFF", remainingMinutes = 0),
+            "idle-after-error",
+            observedAt.plusSeconds(120),
+            error,
+        )
+        val errorCleared = idleAfterError.events.single { it.type == "ERROR_CLEARED" }
+
+        assertEquals("RUNNING", errorCleared.previousState)
+        assertEquals("POWER_OFF", errorCleared.currentState)
+        assertEquals(idleAfterError.machines.single().dryer?.sessionId, errorCleared.sessionId)
+
+        val paused = normalizer.normalize(
+            dryerRaw("PAUSE", remainingMinutes = 49),
+            "paused",
+            observedAt.plusSeconds(60),
+            running,
+        )
+        val idleAfterPause = normalizer.normalize(
+            dryerRaw("POWER_OFF", remainingMinutes = 0),
+            "idle-after-pause",
+            observedAt.plusSeconds(120),
+            paused,
+        )
+        val pauseChanged = idleAfterPause.events.single { it.type == "STATE_CHANGED" }
+
+        assertEquals("PAUSE", pauseChanged.previousState)
+        assertEquals("POWER_OFF", pauseChanged.currentState)
+        assertEquals(idleAfterPause.machines.single().dryer?.sessionId, pauseChanged.sessionId)
+    }
+
+    private fun dryerRaw(state: String, remainingMinutes: Int, error: String? = null) = mapper.readTree(
+        """
+        {
+          "워시타워_1": {
+            "dryer": {
+              "runState": {"currentState": "$state"},
+              "timer": {
+                "remainHour": 0,
+                "remainMinute": $remainingMinutes,
+                "totalHour": 1,
+                "totalMinute": 0
+              }${error?.let { ",\n              \"error\": \"$it\"" }.orEmpty()}
+            }
+          }
+        }
+        """.trimIndent(),
+    )
 }


### PR DESCRIPTION
## 변경 사항

- 선택한 건조기가 ERROR 또는 PAUSED가 되면 기존 laundry-attention 알림을 발송합니다.
- 같은 장애의 ERROR→PAUSE 연쇄는 한 번만 알리고, 정상 재개 후 새 장애는 다시 알립니다.
- N분 전·완료 예상 알림 뒤에도 watch를 종료 상태까지 유지합니다.
- 수집 사이에 지나간 장애도 laundry_event 이력으로 복구하고, 반복 SHA의 최신 세션 컨텍스트를 별도로 보존합니다.
- watch 행 잠금으로 취소·완료와 알림 생성의 경합을 차단합니다.

## 운영 데이터 검증

- 2026-08-14~25 건조기 339세션 중 ERROR/PAUSE가 77세션(22.7%)에서 발생했습니다.
- STOPPED_UNEXPECTEDLY 216건 중 최소 63%가 COOLING/WRINKLE_CARE 이후 정상 종료 흐름이어서 이번 알림 조건에서는 제외했습니다.

## 검증

- JAVA 21 ./gradlew --no-daemon check :api:bootJar :worker:bootJar --rerun-tasks
- npm --prefix frontend test -- src/tests/contracts/release-channel.test.ts
- pre-push server check