### PR TITLE
fix(config): Tauri 외부 프로젝트 링크 열기 허용

### DIFF
--- a/desktop/capabilities/dashboard.json
+++ b/desktop/capabilities/dashboard.json
@@ -5,6 +5,14 @@
   "windows": ["dashboard"],
   "permissions": [
     "core:event:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "https://github.com/YangSiJun528/jungle-bell" },
+        { "url": "https://github.com/YangSiJun528/jungle-bell/issues/new/choose" },
+        { "url": "https://github.com/YangSiJun528/jungle-bell/releases/latest" }
+      ]
+    },
     "allow-bootstrap-desktop-http-session",
     "allow-get-desktop-settings",
     "allow-check-desktop-update",

--- a/frontend/src/tests/contracts/desktop-external-links.test.ts
+++ b/frontend/src/tests/contracts/desktop-external-links.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+
+import {test} from 'vitest';
+
+type CapabilityPermission =
+    | string
+    | {
+          identifier: string;
+          allow?: Array<{url: string}>;
+      };
+
+const repoRoot = new URL('../../../../', import.meta.url);
+const dashboardCapability = JSON.parse(
+    readFileSync(new URL('desktop/capabilities/dashboard.json', repoRoot), 'utf8'),
+) as {permissions: CapabilityPermission[]};
+const desktopAppSource = readFileSync(new URL('desktop/src/lib.rs', repoRoot), 'utf8');
+
+test('Tauri 대시보드는 프로젝트 링크만 시스템 브라우저로 열 수 있다', () => {
+    assert.match(desktopAppSource, /\.plugin\(tauri_plugin_opener::init\(\)\)/u);
+    assert.equal(dashboardCapability.permissions.includes('opener:default'), false);
+    assert.deepEqual(
+        dashboardCapability.permissions.find(
+            (permission) =>
+                typeof permission !== 'string' && permission.identifier === 'opener:allow-open-url',
+        ),
+        {
+            identifier: 'opener:allow-open-url',
+            allow: [
+                {url: 'https://github.com/YangSiJun528/jungle-bell'},
+                {url: 'https://github.com/YangSiJun528/jungle-bell/issues/new/choose'},
+                {url: 'https://github.com/YangSiJun528/jungle-bell/releases/latest'},
+            ],
+        },
+    );
+});


### PR DESCRIPTION
## 변경 사항

- 대시보드 opener capability에 GitHub, 피드백, 릴리즈 URL만 허용했습니다.
- 광범위한 opener 기본 권한을 사용하지 않는 회귀 테스트를 추가했습니다.

## 검증

- JUNGLE_BELL_DATA_API_URL=https://jungle-bell.sijun-yang.com npm run verify
- 로컬 push 훅의 frontend check, desktop test, desktop clippy 통과

Closes #63