### PR TITLE
[stack 1/9] feat(platform): 플랫폼 capability와 상태 계약 정의

### DIFF
--- a/docs/reference-platform-status-model.md
+++ b/docs/reference-platform-status-model.md
@@ -1,0 +1,117 @@
+# 플랫폼 상태 모델 레퍼런스
+
+`frontend/src/platform/status-model.ts`는 Web, PWA, PC의 정적 capability와
+인증, 푸시, 업데이트의 동적 상태 어휘를 정의하는 기준 계약이다.
+현재 `PlatformAdapter`에 연결하는 작업은 후속 PR 범위다.
+
+## 플랫폼 surface
+
+| 값    | 판정 기준                                                            |
+| ----- | -------------------------------------------------------------------- |
+| `web` | 일반 브라우저 탭                                                     |
+| `pwa` | `display-mode: standalone` 또는 iOS standalone으로 실행한 설치형 PWA |
+| `pc`  | Tauri PC 앱                                                          |
+
+PWA surface 판정은 UI 분기일 뿐 인증과 권한의 증명이 아니다.
+
+## Capability matrix
+
+아래 표의 키와 값은 `PLATFORM_CAPABILITY_MATRIX`와 동일하다.
+
+| Surface | `publicFeatures` | `personalFeatures`        | `installation` | `authentication` | `notifications`    | `updates`         |
+| ------- | ---------------- | ------------------------- | -------------- | ---------------- | ------------------ | ----------------- |
+| `web`   | `available`      | `install-required`        | `pwa-install`  | `not-supported`  | `install-required` | `browser-managed` |
+| `pwa`   | `available`      | `connection-required`     | `installed`    | `mobile-session` | `web-push`         | `service-worker`  |
+| `pc`    | `available`      | `authentication-required` | `native-app`   | `lms-and-server` | `os-notification`  | `native-updater`  |
+
+| Capability         | 값                        | 정의                                                          |
+| ------------------ | ------------------------- | ------------------------------------------------------------- |
+| `publicFeatures`   | `available`               | 홈, 세탁실, 식단, 앱 안내는 부가 상태와 무관하게 제공한다.    |
+| `personalFeatures` | `install-required`        | Web에서는 설치 및 연결 동선만 제공한다.                       |
+| `personalFeatures` | `connection-required`     | PWA는 PC와 연결한 뒤 개인 기능을 제공한다.                    |
+| `personalFeatures` | `authentication-required` | PC는 LMS와 서버 인증을 완료한 뒤 개인 기능을 제공한다.        |
+| `installation`     | `pwa-install`             | PWA 설치 안내와 지원되는 설치 prompt를 사용한다.              |
+| `installation`     | `installed`               | 이미 설치된 standalone PWA다.                                 |
+| `installation`     | `native-app`              | native installer로 설치한 Tauri 앱이다.                       |
+| `authentication`   | `not-supported`           | Web은 개인 session을 받지 않는다.                             |
+| `authentication`   | `mobile-session`          | PWA는 Strict HttpOnly mobile session을 사용한다.              |
+| `authentication`   | `lms-and-server`          | PC는 LMS 로컬 상태와 서버 credential/session을 각각 확인한다. |
+| `notifications`    | `install-required`        | Web은 알림 대신 PWA/PC 설치 동선을 제공한다.                  |
+| `notifications`    | `web-push`                | PWA는 service worker와 Web Push를 사용한다.                   |
+| `notifications`    | `os-notification`         | PC는 운영체제 알림을 사용한다.                                |
+| `updates`          | `browser-managed`         | Web 자산 교체는 브라우저 새로고침으로 반영한다.               |
+| `updates`          | `service-worker`          | PWA는 service worker 대기 및 교체 상태를 사용한다.            |
+| `updates`          | `native-updater`          | PC는 Tauri native updater를 사용한다.                         |
+
+## 인증 상태
+
+`AuthenticationState`의 판별자는 `status`다.
+
+| `status`        | 정의                                                 |
+| --------------- | ---------------------------------------------------- |
+| `checking`      | 현재 인증과 session을 확인 중이다.                   |
+| `first-connect` | 이전 연결이 없어 첫 인증 또는 PC 연결이 필요하다.    |
+| `authenticated` | 해당 surface의 인증 선행 조건을 모두 확인했다.       |
+| `expired`       | 이전에 있던 credential 또는 session이 만료됐다.      |
+| `offline`       | 네트워크 단절로 인증을 확인할 수 없다.               |
+| `server-error`  | 서버 오류로 인증을 확인할 수 없다.                   |
+| `recovering`    | 만료, offline 또는 서버 오류에서 복구를 시도 중이다. |
+
+## 푸시 상태
+
+`PushState`의 판별자는 `status`다.
+
+| `status`             | 정의                                                    |
+| -------------------- | ------------------------------------------------------- |
+| `unsupported`        | 현재 surface 또는 런타임이 Push를 제공하지 않는다.      |
+| `permission-default` | 알림 권한을 아직 요청하지 않았다.                       |
+| `denied`             | 사용자 또는 운영체제가 알림 권한을 거부했다.            |
+| `subscribed-local`   | 로컬 Push 구독은 있지만 서버 등록은 확인되지 않았다.    |
+| `registered-server`  | 로컬 구독을 현재 계정의 서버에 등록했다.                |
+| `test-sending`       | 현재 기기로 테스트 알림을 발송 중이다.                  |
+| `arrived`            | 사용자가 테스트 알림의 실제 도착을 확인했다.            |
+| `not-arrived`        | 사용자가 테스트 알림이 도착하지 않았음을 확인했다.      |
+| `error`              | 권한 이후의 준비, 구독, 등록 또는 발송 단계가 실패했다. |
+
+## 업데이트 상태
+
+`UpdateState`의 판별자는 `status`다.
+
+| `status`           | 정의                                          |
+| ------------------ | --------------------------------------------- |
+| `checking`         | 새 버전을 확인 중이다.                        |
+| `latest`           | 현재 버전이 최신이다.                         |
+| `optional`         | 나중에 적용할 수 있는 업데이트가 있다.        |
+| `mandatory`        | 정상 사용 전에 적용해야 하는 업데이트가 있다. |
+| `downloading`      | 업데이트를 다운로드 중이다.                   |
+| `verifying`        | 다운로드한 업데이트를 검증 중이다.            |
+| `installing`       | 검증한 업데이트를 설치 중이다.                |
+| `restart-required` | 설치를 완료하려면 재시작해야 한다.            |
+| `failed`           | 확인, 다운로드, 검증 또는 설치가 실패했다.    |
+
+## 계약 불변조건
+
+- Capability는 현재 준비 상태가 아닌 surface의 정적 지원 방식이다.
+- 인증, 푸시, 업데이트는 `status`를 판별자로 가진 객체 union이다.
+- Capability 셀과 동적 상태는 `boolean` 또는 `null`로 대체하지 않는다.
+- `first-connect`와 `expired`, `offline`과 `server-error`, `subscribed-local`과
+  `registered-server`, `arrived`와 `not-arrived`, `optional`과 `mandatory`를 합치지 않는다.
+- 상태를 추가하거나 이름을 바꿀 때는 타입, 런타임 guard, 계약 테스트,
+  이 문서를 함께 변경한다.
+
+## 후속 PR wiring 규칙
+
+| 경계              | 규칙                                                                                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Surface 판정      | Desktop build는 `pc`, browser에서 standalone 판정이 `true`이면 `pwa`, 나머지는 `web`으로 한 번만 정규화한다. URL 경로나 user agent를 권한 판정에 사용하지 않는다.   |
+| 공개 기능         | 인증, 푸시, 업데이트 상태로 홈, 세탁실, 식단, 앱 안내 라우트를 차단하지 않는다.                                                                                     |
+| 인증 producer     | 쿠키 유무, HTTP 응답, 네트워크 오류, LMS 상태를 producer 경계에서 `AuthenticationState`로 변환한다. 쿠키 없음만으로 `first-connect`와 `expired`를 선택하지 않는다.  |
+| 푸시 producer     | 권한 → 로컬 구독 → 서버 등록 → 테스트 발송 → 실제 도착 확인 순서로 상태를 발행한다. API 성공이나 0개 대상을 `arrived`로 처리하지 않는다.                            |
+| 업데이트 producer | 이전 `mandatory`를 저장한 뒤 새 확인이 실패해도 차단 상태를 보존한다. 다운로드, 검증, 설치, 재시작을 각각 발행한다.                                                 |
+| 외부 응답         | 기존 `boolean` 또는 `null`은 producer 경계에서 명시적 우선순위로 새 상태에 매핑한다. 소비자에 원시값을 전파하지 않는다.                                             |
+| 소비자            | `status`를 exhaustive switch로 처리하고 기본 분기로 알 수 없는 상태를 숨기지 않는다. 차단 UI는 현재 상태, 필요한 이유, 다음 행동, 복구 또는 나가기 경로를 표시한다. |
+
+우선 wiring 대상은 `frontend/src/platform/contracts.ts`,
+`frontend/src/app/dashboard-account-state.ts`,
+`frontend/src/features/notifications/notification-delivery-setup.tsx`,
+`frontend/src/app/desktop-update-gate.tsx`다.

