### PR TITLE
refactor(analytics): 사용량 재시도 조건 정리 및 0.5.9 갱신

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "jungle-bell"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jungle-bell"
-version = "0.5.8"
+version = "0.5.9"
 description = "Krafton Jungle attendance check reminder"
 authors = ["sijun-yang"]
 edition = "2021"

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Jungle Bell",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "identifier": "dev.sijun-yang.jungle-bell.v2",
   "build": {
     "beforeDevCommand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jungle-bell-frontend",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.29",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/platform/web/usage-reporting.ts
+++ b/frontend/src/platform/web/usage-reporting.ts
@@ -48,15 +48,16 @@ async function requestWithRetry(
     options: UsageReportOptions,
 ): Promise<Response | undefined> {
     const delay = options.delay ?? defaultRetryDelay;
+    const shouldStop = () => options.signal?.aborted || !canAttempt();
 
     for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt += 1) {
-        if (options.signal?.aborted || !canAttempt()) return undefined;
+        if (shouldStop()) return undefined;
 
         let response: Response;
         try {
             response = await fetcher(path, init);
         } catch {
-            if (options.signal?.aborted || !canAttempt()) return undefined;
+            if (shouldStop()) return undefined;
             const retryDelay = RETRY_DELAYS_MS[attempt];
             if (retryDelay === undefined) return undefined;
             await delay(retryDelay, options.signal);
@@ -64,7 +65,7 @@ async function requestWithRetry(
         }
 
         if (!RETRYABLE_STATUSES.has(response.status)) return response;
-        if (options.signal?.aborted || !canAttempt()) return response;
+        if (shouldStop()) return response;
         const retryDelay = RETRY_DELAYS_MS[attempt];
         if (retryDelay === undefined) return response;
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "app.junglebell"
-    version = "0.5.8"
+    version = "0.5.9"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 변경 사항

- 사용량 보고 재시도의 중단 조건을 함수로 통합하면서 AbortSignal 상태를 비동기 경계마다 다시 읽는 취소 동작을 유지했습니다.
- React Doctor 진단을 해소해 변경 파일 및 전체 프런트엔드 스캔을 100점으로 맞췄습니다.
- 프런트엔드, 서버, 데스크톱의 앱 버전을 0.5.8에서 0.5.9로 일괄 갱신했습니다.

## 검증

- React Doctor 0.9.12: 100/100
- npm run check: 102개 파일, 533개 테스트 통과
- npm test -- src/tests/contracts/release-channel.test.ts: 6개 테스트 통과
- node scripts/verify-release-version.mjs v0.5.9
- cargo metadata --locked --offline --format-version 1 --no-deps
- pre-push: frontend check, server check, desktop test, desktop clippy 통과