### PR TITLE
[stack 2/9] fix(updater): 필수 업데이트 fail-open 차단

### DIFF
--- a/desktop/src/updater.rs
+++ b/desktop/src/updater.rs
@@ -4,8 +4,8 @@ use std::{
     fs,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicU8, Ordering},
-        Arc,
+        atomic::{AtomicU64, AtomicU8, Ordering},
+        Arc, RwLock,
     },
     time::Duration,
 };
@@ -13,7 +13,7 @@ use std::{
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
-use tauri_plugin_updater::{Update, UpdaterExt};
+use tauri_plugin_updater::{Error as UpdaterError, Update, UpdaterExt};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -32,18 +32,49 @@ const SESSION_BACKGROUND: u8 = 0;
 const SESSION_FOREGROUND: u8 = 1;
 const SESSION_INSTALLING: u8 = 2;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DesktopUpdateStage {
+    Checking,
+    Latest,
+    Optional,
+    Mandatory,
+    Downloading,
+    Verifying,
+    Installing,
+    RestartRequired,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum DesktopUpdatePolicy {
+    Optional,
+    Mandatory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopUpdateProgress {
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DesktopUpdateStatus {
     current_version: String,
     available_version: Option<String>,
-    mandatory: bool,
+    status: DesktopUpdateStage,
+    policy: Option<DesktopUpdatePolicy>,
+    progress: Option<DesktopUpdateProgress>,
+    error_code: Option<String>,
 }
 
 impl DesktopUpdateStatus {
     fn new(current_version: impl Into<String>, available_version: Option<String>) -> Self {
         let current_version = current_version.into();
-        let mandatory = current_version
+        let policy = current_version
             .parse::<Version>()
             .ok()
             .zip(
@@ -51,12 +82,63 @@ impl DesktopUpdateStatus {
                     .as_deref()
                     .and_then(|version| version.parse::<Version>().ok()),
             )
-            .is_some_and(|(current, available)| is_mandatory_update(&current, &available));
+            .map(|(current, available)| {
+                if is_mandatory_update(&current, &available) {
+                    DesktopUpdatePolicy::Mandatory
+                } else {
+                    DesktopUpdatePolicy::Optional
+                }
+            });
+        let status = match policy {
+            Some(DesktopUpdatePolicy::Mandatory) => DesktopUpdateStage::Mandatory,
+            Some(DesktopUpdatePolicy::Optional) => DesktopUpdateStage::Optional,
+            None => DesktopUpdateStage::Latest,
+        };
         Self {
             current_version,
             available_version,
-            mandatory,
+            status,
+            policy,
+            progress: None,
+            error_code: None,
         }
+    }
+
+    fn checking(current_version: impl Into<String>) -> Self {
+        Self {
+            current_version: current_version.into(),
+            available_version: None,
+            status: DesktopUpdateStage::Checking,
+            policy: None,
+            progress: None,
+            error_code: None,
+        }
+    }
+
+    fn checking_from(mut self, current_version: impl Into<String>) -> Self {
+        self.current_version = current_version.into();
+        self.status = DesktopUpdateStage::Checking;
+        self.progress = None;
+        self.error_code = None;
+        self
+    }
+
+    fn with_stage(mut self, status: DesktopUpdateStage, progress: Option<DesktopUpdateProgress>) -> Self {
+        self.status = status;
+        self.progress = progress;
+        self.error_code = None;
+        self
+    }
+
+    fn failed(mut self, error_code: impl Into<String>) -> Self {
+        self.status = DesktopUpdateStage::Failed;
+        self.error_code = Some(error_code.into());
+        self
+    }
+
+    fn with_progress(mut self, progress: DesktopUpdateProgress) -> Self {
+        self.progress = Some(progress);
+        self
     }
 }
 
@@ -113,21 +195,25 @@ struct CachedUpdateCheck {
 #[derive(Default)]
 struct UpdateOperationState {
     cached: Option<CachedUpdateCheck>,
-    latest_check_error: Option<String>,
     pending: Option<PendingUpdateMarker>,
 }
 
 impl UpdateOperationState {
     fn cached_check(&self) -> Option<Result<CheckedUpdate, String>> {
-        if let Some(error) = self.latest_check_error.as_ref() {
-            return Some(Err(error.clone()));
-        }
         self.cached.as_ref().map(|cached| {
             Ok(CheckedUpdate {
                 status: cached.status.clone(),
                 update: cached.update.clone(),
             })
         })
+    }
+
+    fn remember_failure(&mut self, error_code: &str) -> bool {
+        let Some(cached) = self.cached.as_mut() else {
+            return false;
+        };
+        cached.status = cached.status.clone().failed(error_code);
+        true
     }
 }
 
@@ -142,6 +228,7 @@ pub(crate) enum AutoUpdateOutcome {
 /// 업데이트 확인, 유예 상태, 설치 직전 안전 판정을 하나의 직렬화 경계에서 관리한다.
 pub(crate) struct UpdateCoordinator {
     operation: Mutex<UpdateOperationState>,
+    status_snapshot: RwLock<DesktopUpdateStatus>,
     session_state: AtomicU8,
     marker_path: PathBuf,
 }
@@ -151,12 +238,13 @@ impl UpdateCoordinator {
         let marker_path = app.path().app_data_dir()?.join(PENDING_UPDATE_FILE);
         let current_version = app.package_info().version.clone();
         let pending = load_pending_marker(&marker_path, &current_version);
+        let initial_status = pending.as_ref().map_or_else(
+            || DesktopUpdateStatus::checking(current_version.to_string()),
+            |marker| DesktopUpdateStatus::new(current_version.to_string(), Some(marker.version.clone())),
+        );
         Ok(Self {
-            operation: Mutex::new(UpdateOperationState {
-                cached: None,
-                latest_check_error: None,
-                pending,
-            }),
+            operation: Mutex::new(UpdateOperationState { cached: None, pending }),
+            status_snapshot: RwLock::new(initial_status),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path,
         })
@@ -197,6 +285,55 @@ impl UpdateCoordinator {
             .is_ok()
     }
 
+    fn try_begin_manual_install(&self) -> bool {
+        self.mark_foreground_seen()
+            && self
+                .session_state
+                .compare_exchange(
+                    SESSION_FOREGROUND,
+                    SESSION_INSTALLING,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+    }
+
+    fn status_snapshot(&self) -> DesktopUpdateStatus {
+        self.status_snapshot
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn publish_status(&self, status: DesktopUpdateStatus) {
+        *self
+            .status_snapshot
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = status;
+    }
+
+    fn remember_status(&self, state: &mut UpdateOperationState, status: DesktopUpdateStatus) {
+        if let Some(cached) = state.cached.as_mut() {
+            cached.status = status.clone();
+        }
+        self.publish_status(status);
+    }
+
+    fn remember_failure(&self, state: &mut UpdateOperationState, current_version: &str, error_code: &str) {
+        let status = if state.remember_failure(error_code) {
+            state.cached.as_ref().unwrap().status.clone()
+        } else {
+            self.status_snapshot().checking_from(current_version).failed(error_code)
+        };
+        if state.cached.is_none() && status.available_version.is_some() {
+            state.cached = Some(CachedUpdateCheck {
+                status: status.clone(),
+                update: None,
+            });
+        }
+        self.publish_status(status);
+    }
+
     pub(crate) async fn has_pending_auto_install(&self) -> bool {
         self.operation
             .lock()
@@ -207,26 +344,40 @@ impl UpdateCoordinator {
     }
 
     pub(crate) async fn check_update(&self, app: &tauri::AppHandle) -> Result<DesktopUpdateStatus, String> {
+        if self.session_state.load(Ordering::Acquire) == SESSION_INSTALLING {
+            return Ok(self.status_snapshot());
+        }
         let mut state = self.operation.lock().await;
         let checked = self.check_remote(app, &mut state, false).await?;
         Ok(checked.status)
     }
 
     pub(crate) async fn refresh_update(&self, app: &tauri::AppHandle) -> Result<DesktopUpdateStatus, String> {
+        if self.session_state.load(Ordering::Acquire) == SESSION_INSTALLING {
+            return Ok(self.status_snapshot());
+        }
         let mut state = self.operation.lock().await;
         let checked = self.check_remote(app, &mut state, true).await?;
         Ok(checked.status)
     }
 
     pub(crate) async fn install_update(&self, app: tauri::AppHandle) -> Result<(), String> {
-        if !self.mark_foreground_seen() {
+        if !self.try_begin_manual_install() {
             return Err("UPDATE_INSTALL_IN_PROGRESS".to_owned());
         }
+        let result = self.install_foreground_update(app).await;
+        if !matches!(result, Ok(true)) {
+            self.session_state.store(SESSION_FOREGROUND, Ordering::Release);
+        }
+        result.map(|_| ())
+    }
+
+    async fn install_foreground_update(&self, app: tauri::AppHandle) -> Result<bool, String> {
         let mut state = self.operation.lock().await;
         let checked = self.check_remote(&app, &mut state, true).await?;
         let Some(update) = checked.update else {
             log::debug!("[updater] 최신 버전");
-            return Ok(());
+            return Ok(false);
         };
 
         // Windows installer는 install 호출 안에서 프로세스를 종료할 수 있다.
@@ -240,13 +391,42 @@ impl UpdateCoordinator {
         if let Err(error) = self.persist_pending_version(&mut state, &update.version) {
             log::warn!("[updater] 수동 설치 marker 기록 실패: {error}");
         }
+        let (bytes, progress) = match self.download_verified_update(&checked.status, &update).await {
+            Ok(download) => download,
+            Err(error) => {
+                let error_code = updater_operation_error_code(&error);
+                log::error!("[updater] 업데이트 다운로드 또는 서명 검증 실패: {error}");
+                let failed = self.status_snapshot().failed(error_code);
+                self.remember_status(&mut state, failed);
+                self.defer_pending_retry(&mut state);
+                return Err(error_code.to_owned());
+            }
+        };
         self.notify_installing(&app, &update.version);
-        if let Err(error) = install_verified_update(update).await {
+        self.remember_status(
+            &mut state,
+            checked
+                .status
+                .clone()
+                .with_stage(DesktopUpdateStage::Installing, Some(progress.clone())),
+        );
+        if let Err(error) = update.install(bytes) {
+            log::error!("[updater] 업데이트 설치 실패: {error}");
+            self.remember_status(
+                &mut state,
+                checked.status.failed("UPDATE_INSTALL_FAILED").with_progress(progress),
+            );
             self.defer_pending_retry(&mut state);
-            return Err(error);
+            return Err("UPDATE_INSTALL_FAILED".to_owned());
         }
+        self.remember_status(
+            &mut state,
+            checked
+                .status
+                .with_stage(DesktopUpdateStage::RestartRequired, Some(progress)),
+        );
         app.request_restart();
-        Ok(())
+        Ok(true)
     }
 
     pub(crate) async fn apply_pending_update_on_start(&self, app: tauri::AppHandle) -> AutoUpdateOutcome {
@@ -290,10 +470,13 @@ impl UpdateCoordinator {
             return AutoUpdateOutcome::Deferred;
         }
         log::info!("[updater] v{} 서명 검증 다운로드 시작", update.version);
-        let bytes = match update.download(|_, _| {}, || {}).await {
-            Ok(bytes) => bytes,
+        let (bytes, progress) = match self.download_verified_update(&checked.status, &update).await {
+            Ok(download) => download,
             Err(error) => {
                 log::error!("[updater] 업데이트 다운로드 또는 서명 검증 실패: {error}");
+                let error_code = updater_operation_error_code(&error);
+                let failed = self.status_snapshot().failed(error_code);
+                self.remember_status(&mut state, failed);
                 self.defer_pending_retry(&mut state);
                 return AutoUpdateOutcome::Failed;
             }
@@ -306,24 +489,44 @@ impl UpdateCoordinator {
                 "[updater] 다운로드 중 사용자 세션이 시작되어 v{} 설치를 유예",
                 update.version
             );
+            self.remember_status(&mut state, checked.status);
             return AutoUpdateOutcome::Deferred;
         }
 
         if let Err(error) = self.record_install_attempt(&mut state, &update.version) {
             self.session_state.store(SESSION_BACKGROUND, Ordering::Release);
             log::warn!("[updater] 자동 설치 marker 기록 실패로 설치를 유예: {error}");
-            return AutoUpdateOutcome::Deferred;
+            let failed = checked.status.failed("UPDATE_STATE_SAVE_FAILED");
+            self.remember_status(&mut state, failed);
+            return AutoUpdateOutcome::Failed;
         }
 
+        self.remember_status(
+            &mut state,
+            checked
+                .status
+                .clone()
+                .with_stage(DesktopUpdateStage::Installing, Some(progress.clone())),
+        );
         if let Err(error) = update.install(bytes) {
             self.session_state.store(SESSION_BACKGROUND, Ordering::Release);
             log::error!("[updater] 업데이트 설치 실패: {error}");
+            self.remember_status(
+                &mut state,
+                checked.status.failed("UPDATE_INSTALL_FAILED").with_progress(progress),
+            );
             self.defer_pending_retry(&mut state);
             return AutoUpdateOutcome::Failed;
         }
 
         // Windows updater는 install 안에서 상태 정리 hook 실행 후 프로세스를
         // 종료한다. install이 반환되는 플랫폼은 이벤트 루프에 재시작을 요청한다.
+        self.remember_status(
+            &mut state,
+            checked
+                .status
+                .with_stage(DesktopUpdateStage::RestartRequired, Some(progress)),
+        );
         app.request_restart();
         AutoUpdateOutcome::RestartRequested
     }
@@ -336,16 +539,22 @@ impl UpdateCoordinator {
     ) -> Result<CheckedUpdate, String> {
         if !force {
             if let Some(cached) = state.cached_check() {
+                if let Ok(checked) = &cached {
+                    self.publish_status(checked.status.clone());
+                }
                 return cached;
             }
         }
+
+        let current_version = app.package_info().version.to_string();
+        self.publish_status(self.status_snapshot().checking_from(current_version.clone()));
 
         let updater = match app.updater_builder().timeout(UPDATE_CHECK_TIMEOUT).build() {
             Ok(updater) => updater,
             Err(error) => {
                 log::debug!("[updater] updater 초기화 실패: {error}");
                 let error = "UPDATER_UNAVAILABLE".to_owned();
-                state.latest_check_error = Some(error.clone());
+                self.remember_failure(state, &current_version, &error);
                 self.defer_pending_retry(state);
                 return Err(error);
             }
@@ -355,16 +564,14 @@ impl UpdateCoordinator {
             Err(error) => {
                 log::warn!("[updater] 업데이트 확인 실패: {error}");
                 let error = "UPDATE_CHECK_FAILED".to_owned();
-                state.latest_check_error = Some(error.clone());
+                self.remember_failure(state, &current_version, &error);
                 self.defer_pending_retry(state);
                 return Err(error);
             }
         };
-        state.latest_check_error = None;
         if let Some(update) = update.as_mut() {
             update.timeout = Some(UPDATE_DOWNLOAD_TIMEOUT);
         }
-        let current_version = app.package_info().version.to_string();
         let status = DesktopUpdateStatus::new(current_version, update.as_ref().map(|update| update.version.clone()));
 
         match update.as_ref() {
@@ -384,7 +591,66 @@ impl UpdateCoordinator {
             status: status.clone(),
             update: update.clone(),
         });
+        self.publish_status(status.clone());
         Ok(CheckedUpdate { status, update })
+    }
+
+    async fn download_verified_update(
+        &self,
+        status: &DesktopUpdateStatus,
+        update: &Update,
+    ) -> Result<(Vec<u8>, DesktopUpdateProgress), UpdaterError> {
+        let downloaded_bytes = Arc::new(AtomicU64::new(0));
+        let total_bytes = Arc::new(AtomicU64::new(u64::MAX));
+        let initial_progress = DesktopUpdateProgress {
+            downloaded_bytes: 0,
+            total_bytes: None,
+        };
+        self.publish_status(
+            status
+                .clone()
+                .with_stage(DesktopUpdateStage::Downloading, Some(initial_progress)),
+        );
+
+        let chunk_downloaded = downloaded_bytes.clone();
+        let chunk_total = total_bytes.clone();
+        let chunk_status = status.clone();
+        let finish_downloaded = downloaded_bytes.clone();
+        let finish_total = total_bytes.clone();
+        let finish_status = status.clone();
+        let bytes = update
+            .download(
+                |chunk_length, content_length| {
+                    let downloaded = chunk_downloaded
+                        .fetch_add(chunk_length as u64, Ordering::AcqRel)
+                        .saturating_add(chunk_length as u64);
+                    if let Some(total) = content_length {
+                        chunk_total.store(total, Ordering::Release);
+                    }
+                    let progress = DesktopUpdateProgress {
+                        downloaded_bytes: downloaded,
+                        total_bytes: observed_total_bytes(&chunk_total),
+                    };
+                    self.publish_status(
+                        chunk_status
+                            .clone()
+                            .with_stage(DesktopUpdateStage::Downloading, Some(progress)),
+                    );
+                },
+                || {
+                    let progress = DesktopUpdateProgress {
+                        downloaded_bytes: finish_downloaded.load(Ordering::Acquire),
+                        total_bytes: observed_total_bytes(&finish_total),
+                    };
+                    self.publish_status(finish_status.with_stage(DesktopUpdateStage::Verifying, Some(progress)));
+                },
+            )
+            .await?;
+        let progress = DesktopUpdateProgress {
+            downloaded_bytes: downloaded_bytes.load(Ordering::Acquire),
+            total_bytes: observed_total_bytes(&total_bytes),
+        };
+        Ok((bytes, progress))
     }
 
     fn persist_pending_version(&self, state: &mut UpdateOperationState, version: &str) -> Result<(), String> {
@@ -437,12 +703,18 @@ struct CheckedUpdate {
     update: Option<Update>,
 }
 
-async fn install_verified_update(update: Update) -> Result<(), String> {
-    log::info!("[updater] v{} 설치 시작", update.version);
-    update.download_and_install(|_, _| {}, || {}).await.map_err(|error| {
-        log::error!("[updater] 업데이트 설치 실패: {error}");
-        "UPDATE_INSTALL_FAILED".to_owned()
-    })
+fn observed_total_bytes(total_bytes: &AtomicU64) -> Option<u64> {
+    match total_bytes.load(Ordering::Acquire) {
+        u64::MAX => None,
+        total => Some(total),
+    }
+}
+
+fn updater_operation_error_code(error: &UpdaterError) -> &'static str {
+    match error {
+        UpdaterError::Minisign(_) | UpdaterError::Base64(_) | UpdaterError::SignatureUtf8(_) => "UPDATE_VERIFY_FAILED",
+        _ => "UPDATE_DOWNLOAD_FAILED",
+    }
 }
 
 pub(crate) fn mark_foreground_session(app: &tauri::AppHandle) -> bool {
@@ -530,17 +802,28 @@ mod tests {
     }
 
     #[test]
-    fn 업데이트_상태는_현재_버전과_선택적_최신_버전을_노출한다() {
+    fn 업데이트_상태는_단계_policy_진행률_오류를_exact하게_노출한다() {
         let available = DesktopUpdateStatus::new("0.5.0", Some("0.5.1".to_owned()));
         let mandatory = DesktopUpdateStatus::new("0.5.0", Some("0.6.0".to_owned()));
         let current = DesktopUpdateStatus::new("0.6.0", None);
+        let downloading = mandatory.clone().with_stage(
+            DesktopUpdateStage::Downloading,
+            Some(DesktopUpdateProgress {
+                downloaded_bytes: 25,
+                total_bytes: Some(100),
+            }),
+        );
+        let failed = downloading.failed("UPDATE_VERIFY_FAILED");
 
         assert_eq!(
             serde_json::to_value(available).unwrap(),
             serde_json::json!({
                 "currentVersion": "0.5.0",
                 "availableVersion": "0.5.1",
-                "mandatory": false
+                "status": "optional",
+                "policy": "optional",
+                "progress": null,
+                "errorCode": null
             })
         );
         assert_eq!(
@@ -548,7 +831,10 @@ mod tests {
             serde_json::json!({
                 "currentVersion": "0.5.0",
                 "availableVersion": "0.6.0",
-                "mandatory": true
+                "status": "mandatory",
+                "policy": "mandatory",
+                "progress": null,
+                "errorCode": null
             })
         );
         assert_eq!(
@@ -556,7 +842,21 @@ mod tests {
             serde_json::json!({
                 "currentVersion": "0.6.0",
                 "availableVersion": null,
-                "mandatory": false
+                "status": "latest",
+                "policy": null,
+                "progress": null,
+                "errorCode": null
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(failed).unwrap(),
+            serde_json::json!({
+                "currentVersion": "0.5.0",
+                "availableVersion": "0.6.0",
+                "status": "failed",
+                "policy": "mandatory",
+                "progress": {"downloadedBytes": 25, "totalBytes": 100},
+                "errorCode": "UPDATE_VERIFY_FAILED"
             })
         );
     }
@@ -616,7 +916,6 @@ mod tests {
         let eligible = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState {
                 cached: None,
-                latest_check_error: None,
                 pending: Some(PendingUpdateMarker {
                     schema_version: PENDING_UPDATE_SCHEMA_VERSION,
                     version: "0.6.0".into(),
@@ -624,13 +923,13 @@ mod tests {
                     retry_not_before_unix_seconds: 0,
                 }),
             }),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: PathBuf::new(),
         };
         let exhausted = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState {
                 cached: None,
-                latest_check_error: None,
                 pending: Some(PendingUpdateMarker {
                     schema_version: PENDING_UPDATE_SCHEMA_VERSION,
                     version: "0.6.0".into(),
@@ -638,13 +937,13 @@ mod tests {
                     retry_not_before_unix_seconds: 0,
                 }),
             }),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: PathBuf::new(),
         };
         let backed_off = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState {
                 cached: None,
-                latest_check_error: None,
                 pending: Some(PendingUpdateMarker {
                     schema_version: PENDING_UPDATE_SCHEMA_VERSION,
                     version: "0.6.0".into(),
@@ -652,6 +951,7 @@ mod tests {
                     retry_not_before_unix_seconds: i64::MAX,
                 }),
             }),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: PathBuf::new(),
         };
@@ -666,12 +966,12 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let coordinator = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState::default()),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: directory.path().join(PENDING_UPDATE_FILE),
         };
         let mut state = UpdateOperationState {
             cached: None,
-            latest_check_error: None,
             pending: Some(PendingUpdateMarker {
                 schema_version: PENDING_UPDATE_SCHEMA_VERSION,
                 version: "0.6.0".into(),
@@ -687,26 +987,39 @@ mod tests {
     }
 
     #[test]
-    fn 최신_확인_오류는_이전_mandatory_cache보다_우선한다() {
-        let state = UpdateOperationState {
+    fn 최신_확인_오류에도_이전_mandatory_cache를_실패_상태로_보존한다() {
+        let mut state = UpdateOperationState {
             cached: Some(CachedUpdateCheck {
                 status: DesktopUpdateStatus::new("0.5.0", Some("0.6.0".into())),
                 update: None,
             }),
-            latest_check_error: Some("UPDATE_CHECK_FAILED".into()),
             pending: None,
         };
 
-        assert!(matches!(
-            state.cached_check(),
-            Some(Err(error)) if error == "UPDATE_CHECK_FAILED"
-        ));
+        assert!(state.remember_failure("UPDATE_CHECK_FAILED"));
+        let checked = state.cached_check().unwrap().unwrap();
+        assert_eq!(checked.status.status, DesktopUpdateStage::Failed);
+        assert_eq!(checked.status.policy, Some(DesktopUpdatePolicy::Mandatory));
+        assert_eq!(checked.status.error_code.as_deref(), Some("UPDATE_CHECK_FAILED"));
+    }
+
+    #[test]
+    fn 서명_오류와_네트워크_오류를_검증과_다운로드_단계로_구분한다() {
+        assert_eq!(
+            updater_operation_error_code(&tauri_plugin_updater::Error::SignatureUtf8("bad".into())),
+            "UPDATE_VERIFY_FAILED"
+        );
+        assert_eq!(
+            updater_operation_error_code(&tauri_plugin_updater::Error::Network("offline".into())),
+            "UPDATE_DOWNLOAD_FAILED"
+        );
     }
 
     #[test]
     fn 설치_확정과_사용자_창_열기는_하나만_먼저_상태를_선점한다() {
         let foreground_first = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState::default()),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: PathBuf::new(),
         };
@@ -715,6 +1028,7 @@ mod tests {
 
         let install_first = UpdateCoordinator {
             operation: Mutex::new(UpdateOperationState::default()),
+            status_snapshot: RwLock::new(DesktopUpdateStatus::checking("0.5.0")),
             session_state: AtomicU8::new(SESSION_BACKGROUND),
             marker_path: PathBuf::new(),
         };

--- a/frontend/src/app/desktop-update-gate-decision.ts
+++ b/frontend/src/app/desktop-update-gate-decision.ts
@@ -1,0 +1,28 @@
+import type {DesktopUpdateStatus} from '@/platform/contracts';
+
+interface DesktopUpdateGateDecisionInput {
+    desktop: boolean;
+    data: DesktopUpdateStatus | undefined;
+    queryPending: boolean;
+    queryError: boolean;
+}
+
+export interface DesktopUpdateGateDecision {
+    renderDashboard: boolean;
+    blocked: boolean;
+    canAdmit: boolean;
+}
+
+export function desktopUpdateGateDecision({
+    desktop,
+    data,
+}: DesktopUpdateGateDecisionInput): DesktopUpdateGateDecision {
+    if (!desktop) return {renderDashboard: true, blocked: false, canAdmit: true};
+    const mandatory = data?.policy === 'mandatory';
+    const canAdmit = data?.status === 'latest' || data?.policy === 'optional';
+    return {
+        renderDashboard: true,
+        blocked: mandatory || !canAdmit,
+        canAdmit,
+    };
+}

--- a/frontend/src/app/desktop-update-gate.test.tsx
+++ b/frontend/src/app/desktop-update-gate.test.tsx
@@ -1,22 +1,20 @@
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, test, vi} from 'vitest';
 
+import type {DesktopUpdateStatus} from '@/platform/contracts';
+
 import {DesktopUpdateGate} from './desktop-update-gate';
+import {desktopUpdateGateDecision} from './desktop-update-gate-decision';
 
 const {environment, updateQuery} = vi.hoisted(() => ({
     environment: {
         platform: {kind: 'browser', capabilities: {desktopSettings: false}},
         checkDesktopUpdate: vi.fn<() => Promise<unknown>>(),
         installDesktopUpdate: vi.fn<() => Promise<void>>(),
+        openLogFolder: vi.fn<() => Promise<void>>(),
     },
     updateQuery: {
-        data: undefined as
-            | undefined
-            | {
-                  currentVersion: string;
-                  availableVersion: string | null;
-                  mandatory: boolean;
-              },
+        data: undefined as DesktopUpdateStatus | undefined,
         isError: false,
         isPending: false,
         isFetching: false,
@@ -25,6 +23,8 @@ const {environment, updateQuery} = vi.hoisted(() => ({
 }));
 
 vi.mock('@tanstack/react-query', () => ({
+    useIsMutating: () => 0,
+    useQueryClient: () => ({invalidateQueries: vi.fn<() => Promise<void>>()}),
     useMutation: ({mutationFn}: {mutationFn: () => Promise<unknown>}) => ({
         isPending: false,
         isError: false,
@@ -36,17 +36,29 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('./dashboard-context', () => ({
     queryKeys: {desktopUpdate: ['desktop-update'] as const},
     useDashboardEnvironment: () => ({
-        api: {
-            checkDesktopUpdate: environment.checkDesktopUpdate,
-            installDesktopUpdate: environment.installDesktopUpdate,
-        },
+        api: environment,
         platform: environment.platform,
     }),
 }));
 
+function status(
+    updateStatus: DesktopUpdateStatus['status'],
+    overrides: Partial<DesktopUpdateStatus> = {},
+): DesktopUpdateStatus {
+    return {
+        currentVersion: '0.5.4',
+        availableVersion: updateStatus === 'latest' ? null : '0.6.0',
+        status: updateStatus,
+        policy: updateStatus === 'latest' ? null : 'mandatory',
+        progress: null,
+        errorCode: updateStatus === 'failed' ? 'UPDATE_INSTALL_FAILED' : null,
+        ...overrides,
+    };
+}
+
 function renderGate(options: {
     platform: 'browser' | 'desktop';
-    data?: typeof updateQuery.data;
+    data?: DesktopUpdateStatus;
     error?: boolean;
     pending?: boolean;
 }): string {
@@ -74,61 +86,108 @@ function RouteContent() {
 
 describe('DesktopUpdateGate', () => {
     test('웹과 PWA는 업데이트 확인 없이 대시보드를 연다', () => {
-        const markup = renderGate({
-            platform: 'browser',
-            data: {currentVersion: '0.5.0', availableVersion: '0.6.0', mandatory: true},
-        });
+        const markup = renderGate({platform: 'browser', data: status('mandatory')});
 
         expect(markup).toContain('대시보드');
         expect(routeRenderCount).toBe(1);
     });
 
-    test('PC 앱도 업데이트 확인 중에 대시보드를 연다', () => {
+    test('PC 최초 확인 중에는 대시보드를 inert로 만들고 안정적인 overlay를 표시한다', () => {
         const markup = renderGate({platform: 'desktop', pending: true});
 
-        expect(markup).toContain('대시보드');
+        expect(markup).toContain('업데이트 확인 중');
+        expect(markup).toContain('data-route-content');
+        expect(markup).toContain('inert=""');
+        expect(markup).toContain('aria-hidden="true"');
         expect(routeRenderCount).toBe(1);
     });
 
-    test('같은 minor의 patch 업데이트는 대시보드를 차단하지 않는다', () => {
-        const markup = renderGate({
-            platform: 'desktop',
-            data: {currentVersion: '0.5.0', availableVersion: '0.5.1', mandatory: false},
-        });
-
-        expect(markup).toContain('대시보드');
-        expect(routeRenderCount).toBe(1);
-    });
-
-    test('정식 minor 업데이트는 설치 전까지 대시보드를 차단한다', () => {
-        const markup = renderGate({
-            platform: 'desktop',
-            data: {currentVersion: '0.5.4', availableVersion: '0.6.0', mandatory: true},
-        });
-
-        expect(markup).toContain('PC 앱 업데이트가 필요합니다.');
-        expect(markup).toContain('현재 v0.5.4');
-        expect(markup).toContain('최신 정식 버전 v0.6.0');
-        expect(markup).toContain('지금 업데이트');
-        expect(markup).not.toContain('data-route-content');
-        expect(routeRenderCount).toBe(0);
-    });
-
-    test('업데이트 확인 실패는 대시보드를 차단하지 않는다', () => {
+    test('최초 확인 실패는 복구 경로가 있는 차단 화면을 표시한다', () => {
         const markup = renderGate({platform: 'desktop', error: true});
 
-        expect(markup).toContain('대시보드');
+        expect(markup).toContain('업데이트를 확인하지 못했습니다');
+        expect(markup).toContain('최신 버전 확인 단계에서 실패했습니다');
+        expect(markup).toContain('다시 확인');
+        expect(markup).toContain('인터넷 연결');
+        expect(markup).toContain('로그 폴더 열기');
+        expect(markup).toContain('수동 설치');
+        expect(markup).toContain('inert=""');
+    });
+
+    test('optional과 latest 결과는 대시보드를 연다', () => {
+        expect(
+            renderGate({
+                platform: 'desktop',
+                data: status('optional', {policy: 'optional', availableVersion: '0.5.5'}),
+            }),
+        ).toContain('대시보드');
+        expect(renderGate({platform: 'desktop', data: status('latest')})).toContain('대시보드');
+    });
+
+    test('mandatory 업데이트는 설치 전까지 차단하고 실제 결과를 버튼에 설명한다', () => {
+        const markup = renderGate({platform: 'desktop', data: status('mandatory')});
+
+        expect(markup).toContain('PC 앱 업데이트가 필요합니다');
+        expect(markup).toContain('현재 v0.5.4');
+        expect(markup).toContain('최신 정식 버전 v0.6.0');
+        expect(markup).toContain('업데이트하고 재시작');
+        expect(markup).toContain('inert=""');
         expect(routeRenderCount).toBe(1);
     });
 
-    test('실패한 재확인에 기존 mandatory 데이터가 남아 있어도 대시보드를 차단하지 않는다', () => {
+    test('새 확인 오류가 나도 cached mandatory 결과로 차단을 유지한다', () => {
         const markup = renderGate({
             platform: 'desktop',
-            data: {currentVersion: '0.5.4', availableVersion: '0.6.0', mandatory: true},
+            data: status('mandatory'),
             error: true,
         });
 
-        expect(markup).toContain('대시보드');
+        expect(markup).toContain('PC 앱 업데이트가 필요합니다');
+        expect(markup).toContain('inert=""');
         expect(routeRenderCount).toBe(1);
+    });
+
+    test.each([
+        ['downloading', '업데이트 다운로드 중'],
+        ['verifying', '업데이트 검증 중'],
+        ['installing', '업데이트 설치 중'],
+        ['restart-required', '재시작 준비 완료'],
+    ] as const)('%s 단계와 진행 상태를 표시한다', (updateStatus, label) => {
+        const markup = renderGate({
+            platform: 'desktop',
+            data: status(updateStatus, {
+                progress: {downloadedBytes: 50, totalBytes: 100},
+            }),
+        });
+
+        expect(markup).toContain(label);
+        expect(markup).toContain('<progress');
+        expect(markup).toContain('inert=""');
+    });
+
+    test('mandatory 실패는 요약과 재시도, 네트워크, 로그, 수동 설치 경로를 모두 제공한다', () => {
+        const markup = renderGate({platform: 'desktop', data: status('failed')});
+
+        expect(markup).toContain('업데이트를 완료하지 못했습니다');
+        expect(markup).toContain('설치 단계에서 실패했습니다');
+        expect(markup).toContain('업데이트 다시 시도');
+        expect(markup).toContain('인터넷 연결');
+        expect(markup).toContain('로그 폴더 열기');
+        expect(markup).toContain('수동 설치');
+        expect(markup).toContain(
+            'href="https://github.com/YangSiJun528/jungle-bell/releases/latest"',
+        );
+        expect(markup).toContain('inert=""');
+    });
+
+    test('이미 열린 대시보드는 뒤늦은 mandatory에서도 mount를 보존하고 overlay로 차단한다', () => {
+        expect(
+            desktopUpdateGateDecision({
+                desktop: true,
+                data: status('mandatory'),
+                queryPending: false,
+                queryError: false,
+            }),
+        ).toMatchObject({renderDashboard: true, blocked: true});
     });
 });

--- a/frontend/src/app/desktop-update-gate.tsx
+++ b/frontend/src/app/desktop-update-gate.tsx
@@ -1,17 +1,16 @@
-import {useMutation} from '@tanstack/react-query';
-import {Download} from 'lucide-react';
+import {useMutation, useQueryClient} from '@tanstack/react-query';
 import type {PropsWithChildren} from 'react';
 
 import jungleBellLogo from '@/assets/logo.png';
-import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
-import {Button} from '@/components/ui/button';
 
-import {useDashboardEnvironment} from './dashboard-context';
-import {useDesktopUpdateQuery} from './desktop-update-query';
+import {queryKeys, useDashboardEnvironment} from './dashboard-context';
+import {desktopUpdateGateDecision} from './desktop-update-gate-decision';
+import {DesktopUpdatePanel} from './desktop-update-panel';
+import {desktopUpdateInstallMutationKey, useDesktopUpdateQuery} from './desktop-update-query';
 
 function UpdateGateFrame({children}: PropsWithChildren) {
     return (
-        <main
+        <div
             className="grid min-h-svh place-items-center bg-background px-4 py-8 text-foreground"
             data-desktop-update-gate="true"
         >
@@ -29,53 +28,64 @@ function UpdateGateFrame({children}: PropsWithChildren) {
                 </header>
                 {children}
             </div>
-        </main>
+        </div>
     );
 }
 
 export function DesktopUpdateGate({children}: PropsWithChildren) {
     const {api} = useDashboardEnvironment();
-    const {desktop, update} = useDesktopUpdateQuery();
+    const client = useQueryClient();
+    const {desktop, installMutationPending, update} = useDesktopUpdateQuery();
     const install = useMutation({
+        mutationKey: desktopUpdateInstallMutationKey,
         mutationFn: () => api.installDesktopUpdate(),
-        onSuccess: () => update.refetch(),
+        onSettled: () => client.invalidateQueries({queryKey: queryKeys.desktopUpdate}),
+    });
+    // 로그 폴더 열기는 query-backed 애플리케이션 상태를 변경하지 않는다.
+    // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
+    const openLogs = useMutation({mutationFn: () => api.openLogFolder()});
+    const decision = desktopUpdateGateDecision({
+        desktop,
+        data: update.data,
+        queryPending: update.isPending,
+        queryError: update.isError,
     });
 
-    if (
-        !desktop ||
-        update.isPending ||
-        update.isError ||
-        !update.data?.mandatory ||
-        !update.data.availableVersion
-    ) {
-        return children;
-    }
+    if (!desktop) return children;
 
     return (
-        <UpdateGateFrame>
-            <Alert className="border-amber-500/25 bg-amber-500/10 text-amber-950 dark:text-amber-100">
-                <Download aria-hidden="true" />
-                <AlertTitle>PC 앱 업데이트가 필요합니다.</AlertTitle>
-                <AlertDescription>
-                    <p>
-                        현재 v{update.data.currentVersion}에서는 앱을 계속 사용할 수 없습니다. 최신
-                        정식 버전 v{update.data.availableVersion}으로 업데이트하세요.
-                    </p>
-                    {install.isError ? (
-                        <p className="text-destructive">
-                            업데이트를 설치하지 못했습니다. 잠시 후 다시 시도하세요.
-                        </p>
-                    ) : null}
-                    <Button
-                        className="mt-2"
-                        disabled={install.isPending}
-                        onClick={() => install.mutate()}
-                    >
-                        <Download aria-hidden="true" />
-                        {install.isPending ? '업데이트 중' : '지금 업데이트'}
-                    </Button>
-                </AlertDescription>
-            </Alert>
-        </UpdateGateFrame>
+        <>
+            {decision.renderDashboard ? (
+                <div
+                    inert={decision.blocked ? true : undefined}
+                    aria-hidden={decision.blocked || undefined}
+                    className={decision.blocked ? 'pointer-events-none select-none' : undefined}
+                    data-desktop-update-content="true"
+                >
+                    {children}
+                </div>
+            ) : null}
+            {decision.blocked ? (
+                <dialog
+                    open
+                    className="fixed inset-0 z-[100] m-0 h-full max-h-none w-full max-w-none overflow-y-auto border-0 bg-background p-0"
+                    aria-modal="true"
+                    aria-label="PC 앱 업데이트"
+                >
+                    <UpdateGateFrame>
+                        <DesktopUpdatePanel
+                            status={update.data}
+                            checkFailed={update.isError}
+                            installFailed={install.isError}
+                            installPending={install.isPending || installMutationPending}
+                            logFailed={openLogs.isError}
+                            onInstall={() => install.mutate()}
+                            onCheckAgain={() => void update.refetch()}
+                            onOpenLogs={() => openLogs.mutate()}
+                        />
+                    </UpdateGateFrame>
+                </dialog>
+            ) : null}
+        </>
     );
 }

--- a/frontend/src/app/desktop-update-later.ts
+++ b/frontend/src/app/desktop-update-later.ts
@@ -1,0 +1,45 @@
+import {isRecord} from '@/lib/object';
+
+const OPTIONAL_UPDATE_LATER_KEY = 'jungle-bell:desktop-update-later:v1';
+
+type UpdateDeferralStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+function sessionStorageOrNull(): UpdateDeferralStorage | null {
+    try {
+        return typeof window === 'undefined' ? null : window.sessionStorage;
+    } catch {
+        return null;
+    }
+}
+
+export function isOptionalDesktopUpdateDeferred(
+    version: string,
+    storage: UpdateDeferralStorage | null = sessionStorageOrNull(),
+): boolean {
+    if (!storage) return false;
+    try {
+        const raw = storage.getItem(OPTIONAL_UPDATE_LATER_KEY);
+        if (!raw) return false;
+        const value: unknown = JSON.parse(raw);
+        if (!isRecord(value)) return false;
+        return (
+            Object.keys(value).length === 2 &&
+            value.schemaVersion === 1 &&
+            value.version === version
+        );
+    } catch {
+        return false;
+    }
+}
+
+export function deferOptionalDesktopUpdate(
+    version: string,
+    storage: UpdateDeferralStorage | null = sessionStorageOrNull(),
+): void {
+    if (!storage) return;
+    try {
+        storage.setItem(OPTIONAL_UPDATE_LATER_KEY, JSON.stringify({schemaVersion: 1, version}));
+    } catch {
+        // 저장소가 막혀 있으면 안내를 숨기지 않는 안전한 기본값을 유지한다.
+    }
+}

--- a/frontend/src/app/desktop-update-notice.test.tsx
+++ b/frontend/src/app/desktop-update-notice.test.tsx
@@ -1,37 +1,47 @@
-import {readFileSync} from 'node:fs';
-
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, test, vi} from 'vitest';
 
+import type {DesktopUpdateStatus} from '@/platform/contracts';
+
+import {queryKeys} from './dashboard-context';
+import {deferOptionalDesktopUpdate, isOptionalDesktopUpdateDeferred} from './desktop-update-later';
 import {DesktopUpdateNotice} from './desktop-update-notice';
 
-const source = readFileSync(new URL('./desktop-update-notice.tsx', import.meta.url), 'utf8');
-const {environment, queryKeys} = vi.hoisted(() => ({
-    queryKeys: {
-        desktopUpdate: ['desktop-update'] as const,
-    },
+const {environment} = vi.hoisted(() => ({
     environment: {
         api: {
             checkDesktopUpdate: vi.fn<() => Promise<unknown>>(),
             installDesktopUpdate: vi.fn<() => Promise<void>>(),
+            openLogFolder: vi.fn<() => Promise<void>>(),
         },
         platform: {kind: 'desktop', capabilities: {desktopSettings: true}},
     },
 }));
 
-vi.mock('@/app/dashboard-context', () => ({
-    queryKeys,
+vi.mock('@/app/dashboard-context', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/app/dashboard-context')>()),
     useDashboardEnvironment: () => environment,
 }));
 
-function renderNotice(options: {availableVersion: string | null; mandatory?: boolean}): string {
-    const client = new QueryClient();
-    client.setQueryData(queryKeys.desktopUpdate, {
+function status(
+    updateStatus: DesktopUpdateStatus['status'],
+    overrides: Partial<DesktopUpdateStatus> = {},
+): DesktopUpdateStatus {
+    return {
         currentVersion: '0.5.0',
-        availableVersion: options.availableVersion,
-        mandatory: options.mandatory ?? false,
-    });
+        availableVersion: updateStatus === 'latest' ? null : '0.5.1',
+        status: updateStatus,
+        policy: updateStatus === 'latest' ? null : 'optional',
+        progress: null,
+        errorCode: updateStatus === 'failed' ? 'UPDATE_DOWNLOAD_FAILED' : null,
+        ...overrides,
+    };
+}
+
+function renderNotice(data: DesktopUpdateStatus): string {
+    const client = new QueryClient();
+    client.setQueryData(queryKeys.desktopUpdate, data);
     return renderToStaticMarkup(
         <QueryClientProvider client={client}>
             <DesktopUpdateNotice />
@@ -39,19 +49,76 @@ function renderNotice(options: {availableVersion: string | null; mandatory?: boo
     );
 }
 
-describe('DesktopUpdateNotice', () => {
-    test('일반 patch 업데이트가 있으면 설정과 무관하게 비차단 안내와 수동 설치 버튼을 표시한다', () => {
-        const markup = renderNotice({availableVersion: '0.5.1'});
+function memoryStorage() {
+    const values = new Map<string, string>();
+    return {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+    };
+}
 
-        expect(markup).toContain('업데이트가 필요합니다.');
+describe('DesktopUpdateNotice', () => {
+    test('optional 업데이트는 실제 결과 버튼과 나중에 정책을 표시한다', () => {
+        const markup = renderNotice(status('optional'));
+
+        expect(markup).toContain('Jungle Bell 업데이트가 있습니다');
         expect(markup).toContain('현재 v0.5.0');
         expect(markup).toContain('최신 v0.5.1');
-        expect(markup).toContain('지금 업데이트');
-        expect(source).toContain('api.installDesktopUpdate()');
+        expect(markup).toContain('업데이트하고 재시작');
+        expect(markup).toContain('나중에');
     });
 
-    test('최신 버전이거나 강제 업데이트면 일반 안내를 숨긴다', () => {
-        expect(renderNotice({availableVersion: null})).toBe('');
-        expect(renderNotice({availableVersion: '0.6.0', mandatory: true})).toBe('');
+    test('latest와 mandatory는 optional 안내를 숨긴다', () => {
+        expect(renderNotice(status('latest'))).toBe('');
+        expect(
+            renderNotice(status('mandatory', {policy: 'mandatory', availableVersion: '0.6.0'})),
+        ).toBe('');
+    });
+
+    test('optional 설치 중에도 다운로드 진행 상태를 유지한다', () => {
+        const markup = renderNotice(
+            status('downloading', {progress: {downloadedBytes: 25, totalBytes: 100}}),
+        );
+
+        expect(markup).toContain('업데이트 다운로드 중');
+        expect(markup).toContain('<progress');
+        expect(markup).toContain('25%');
+    });
+
+    test('optional 설치 실패도 복구 경로를 제공한다', () => {
+        const markup = renderNotice(status('failed'));
+
+        expect(markup).toContain('다운로드 단계에서 실패했습니다');
+        expect(markup).toContain('업데이트 다시 시도');
+        expect(markup).toContain('로그 폴더 열기');
+        expect(markup).toContain('수동 설치');
+    });
+
+    test('나중에는 같은 앱 세션의 같은 버전만 숨기고 새 버전은 다시 표시한다', () => {
+        const storage = memoryStorage();
+
+        expect(isOptionalDesktopUpdateDeferred('0.5.1', storage)).toBe(false);
+        deferOptionalDesktopUpdate('0.5.1', storage);
+        expect(isOptionalDesktopUpdateDeferred('0.5.1', storage)).toBe(true);
+        expect(isOptionalDesktopUpdateDeferred('0.5.2', storage)).toBe(false);
+    });
+
+    test('저장소가 막히거나 값이 손상되면 optional 안내를 숨기지 않는다', () => {
+        const blockedStorage = {
+            getItem: () => {
+                throw new Error('blocked');
+            },
+            setItem: () => {
+                throw new Error('blocked');
+            },
+        };
+        const malformedStorage = {
+            getItem: () => '{not-json',
+            setItem: vi.fn<(key: string, value: string) => void>(),
+        };
+
+        expect(isOptionalDesktopUpdateDeferred('0.5.1', blockedStorage)).toBe(false);
+        expect(isOptionalDesktopUpdateDeferred('0.5.1', malformedStorage)).toBe(false);
+        expect(() => deferOptionalDesktopUpdate('0.5.1', blockedStorage)).not.toThrow();
     });
 });

--- a/frontend/src/app/desktop-update-notice.tsx
+++ b/frontend/src/app/desktop-update-notice.tsx
@@ -1,49 +1,51 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
-import {Download} from 'lucide-react';
-
-import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
-import {Button} from '@/components/ui/button';
+import {useState} from 'react';
 
 import {queryKeys, useDashboardEnvironment} from './dashboard-context';
-import {useDesktopUpdateQuery} from './desktop-update-query';
+import {deferOptionalDesktopUpdate, isOptionalDesktopUpdateDeferred} from './desktop-update-later';
+import {DesktopUpdatePanel} from './desktop-update-panel';
+import {desktopUpdateInstallMutationKey, useDesktopUpdateQuery} from './desktop-update-query';
 
 export function DesktopUpdateNotice() {
     const {api} = useDashboardEnvironment();
     const client = useQueryClient();
-    const {desktop, update} = useDesktopUpdateQuery();
+    const {desktop, installMutationPending, update} = useDesktopUpdateQuery();
+    const [deferredVersion, setDeferredVersion] = useState<string | null>(null);
     const install = useMutation({
+        mutationKey: desktopUpdateInstallMutationKey,
         mutationFn: () => api.installDesktopUpdate(),
-        onSuccess: async () => {
-            await client.invalidateQueries({queryKey: queryKeys.desktopUpdate});
-        },
+        onSettled: () => client.invalidateQueries({queryKey: queryKeys.desktopUpdate}),
     });
+    // 로그 폴더 열기는 query-backed 애플리케이션 상태를 변경하지 않는다.
+    // react-doctor-disable-next-line react-doctor/query-mutation-missing-invalidation
+    const openLogs = useMutation({mutationFn: () => api.openLogFolder()});
+    const status = update.data;
+    const availableVersion = status?.availableVersion;
+    const optional =
+        desktop && status?.policy === 'optional' && typeof availableVersion === 'string';
+    const deferred =
+        optional &&
+        status.status === 'optional' &&
+        (deferredVersion === availableVersion || isOptionalDesktopUpdateDeferred(availableVersion));
 
-    if (!desktop || !update.data?.availableVersion || update.data.mandatory) return null;
+    if (!optional || deferred) return null;
 
     return (
-        <Alert className="mb-4 border-amber-500/50 bg-amber-500/10">
-            <Download aria-hidden="true" />
-            <AlertTitle>Jungle Bell 업데이트가 필요합니다.</AlertTitle>
-            <AlertDescription className="mt-1 gap-3 sm:flex sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                    <p>
-                        현재 v{update.data.currentVersion} · 최신 v{update.data.availableVersion}
-                    </p>
-                    {install.isError ? (
-                        <p className="mt-1 text-destructive">
-                            업데이트를 설치하지 못했습니다. 잠시 후 다시 시도하세요.
-                        </p>
-                    ) : null}
-                </div>
-                <Button
-                    size="sm"
-                    className="shrink-0"
-                    disabled={install.isPending}
-                    onClick={() => install.mutate()}
-                >
-                    {install.isPending ? '업데이트 중' : '지금 업데이트'}
-                </Button>
-            </AlertDescription>
-        </Alert>
+        <DesktopUpdatePanel
+            compact
+            status={status}
+            installFailed={install.isError}
+            installPending={install.isPending || installMutationPending}
+            logFailed={openLogs.isError}
+            onInstall={() => install.mutate()}
+            onCheckAgain={() => void update.refetch()}
+            onOpenLogs={() => openLogs.mutate()}
+            onLater={() => {
+                const version = status.availableVersion;
+                if (!version) return;
+                deferOptionalDesktopUpdate(version);
+                setDeferredVersion(version);
+            }}
+        />
     );
 }

--- a/frontend/src/app/desktop-update-panel.tsx
+++ b/frontend/src/app/desktop-update-panel.tsx
@@ -1,0 +1,194 @@
+import {Download, ExternalLink, RefreshCw, ScrollText} from 'lucide-react';
+
+import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
+import {Button} from '@/components/ui/button';
+import type {DesktopUpdateStatus} from '@/platform/contracts';
+
+const RELEASE_URL = 'https://github.com/YangSiJun528/jungle-bell/releases/latest';
+
+interface DesktopUpdatePanelProps {
+    status: DesktopUpdateStatus | undefined;
+    checkFailed?: boolean;
+    installFailed?: boolean;
+    installPending: boolean;
+    logFailed: boolean;
+    compact?: boolean;
+    onInstall: () => void;
+    onCheckAgain: () => void;
+    onOpenLogs: () => void;
+    onLater?: () => void;
+}
+
+function failureSummary(errorCode: string | null | undefined): string {
+    switch (errorCode) {
+        case 'UPDATER_UNAVAILABLE':
+            return '업데이트 서비스를 시작하지 못했습니다.';
+        case 'UPDATE_CHECK_FAILED':
+            return '최신 버전 확인 단계에서 실패했습니다.';
+        case 'UPDATE_DOWNLOAD_FAILED':
+            return '다운로드 단계에서 실패했습니다.';
+        case 'UPDATE_VERIFY_FAILED':
+            return '서명 검증 단계에서 실패해 설치를 중단했습니다.';
+        case 'UPDATE_INSTALL_FAILED':
+            return '설치 단계에서 실패했습니다.';
+        case 'UPDATE_INSTALL_IN_PROGRESS':
+            return '다른 업데이트 작업이 이미 진행 중입니다.';
+        case 'UPDATE_STATE_SAVE_FAILED':
+            return '업데이트 재시도 상태를 저장하지 못했습니다.';
+        default:
+            return '업데이트 작업을 완료하지 못했습니다.';
+    }
+}
+
+function stageTitle(status: DesktopUpdateStatus | undefined, checkFailed: boolean): string {
+    if (!status) return checkFailed ? '업데이트를 확인하지 못했습니다' : '업데이트 확인 중';
+    const updateStatus = status.status;
+    switch (updateStatus) {
+        case 'checking':
+            return '업데이트 확인 중';
+        case 'latest':
+            return '최신 버전입니다';
+        case 'optional':
+            return 'Jungle Bell 업데이트가 있습니다';
+        case 'mandatory':
+            return 'PC 앱 업데이트가 필요합니다';
+        case 'downloading':
+            return '업데이트 다운로드 중';
+        case 'verifying':
+            return '업데이트 검증 중';
+        case 'installing':
+            return '업데이트 설치 중';
+        case 'restart-required':
+            return '재시작 준비 완료';
+        case 'failed':
+            return '업데이트를 완료하지 못했습니다';
+        default: {
+            const exhaustive: never = updateStatus;
+            return exhaustive;
+        }
+    }
+}
+
+function UpdateProgress({status}: {status: DesktopUpdateStatus | undefined}) {
+    const active =
+        !status ||
+        ['checking', 'downloading', 'verifying', 'installing', 'restart-required'].includes(
+            status.status,
+        );
+    if (!active) return null;
+    const progress = status?.progress;
+    const totalBytes = progress?.totalBytes;
+    const downloadedBytes = progress?.downloadedBytes ?? 0;
+    const determinate = typeof totalBytes === 'number';
+    const complete = status?.status === 'restart-required';
+    const value = complete ? 1 : determinate ? downloadedBytes : undefined;
+    const max = complete ? 1 : determinate ? totalBytes : undefined;
+    const percent =
+        determinate && totalBytes > 0
+            ? Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+            : null;
+    return (
+        <output className="mt-3 block w-full space-y-1" aria-live="polite">
+            <progress
+                className="h-2 w-full accent-primary"
+                aria-label={stageTitle(status, false)}
+                value={value}
+                max={max}
+            />
+            {percent !== null && status?.status === 'downloading' ? (
+                <p>{percent}% 다운로드됨</p>
+            ) : null}
+        </output>
+    );
+}
+
+export function DesktopUpdatePanel({
+    status,
+    checkFailed = false,
+    installFailed = false,
+    installPending,
+    logFailed,
+    compact = false,
+    onInstall,
+    onCheckAgain,
+    onOpenLogs,
+    onLater,
+}: DesktopUpdatePanelProps) {
+    const failed = checkFailed || installFailed || status?.status === 'failed';
+    const hasRelease = status?.availableVersion !== null && status?.availableVersion !== undefined;
+    const ready = status?.status === 'optional' || status?.status === 'mandatory';
+    const retryInstall = failed && hasRelease;
+
+    return (
+        <Alert
+            role={failed ? 'alert' : 'status'}
+            aria-live={failed ? 'assertive' : 'polite'}
+            className={compact ? 'mb-4 border-amber-500/50 bg-amber-500/10' : undefined}
+        >
+            <Download aria-hidden="true" />
+            <AlertTitle>{stageTitle(status, checkFailed)}</AlertTitle>
+            <AlertDescription className="mt-1 w-full gap-3">
+                {hasRelease ? (
+                    <p>
+                        현재 v{status.currentVersion} ·{' '}
+                        {status.policy === 'mandatory' ? '최신 정식 버전' : '최신'} v
+                        {status.availableVersion}
+                    </p>
+                ) : (
+                    <p>안전한 실행을 위해 PC 앱의 최신 호환 버전을 확인하고 있습니다.</p>
+                )}
+                {failed ? (
+                    <div className="space-y-1">
+                        <p className="font-medium text-destructive">
+                            {failureSummary(
+                                checkFailed ? 'UPDATE_CHECK_FAILED' : status?.errorCode,
+                            )}
+                        </p>
+                        <p>인터넷 연결을 확인한 뒤 다시 시도하세요.</p>
+                    </div>
+                ) : null}
+                {failed ? null : <UpdateProgress status={status} />}
+                <div className="flex flex-wrap gap-2 pt-1">
+                    {ready || retryInstall ? (
+                        <Button disabled={installPending} onClick={onInstall}>
+                            {retryInstall ? (
+                                <RefreshCw aria-hidden="true" />
+                            ) : (
+                                <Download aria-hidden="true" />
+                            )}
+                            {retryInstall ? '업데이트 다시 시도' : '업데이트하고 재시작'}
+                        </Button>
+                    ) : null}
+                    {failed && !hasRelease ? (
+                        <Button disabled={installPending} onClick={onCheckAgain}>
+                            <RefreshCw aria-hidden="true" />
+                            다시 확인
+                        </Button>
+                    ) : null}
+                    {onLater && status?.status === 'optional' ? (
+                        <Button variant="outline" onClick={onLater}>
+                            나중에
+                        </Button>
+                    ) : null}
+                    {failed ? (
+                        <>
+                            <Button variant="outline" onClick={onOpenLogs}>
+                                <ScrollText aria-hidden="true" />
+                                로그 폴더 열기
+                            </Button>
+                            <Button variant="outline" asChild>
+                                <a href={RELEASE_URL} target="_blank" rel="noopener noreferrer">
+                                    <ExternalLink aria-hidden="true" />
+                                    릴리스에서 수동 설치
+                                </a>
+                            </Button>
+                        </>
+                    ) : null}
+                </div>
+                {logFailed ? (
+                    <p className="text-destructive">로그 폴더를 열지 못했습니다.</p>
+                ) : null}
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/frontend/src/app/desktop-update-query.test.ts
+++ b/frontend/src/app/desktop-update-query.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, test} from 'vitest';
+
+import {desktopUpdatePollInterval} from './desktop-update-query';
+
+describe('desktopUpdatePollInterval', () => {
+    test.each(['checking', 'downloading', 'verifying', 'installing'] as const)(
+        '%s 상태는 로컬 snapshot을 빠르게 polling한다',
+        (status) => {
+            expect(desktopUpdatePollInterval(status, false)).toBe(250);
+        },
+    );
+
+    test('mutation 시작 직후와 정적 상태의 polling 주기를 구분한다', () => {
+        expect(desktopUpdatePollInterval('mandatory', true)).toBe(250);
+        expect(desktopUpdatePollInterval('optional', false)).toBe(60_000);
+        expect(desktopUpdatePollInterval(undefined, false)).toBe(60_000);
+    });
+});

--- a/frontend/src/app/desktop-update-query.ts
+++ b/frontend/src/app/desktop-update-query.ts
@@ -1,20 +1,43 @@
-import {useQuery} from '@tanstack/react-query';
+import {useIsMutating, useQuery} from '@tanstack/react-query';
+
+import type {UpdateStatus} from '@/platform/status-model';
 
 import {queryKeys, useDashboardEnvironment} from './dashboard-context';
 
 // 원격 endpoint 갱신은 Rust coordinator가 시간당 한 번 수행한다. UI는 로컬
 // IPC cache만 짧게 polling해 새 상태를 늦지 않게 표시한다.
 const UPDATE_STATUS_POLL_INTERVAL_MS = 60 * 1_000;
+const ACTIVE_UPDATE_POLL_INTERVAL_MS = 250;
+const ACTIVE_UPDATE_STATUSES: ReadonlySet<UpdateStatus> = new Set([
+    'checking',
+    'downloading',
+    'verifying',
+    'installing',
+]);
+
+export const desktopUpdateInstallMutationKey = ['desktop-update', 'install'] as const;
+
+export function desktopUpdatePollInterval(
+    status: UpdateStatus | undefined,
+    installMutationPending: boolean,
+): number {
+    return installMutationPending || (status !== undefined && ACTIVE_UPDATE_STATUSES.has(status))
+        ? ACTIVE_UPDATE_POLL_INTERVAL_MS
+        : UPDATE_STATUS_POLL_INTERVAL_MS;
+}
 
 export function useDesktopUpdateQuery() {
     const {api, platform} = useDashboardEnvironment();
     const desktop = platform.kind === 'desktop' && platform.capabilities.desktopSettings;
+    const installMutationPending =
+        useIsMutating({mutationKey: desktopUpdateInstallMutationKey}) > 0;
     const update = useQuery({
         queryKey: queryKeys.desktopUpdate,
         queryFn: () => api.checkDesktopUpdate(),
         enabled: desktop,
         staleTime: UPDATE_STATUS_POLL_INTERVAL_MS,
-        refetchInterval: UPDATE_STATUS_POLL_INTERVAL_MS,
+        refetchInterval: (query) =>
+            desktopUpdatePollInterval(query.state.data?.status, installMutationPending),
     });
-    return {desktop, update};
+    return {desktop, installMutationPending, update};
 }

--- a/frontend/src/platform/contracts.ts
+++ b/frontend/src/platform/contracts.ts
@@ -1,3 +1,5 @@
+import type {UpdateState, UpdateStatus} from './status-model';
+
 export type PlatformKind = 'browser' | 'desktop';
 
 export interface PlatformCapabilities {
@@ -78,11 +80,20 @@ export type DesktopSettingsUpdate = Pick<
     'autoStart' | 'usageAnalytics' | 'debugMode' | 'selectedCohortId'
 >;
 
-export interface DesktopUpdateStatus {
+export type DesktopUpdatePolicy = Extract<UpdateStatus, 'optional' | 'mandatory'>;
+
+export interface DesktopUpdateProgress {
+    downloadedBytes: number;
+    totalBytes: number | null;
+}
+
+export type DesktopUpdateStatus = UpdateState & {
     currentVersion: string;
     availableVersion: string | null;
-    mandatory: boolean;
-}
+    policy: DesktopUpdatePolicy | null;
+    progress: DesktopUpdateProgress | null;
+    errorCode: string | null;
+};
 
 export interface DesktopSettingsAdapter {
     getDesktopSettings(): Promise<DesktopSettings>;

--- a/frontend/src/platform/tauri/desktop-settings.test.ts
+++ b/frontend/src/platform/tauri/desktop-settings.test.ts
@@ -60,20 +60,22 @@ describe('desktop settings adapter', () => {
 });
 
 describe('desktop update adapter', () => {
-    test('parses the exact update status and installs through the native bridge', async () => {
+    test('단계와 policy, 진행률을 포함한 exact 상태를 파싱하고 native 설치를 호출한다', async () => {
+        const updateStatus = {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'downloading',
+            policy: 'mandatory',
+            progress: {downloadedBytes: 25, totalBytes: 100},
+            errorCode: null,
+        };
         const invoke = vi.fn<NativeInvoke>(async (command) => {
-            if (command === 'check_desktop_update') {
-                return {currentVersion: '0.5.0', availableVersion: '0.6.0', mandatory: true};
-            }
+            if (command === 'check_desktop_update') return updateStatus;
             return null;
         });
         const api = createDashboardDesktopSettingsApi(createNativeBridge(invoke));
 
-        await expect(api.checkDesktopUpdate()).resolves.toEqual({
-            currentVersion: '0.5.0',
-            availableVersion: '0.6.0',
-            mandatory: true,
-        });
+        await expect(api.checkDesktopUpdate()).resolves.toEqual(updateStatus);
         await expect(api.installDesktopUpdate()).resolves.toBeUndefined();
         await expect(api.openSystemNotificationSettings()).resolves.toBeUndefined();
         expect(invoke.mock.calls).toEqual([
@@ -84,11 +86,109 @@ describe('desktop update adapter', () => {
     });
 
     test.each([
-        {currentVersion: '0.5.0', availableVersion: null},
-        {currentVersion: '0.5.0', availableVersion: 'latest', mandatory: false},
-        {currentVersion: '0.5.0', availableVersion: null, mandatory: false, extra: true},
-        {currentVersion: '0.5.0', availableVersion: null, mandatory: 'false'},
-        {currentVersion: '0.5.0', availableVersion: null, mandatory: true},
+        {
+            currentVersion: '0.6.0',
+            availableVersion: null,
+            status: 'latest',
+            policy: null,
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.5.1',
+            status: 'optional',
+            policy: 'optional',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'mandatory',
+            policy: 'mandatory',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'failed',
+            policy: 'mandatory',
+            progress: {downloadedBytes: 10, totalBytes: null},
+            errorCode: 'UPDATE_VERIFY_FAILED',
+        },
+    ])('상태 조합을 손실 없이 파싱한다: $status', async (value) => {
+        const api = createDashboardDesktopSettingsApi(createNativeBridge(async () => value));
+        await expect(api.checkDesktopUpdate()).resolves.toEqual(value);
+    });
+
+    test.each([
+        {
+            currentVersion: '0.5.0',
+            availableVersion: null,
+            status: 'latest',
+            policy: null,
+            progress: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: 'latest',
+            status: 'mandatory',
+            policy: 'mandatory',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: null,
+            status: 'latest',
+            policy: null,
+            progress: null,
+            errorCode: null,
+            extra: true,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'mandatory',
+            policy: 'optional',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: null,
+            status: 'mandatory',
+            policy: 'mandatory',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'downloading',
+            policy: 'mandatory',
+            progress: {downloadedBytes: 101, totalBytes: 100},
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'failed',
+            policy: 'mandatory',
+            progress: null,
+            errorCode: null,
+        },
+        {
+            currentVersion: '0.5.0',
+            availableVersion: '0.6.0',
+            status: 'mandatory',
+            policy: 'mandatory',
+            progress: null,
+            errorCode: null,
+            mandatory: true,
+        },
     ])('rejects malformed update status %#', async (value) => {
         const api = createDashboardDesktopSettingsApi(createNativeBridge(async () => value));
         await expect(api.checkDesktopUpdate()).rejects.toThrow('API_RESPONSE_INVALID');

--- a/frontend/src/platform/tauri/desktop-settings.ts
+++ b/frontend/src/platform/tauri/desktop-settings.ts
@@ -7,6 +7,7 @@ import type {
     DesktopUpdateStatus,
     NativeBridge,
 } from '@/platform/contracts';
+import {isUpdateState} from '@/platform/status-model';
 
 const APP_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/u;
 
@@ -56,33 +57,110 @@ export function createDashboardDesktopSettingsApi(
 function parseDesktopUpdateStatus(value: unknown): DesktopUpdateStatus {
     if (!isRecord(value)) throw invalidResponse();
     const source = value;
-    const keys = ['currentVersion', 'availableVersion', 'mandatory'] as const;
+    const keys = [
+        'currentVersion',
+        'availableVersion',
+        'status',
+        'policy',
+        'progress',
+        'errorCode',
+    ] as const;
     if (Object.keys(source).length !== keys.length || keys.some((key) => !hasOwn(source, key))) {
         throw invalidResponse();
     }
-    if (
-        typeof source.currentVersion !== 'string' ||
-        !APP_VERSION_PATTERN.test(source.currentVersion)
-    ) {
+    const currentVersion = source.currentVersion;
+    const availableVersion = source.availableVersion;
+    if (typeof currentVersion !== 'string' || !APP_VERSION_PATTERN.test(currentVersion)) {
         throw invalidResponse();
     }
     if (
-        source.availableVersion !== null &&
-        (typeof source.availableVersion !== 'string' ||
-            !APP_VERSION_PATTERN.test(source.availableVersion))
+        availableVersion !== null &&
+        (typeof availableVersion !== 'string' || !APP_VERSION_PATTERN.test(availableVersion))
     ) {
         throw invalidResponse();
     }
-    if (
-        typeof source.mandatory !== 'boolean' ||
-        (source.mandatory && source.availableVersion === null)
-    )
+    const updateState = {status: source.status};
+    if (!isUpdateState(updateState)) throw invalidResponse();
+    const status = updateState.status;
+    const policy = source.policy;
+    if (policy !== null && policy !== 'optional' && policy !== 'mandatory') {
         throw invalidResponse();
+    }
+    const progress = parseDesktopUpdateProgress(source.progress);
+    const errorCode = source.errorCode;
+    if (
+        errorCode !== null &&
+        (typeof errorCode !== 'string' || !/^[A-Z][A-Z0-9_]{2,63}$/u.test(errorCode))
+    ) {
+        throw invalidResponse();
+    }
+    const hasRelease = availableVersion !== null && policy !== null;
+    const hasNoRelease = availableVersion === null && policy === null;
+    if (!hasRelease && !hasNoRelease) throw invalidResponse();
+    switch (status) {
+        case 'latest':
+            if (!hasNoRelease || progress !== null || errorCode !== null) throw invalidResponse();
+            break;
+        case 'optional':
+        case 'mandatory':
+            if (policy !== status || progress !== null || errorCode !== null) {
+                throw invalidResponse();
+            }
+            break;
+        case 'checking':
+            if (progress !== null || errorCode !== null) throw invalidResponse();
+            break;
+        case 'downloading':
+            if (!hasRelease || progress === null || errorCode !== null) throw invalidResponse();
+            break;
+        case 'verifying':
+        case 'installing':
+        case 'restart-required':
+            if (!hasRelease || progress === null || errorCode !== null) throw invalidResponse();
+            break;
+        case 'failed':
+            if (errorCode === null) throw invalidResponse();
+            break;
+        default:
+            return invalidUpdateStatus(status);
+    }
     return {
-        currentVersion: source.currentVersion,
-        availableVersion: source.availableVersion,
-        mandatory: source.mandatory,
+        currentVersion,
+        availableVersion,
+        status,
+        policy,
+        progress,
+        errorCode,
     };
+}
+
+function invalidUpdateStatus(status: never): never {
+    void status;
+    throw invalidResponse();
+}
+
+function parseDesktopUpdateProgress(value: unknown): DesktopUpdateStatus['progress'] {
+    if (value === null) return null;
+    if (!isRecord(value)) throw invalidResponse();
+    const keys = ['downloadedBytes', 'totalBytes'] as const;
+    if (Object.keys(value).length !== keys.length || keys.some((key) => !hasOwn(value, key))) {
+        throw invalidResponse();
+    }
+    const downloadedBytes = value.downloadedBytes;
+    const totalBytes = value.totalBytes;
+    if (
+        typeof downloadedBytes !== 'number' ||
+        !Number.isSafeInteger(downloadedBytes) ||
+        downloadedBytes < 0 ||
+        (totalBytes !== null &&
+            (typeof totalBytes !== 'number' ||
+                !Number.isSafeInteger(totalBytes) ||
+                totalBytes < 0 ||
+                downloadedBytes > totalBytes))
+    ) {
+        throw invalidResponse();
+    }
+    return {downloadedBytes, totalBytes};
 }
 
 function parseDesktopSettings(value: unknown): DesktopSettings {


### PR DESCRIPTION
# 요약

PC mandatory 업데이트의 fail-open을 막고 진행·실패·복구 흐름을 완성합니다.

- cached mandatory 정책 보존과 blocking overlay
- 다운로드·검증·설치·재시작 상태/진행률
- 재시도·로그·수동 설치·optional 나중에 정책

# 스택

2/9, base: `codex/issue-69-01-state-model`

# 검증

- 독립 worktree: 성공
- `npm run check`: 105개 파일, 566개 테스트 통과
- `npm run verify:desktop`: Rust 단위 236개·통합 2개 통과

Refs #69