--- a/frontend/src/platform/status-model.test.ts
+++ b/frontend/src/platform/status-model.test.ts
@@ -1,0 +1,205 @@
+import {describe, expect, expectTypeOf, it} from 'vitest';
+
+import {
+    AUTHENTICATION_STATUSES,
+    PLATFORM_CAPABILITY_MATRIX,
+    PLATFORM_SURFACES,
+    PUSH_STATUSES,
+    UPDATE_STATUSES,
+    isAuthenticationState,
+    isPushState,
+    isUpdateState,
+    type AuthenticationState,
+    type AuthenticationStatus,
+    type PlatformCapabilityMatrix,
+    type PlatformCapabilityProfile,
+    type PlatformSurface,
+    type PushState,
+    type PushStatus,
+    type UpdateState,
+    type UpdateStatus,
+} from './status-model';
+
+const EXPECTED_PLATFORM_CAPABILITY_MATRIX = {
+    web: {
+        publicFeatures: 'available',
+        personalFeatures: 'install-required',
+        installation: 'pwa-install',
+        authentication: 'not-supported',
+        notifications: 'install-required',
+        updates: 'browser-managed',
+    },
+    pwa: {
+        publicFeatures: 'available',
+        personalFeatures: 'connection-required',
+        installation: 'installed',
+        authentication: 'mobile-session',
+        notifications: 'web-push',
+        updates: 'service-worker',
+    },
+    pc: {
+        publicFeatures: 'available',
+        personalFeatures: 'authentication-required',
+        installation: 'native-app',
+        authentication: 'lms-and-server',
+        notifications: 'os-notification',
+        updates: 'native-updater',
+    },
+} as const;
+
+const EXPECTED_AUTHENTICATION_STATUSES = [
+    'checking',
+    'first-connect',
+    'authenticated',
+    'expired',
+    'offline',
+    'server-error',
+    'recovering',
+] as const;
+
+const EXPECTED_PUSH_STATUSES = [
+    'unsupported',
+    'permission-default',
+    'denied',
+    'subscribed-local',
+    'registered-server',
+    'test-sending',
+    'arrived',
+    'not-arrived',
+    'error',
+] as const;
+
+const EXPECTED_UPDATE_STATUSES = [
+    'checking',
+    'latest',
+    'optional',
+    'mandatory',
+    'downloading',
+    'verifying',
+    'installing',
+    'restart-required',
+    'failed',
+] as const;
+
+type ExpectedDiscriminatedState<Status extends string> = Status extends string
+    ? {readonly status: Status}
+    : never;
+
+describe('platform capability matrix', () => {
+    it('Web, PWA, PC의 여섯 capability를 원인까지 드러내는 값으로 고정한다', () => {
+        expect(PLATFORM_SURFACES).toEqual(['web', 'pwa', 'pc']);
+        expect(PLATFORM_CAPABILITY_MATRIX).toEqual(EXPECTED_PLATFORM_CAPABILITY_MATRIX);
+        expectTypeOf<PlatformCapabilityMatrix>().toEqualTypeOf<
+            typeof EXPECTED_PLATFORM_CAPABILITY_MATRIX
+        >();
+        expectTypeOf<PlatformCapabilityProfile<'web'>>().toEqualTypeOf<
+            (typeof EXPECTED_PLATFORM_CAPABILITY_MATRIX)['web']
+        >();
+        expectTypeOf<PlatformCapabilityProfile<'pwa'>>().toEqualTypeOf<
+            (typeof EXPECTED_PLATFORM_CAPABILITY_MATRIX)['pwa']
+        >();
+        expectTypeOf<PlatformCapabilityProfile<'pc'>>().toEqualTypeOf<
+            (typeof EXPECTED_PLATFORM_CAPABILITY_MATRIX)['pc']
+        >();
+    });
+
+    it('capability 셀을 boolean이나 null로 축약하지 않는다', () => {
+        const capabilityValues = Object.values(PLATFORM_CAPABILITY_MATRIX).flatMap((profile) =>
+            Object.values(profile),
+        );
+
+        expect(capabilityValues).toHaveLength(
+            PLATFORM_SURFACES.length * Object.keys(PLATFORM_CAPABILITY_MATRIX.web).length,
+        );
+        expect(capabilityValues.every((value) => typeof value === 'string')).toBe(true);
+        expect(capabilityValues).not.toContain(true);
+        expect(capabilityValues).not.toContain(false);
+        expect(capabilityValues).not.toContain(null);
+
+        type CapabilityValue = PlatformCapabilityProfile[keyof PlatformCapabilityProfile];
+        expectTypeOf<Extract<CapabilityValue, boolean | null>>().toEqualTypeOf<never>();
+        expectTypeOf<keyof typeof PLATFORM_CAPABILITY_MATRIX>().toEqualTypeOf<PlatformSurface>();
+    });
+});
+
+describe('platform lifecycle states', () => {
+    it('인증 상태를 최초 연결, 만료, 연결 실패와 복구까지 구분한다', () => {
+        expect(AUTHENTICATION_STATUSES).toEqual(EXPECTED_AUTHENTICATION_STATUSES);
+
+        const states = AUTHENTICATION_STATUSES.map((status) => ({status}));
+        expect(states.map(({status}) => status)).toEqual(EXPECTED_AUTHENTICATION_STATUSES);
+        expectTypeOf<AuthenticationStatus>().toEqualTypeOf<
+            (typeof EXPECTED_AUTHENTICATION_STATUSES)[number]
+        >();
+        expectTypeOf<AuthenticationState>().toEqualTypeOf<
+            ExpectedDiscriminatedState<(typeof EXPECTED_AUTHENTICATION_STATUSES)[number]>
+        >();
+        expect(states.every(isAuthenticationState)).toBe(true);
+    });
+
+    it('푸시 상태를 권한, 로컬 구독, 서버 등록과 실제 도착 확인으로 구분한다', () => {
+        expect(PUSH_STATUSES).toEqual(EXPECTED_PUSH_STATUSES);
+
+        const states = PUSH_STATUSES.map((status) => ({status}));
+        expect(states.map(({status}) => status)).toEqual(EXPECTED_PUSH_STATUSES);
+        expectTypeOf<PushStatus>().toEqualTypeOf<(typeof EXPECTED_PUSH_STATUSES)[number]>();
+        expectTypeOf<PushState>().toEqualTypeOf<
+            ExpectedDiscriminatedState<(typeof EXPECTED_PUSH_STATUSES)[number]>
+        >();
+        expect(states.every(isPushState)).toBe(true);
+    });
+
+    it('업데이트 상태를 확인, 배포 단계, 재시작과 실패까지 구분한다', () => {
+        expect(UPDATE_STATUSES).toEqual(EXPECTED_UPDATE_STATUSES);
+
+        const states = UPDATE_STATUSES.map((status) => ({status}));
+        expect(states.map(({status}) => status)).toEqual(EXPECTED_UPDATE_STATUSES);
+        expectTypeOf<UpdateStatus>().toEqualTypeOf<(typeof EXPECTED_UPDATE_STATUSES)[number]>();
+        expectTypeOf<UpdateState>().toEqualTypeOf<
+            ExpectedDiscriminatedState<(typeof EXPECTED_UPDATE_STATUSES)[number]>
+        >();
+        expect(states.every(isUpdateState)).toBe(true);
+    });
+
+    it('상태 계약에 boolean과 null을 대입할 수 없다', () => {
+        expectTypeOf<boolean>().not.toMatchTypeOf<AuthenticationState>();
+        expectTypeOf<null>().not.toMatchTypeOf<AuthenticationState>();
+        expectTypeOf<boolean>().not.toMatchTypeOf<PushState>();
+        expectTypeOf<null>().not.toMatchTypeOf<PushState>();
+        expectTypeOf<boolean>().not.toMatchTypeOf<UpdateState>();
+        expectTypeOf<null>().not.toMatchTypeOf<UpdateState>();
+    });
+
+    it('런타임 경계도 boolean, null, 알 수 없는 status를 상태로 받지 않는다', () => {
+        const invalidStates: unknown[] = [
+            true,
+            false,
+            null,
+            undefined,
+            'checking',
+            {},
+            {status: true},
+            {status: null},
+            {status: 'unknown'},
+        ];
+
+        for (const value of invalidStates) {
+            expect(isAuthenticationState(value)).toBe(false);
+            expect(isPushState(value)).toBe(false);
+            expect(isUpdateState(value)).toBe(false);
+        }
+
+        expect(isAuthenticationState({status: 'unconnected'})).toBe(false);
+        expect(isPushState({status: 'ready'})).toBe(false);
+        expect(isUpdateState({status: 'available'})).toBe(false);
+        expect(isAuthenticationState({status: 'arrived'})).toBe(false);
+        expect(isAuthenticationState({status: 'installing'})).toBe(false);
+        expect(isPushState({status: 'authenticated'})).toBe(false);
+        expect(isPushState({status: 'mandatory'})).toBe(false);
+        expect(isUpdateState({status: 'expired'})).toBe(false);
+        expect(isUpdateState({status: 'denied'})).toBe(false);
+        expect(isAuthenticationState({status: 'expired'})).toBe(true);
+        expect(isPushState({status: 'registered-server'})).toBe(true);
+        expect(isUpdateState({status: 'verifying'})).toBe(true);
+    });
+});

--- a/frontend/src/platform/status-model.ts
+++ b/frontend/src/platform/status-model.ts
@@ -1,0 +1,118 @@
+export const PLATFORM_SURFACES = ['web', 'pwa', 'pc'] as const;
+
+export type PlatformSurface = (typeof PLATFORM_SURFACES)[number];
+
+interface PlatformCapabilitySchema {
+    readonly publicFeatures: 'available';
+    readonly personalFeatures:
+        | 'install-required'
+        | 'connection-required'
+        | 'authentication-required';
+    readonly installation: 'pwa-install' | 'installed' | 'native-app';
+    readonly authentication: 'not-supported' | 'mobile-session' | 'lms-and-server';
+    readonly notifications: 'install-required' | 'web-push' | 'os-notification';
+    readonly updates: 'browser-managed' | 'service-worker' | 'native-updater';
+}
+
+export const PLATFORM_CAPABILITY_MATRIX = {
+    web: {
+        publicFeatures: 'available',
+        personalFeatures: 'install-required',
+        installation: 'pwa-install',
+        authentication: 'not-supported',
+        notifications: 'install-required',
+        updates: 'browser-managed',
+    },
+    pwa: {
+        publicFeatures: 'available',
+        personalFeatures: 'connection-required',
+        installation: 'installed',
+        authentication: 'mobile-session',
+        notifications: 'web-push',
+        updates: 'service-worker',
+    },
+    pc: {
+        publicFeatures: 'available',
+        personalFeatures: 'authentication-required',
+        installation: 'native-app',
+        authentication: 'lms-and-server',
+        notifications: 'os-notification',
+        updates: 'native-updater',
+    },
+} as const satisfies Readonly<Record<PlatformSurface, PlatformCapabilitySchema>>;
+
+export type PlatformCapabilityMatrix = typeof PLATFORM_CAPABILITY_MATRIX;
+export type PlatformCapabilityProfile<Surface extends PlatformSurface = PlatformSurface> =
+    PlatformCapabilityMatrix[Surface];
+
+export const AUTHENTICATION_STATUSES = [
+    'checking',
+    'first-connect',
+    'authenticated',
+    'expired',
+    'offline',
+    'server-error',
+    'recovering',
+] as const;
+
+export const PUSH_STATUSES = [
+    'unsupported',
+    'permission-default',
+    'denied',
+    'subscribed-local',
+    'registered-server',
+    'test-sending',
+    'arrived',
+    'not-arrived',
+    'error',
+] as const;
+
+export const UPDATE_STATUSES = [
+    'checking',
+    'latest',
+    'optional',
+    'mandatory',
+    'downloading',
+    'verifying',
+    'installing',
+    'restart-required',
+    'failed',
+] as const;
+
+export type AuthenticationStatus = (typeof AUTHENTICATION_STATUSES)[number];
+export type PushStatus = (typeof PUSH_STATUSES)[number];
+export type UpdateStatus = (typeof UPDATE_STATUSES)[number];
+
+type DiscriminatedStatus<Status extends string> = {
+    readonly [Value in Status]: {readonly status: Value};
+}[Status];
+
+export type AuthenticationState = DiscriminatedStatus<AuthenticationStatus>;
+export type PushState = DiscriminatedStatus<PushStatus>;
+export type UpdateState = DiscriminatedStatus<UpdateStatus>;
+
+const authenticationStatusSet: ReadonlySet<AuthenticationStatus> = new Set(AUTHENTICATION_STATUSES);
+const pushStatusSet: ReadonlySet<PushStatus> = new Set(PUSH_STATUSES);
+const updateStatusSet: ReadonlySet<UpdateStatus> = new Set(UPDATE_STATUSES);
+
+function hasKnownStatus<Status extends string>(
+    value: unknown,
+    statuses: ReadonlySet<Status>,
+): value is DiscriminatedStatus<Status> {
+    if (typeof value !== 'object' || value === null) return false;
+    const status = Reflect.get(value, 'status');
+    const knownStatuses: ReadonlySet<string> = statuses;
+    return typeof status === 'string' && knownStatuses.has(status);
+}
+
+export function isAuthenticationState(value: unknown): value is AuthenticationState {
+    return hasKnownStatus<AuthenticationStatus>(value, authenticationStatusSet);
+}
+
+export function isPushState(value: unknown): value is PushState {
+    return hasKnownStatus<PushStatus>(value, pushStatusSet);
+}
+
+export function isUpdateState(value: unknown): value is UpdateState {
+    return hasKnownStatus<UpdateStatus>(value, updateStatusSet);
+}


### PR DESCRIPTION
# 요약

Web/PWA/PC별 capability와 인증·푸시·업데이트 상태 계약을 코드와 문서에 정의합니다.

- 단일 boolean/null로 서로 다른 원인을 합치지 않는 discriminated state model
- 플랫폼별 공개/개인 기능과 선행 조건 표
- 계약 및 전이 테스트

# 스택

1/9, base: `main`

# 검증

- 독립 worktree: 성공
- `npm run check`: 104개 파일, 544개 테스트 통과
- clean worktree 확인

Refs #69
