### PR TITLE
[stack 4/9] feat(ui): 반응형 셸과 KRDS 조작성 개선

### DIFF
--- a/frontend/src/app/shell/DashboardFooter.tsx
+++ b/frontend/src/app/shell/DashboardFooter.tsx
@@ -11,7 +11,7 @@ function ExternalFooterLink({href, children}: {href: string; children: string}) 
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            className="inline-flex min-h-(--hit-area-min) items-center gap-1 rounded-sm font-medium text-foreground underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
             {children}
             <ExternalLink className="size-3.5" aria-hidden="true" />
@@ -21,7 +21,7 @@ function ExternalFooterLink({href, children}: {href: string; children: string}) 
 
 export function DashboardFooter() {
     return (
-        <footer className="mx-auto mt-auto w-full max-w-6xl px-3 pt-12 pb-28 sm:px-4 md:px-5 md:pb-8 lg:px-6">
+        <footer className="mx-auto mt-auto w-full max-w-6xl pt-12 pr-[max(var(--dashboard-inline-gutter),var(--safe-area-right))] pb-[calc(var(--dashboard-mobile-navigation-height)+var(--safe-area-bottom)+1rem)] pl-[max(var(--dashboard-inline-gutter),var(--safe-area-left))] lg:pb-8">
             <div className="border-t pt-6 text-sm text-muted-foreground">
                 <nav className="flex flex-wrap gap-x-5 gap-y-3" aria-label="프로젝트 정보">
                     <ExternalFooterLink href={PROJECT_URL}>GitHub</ExternalFooterLink>
@@ -29,7 +29,7 @@ export function DashboardFooter() {
                     <ExternalFooterLink href={RELEASE_URL}>릴리즈</ExternalFooterLink>
                     <Link
                         to="/privacy"
-                        className="rounded-sm font-medium text-foreground underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                        className="inline-flex min-h-(--hit-area-min) items-center rounded-sm font-medium text-foreground underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
                     >
                         개인정보 처리방침
                     </Link>

--- a/frontend/src/app/shell/DashboardShell.tsx
+++ b/frontend/src/app/shell/DashboardShell.tsx
@@ -92,7 +92,7 @@ function SidebarNavigationItem({route, activeRoute}: NavigationItemProps) {
                 asChild
                 isActive={active}
                 tooltip={meta.label}
-                className="h-10 gap-3 rounded-lg px-3 text-sidebar-foreground/70"
+                className="h-auto min-h-(--control-height) gap-3 rounded-lg px-3 text-sidebar-foreground/70 lg:h-10 lg:min-h-10"
             >
                 <Link
                     to={dashboardRoutePath(route)}
@@ -148,7 +148,7 @@ function SidebarNotificationItem({
                         setOpenMobile(false);
                     }}
                     className={cn(
-                        'h-10 gap-3 rounded-lg px-3',
+                        'h-auto min-h-(--control-height) gap-3 rounded-lg px-3 lg:h-10 lg:min-h-10',
                         hasUnread ? 'pr-10' : undefined,
                         hasUnread && !open
                             ? 'text-primary hover:text-primary'
@@ -187,7 +187,7 @@ function BottomNavigationItem({route, activeRoute}: NavigationItemProps) {
             aria-label={meta.label}
             data-dashboard-route={route}
             className={cn(
-                'relative flex min-w-0 flex-col items-center justify-center gap-1 rounded-lg px-1 py-1.5',
+                'relative flex min-h-(--control-height-lg) min-w-0 flex-col items-center justify-center gap-1 rounded-lg px-1 py-1.5',
                 'text-xs leading-none font-medium transition-colors',
                 'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
                 active
@@ -195,6 +195,13 @@ function BottomNavigationItem({route, activeRoute}: NavigationItemProps) {
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
             )}
         >
+            {active ? (
+                <span
+                    data-active-indicator="true"
+                    aria-hidden="true"
+                    className="absolute inset-x-4 top-0 h-0.5 rounded-full bg-current"
+                />
+            ) : null}
             <Icon
                 className="size-[1.125rem]"
                 aria-hidden="true"
@@ -270,15 +277,15 @@ function ShellTopSpacer({
 
     return (
         <div
-            className="flex h-14 shrink-0 items-center gap-2 px-3 sm:h-16 sm:px-4 md:px-5 lg:px-6"
+            className="flex min-h-[calc(3.5rem+var(--safe-area-top))] shrink-0 items-center gap-2 pt-(--safe-area-top) pr-[max(var(--dashboard-inline-gutter),var(--safe-area-right))] pl-[max(var(--dashboard-inline-gutter),var(--safe-area-left))] sm:min-h-[calc(4rem+var(--safe-area-top))]"
             data-shell-top-spacer="true"
         >
             <SidebarTrigger
                 aria-label="사이드바 메뉴 열기"
                 title="사이드바 메뉴 열기"
-                className="bg-background md:hidden"
+                className="bg-background lg:hidden"
             />
-            <div className="ml-auto flex items-center gap-2 md:hidden">
+            <div className="ml-auto flex items-center gap-2 lg:hidden">
                 <SheetTrigger asChild>
                     <Button
                         variant={notificationPanelOpen ? 'secondary' : 'outline'}
@@ -326,9 +333,10 @@ function DashboardBottomNavigation({
 }) {
     return (
         <nav
-            className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/96 px-2 pt-1.5 pb-[calc(env(safe-area-inset-bottom)+0.375rem)] backdrop-blur supports-[backdrop-filter]:bg-background/88 md:hidden"
+            className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/96 pt-1.5 pr-[max(0.5rem,var(--safe-area-right))] pb-[calc(var(--safe-area-bottom)+0.375rem)] pl-[max(0.5rem,var(--safe-area-left))] backdrop-blur supports-[backdrop-filter]:bg-background/88 lg:hidden"
             aria-label="모바일 메뉴"
             data-navigation-group="primary"
+            data-mobile-navigation="true"
         >
             <div
                 className="mx-auto grid max-w-lg gap-1"
@@ -380,7 +388,7 @@ export function DashboardShell({
             >
                 <button
                     type="button"
-                    className="sr-only fixed top-3 left-3 z-[100] rounded-md bg-background px-3 py-2 text-sm font-medium shadow-lg focus:not-sr-only"
+                    className="sr-only fixed top-[max(0.75rem,var(--safe-area-top))] left-[max(0.75rem,var(--safe-area-left))] z-[100] min-h-(--hit-area-min) min-w-(--hit-area-min) rounded-md bg-background px-3 py-2 text-sm font-medium shadow-lg focus:not-sr-only"
                     onClick={() => document.getElementById('dashboard-content')?.focus()}
                 >
                     본문 바로가기
@@ -445,7 +453,10 @@ export function DashboardShell({
                         hasUnreadNotifications={hasUnreadNotifications}
                         notificationAriaLabel={notificationAriaLabel}
                     />
-                    <div className="mx-auto w-full max-w-6xl p-3 sm:p-4 md:p-5 lg:p-6">
+                    <div
+                        className="mx-auto w-full max-w-6xl py-4 pr-[max(var(--dashboard-inline-gutter),var(--safe-area-right))] pl-[max(var(--dashboard-inline-gutter),var(--safe-area-left))] md:py-6"
+                        data-shell-content="true"
+                    >
                         {children}
                     </div>
                     <DashboardFooter />

--- a/frontend/src/app/styles/globals.css
+++ b/frontend/src/app/styles/globals.css
@@ -14,6 +14,15 @@
 :root {
     color-scheme: light;
     --radius: 0.75rem;
+    --hit-area-min: 2.75rem;
+    --control-height: 3rem;
+    --control-height-lg: 3.5rem;
+    --dashboard-inline-gutter: 1rem;
+    --dashboard-mobile-navigation-height: 5rem;
+    --safe-area-top: env(safe-area-inset-top, 0px);
+    --safe-area-right: env(safe-area-inset-right, 0px);
+    --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-area-left: env(safe-area-inset-left, 0px);
     --background: oklch(0.972 0.009 145);
     --foreground: oklch(0.23 0.017 145);
     --card: oklch(0.995 0.004 145);
@@ -45,6 +54,18 @@
     --sidebar-accent-foreground: oklch(0.35 0.09 148);
     --sidebar-border: oklch(0.9 0.012 145);
     --sidebar-ring: oklch(0.52 0.11 148);
+}
+
+@media (min-width: 40rem) {
+    :root {
+        --dashboard-inline-gutter: 1.25rem;
+    }
+}
+
+@media (min-width: 48rem) {
+    :root {
+        --dashboard-inline-gutter: 1.5rem;
+    }
 }
 
 .dark {
@@ -123,8 +144,21 @@
     }
 
     html {
-        min-width: 320px;
+        min-width: min(320px, 100%);
+        max-width: 100%;
+        overflow-x: clip;
+        scroll-padding-bottom: calc(
+            var(--dashboard-mobile-navigation-height) + var(--safe-area-bottom) + 1rem
+        );
         background: var(--background);
+    }
+
+    body,
+    #root {
+        min-height: 100svh;
+        min-height: 100dvh;
+        max-width: 100%;
+        overflow-x: clip;
     }
 
     body {
@@ -132,10 +166,30 @@
         margin: 0;
     }
 
+    :where(
+        [data-slot='button'],
+        [data-slot='input'],
+        [data-slot='select-trigger'],
+        [data-slot='tabs-trigger'],
+        [data-slot='calendar'],
+        [data-slot='switch-row'],
+        [role='alert'],
+        [role='status']
+    ) {
+        scroll-margin-block: 1rem
+            calc(var(--dashboard-mobile-navigation-height) + var(--safe-area-bottom) + 1rem);
+    }
+
     button,
     a,
     input,
     select {
         -webkit-tap-highlight-color: transparent;
+    }
+}
+
+@media (min-width: 64rem) {
+    html {
+        scroll-padding-bottom: 1rem;
     }
 }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -44,7 +44,7 @@ function AlertDialogContent({
             <AlertDialogPrimitive.Content
                 data-slot="alert-dialog-content"
                 className={cn(
-                    'fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+                    'fixed top-1/2 right-[max(1rem,var(--safe-area-right))] left-[max(1rem,var(--safe-area-left))] z-50 mx-auto grid max-h-[calc(100dvh-2rem-var(--safe-area-top)-var(--safe-area-bottom))] w-auto max-w-lg -translate-y-1/2 gap-4 overflow-y-auto overscroll-contain rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
                     className,
                 )}
                 {...props}

--- a/frontend/src/components/ui/alert.test.tsx
+++ b/frontend/src/components/ui/alert.test.tsx
@@ -1,0 +1,24 @@
+import {createElement} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, test} from 'vitest';
+
+import {Alert} from './alert';
+
+describe('Alert live-region semantics', () => {
+    test('static guidance is not announced as an urgent alert by default', () => {
+        const markup = renderToStaticMarkup(createElement(Alert, null, '안내'));
+
+        expect(markup).not.toContain('role="alert"');
+        expect(markup).not.toContain('role="status"');
+    });
+
+    test('destructive feedback is urgent and callers can select a polite status', () => {
+        const errorMarkup = renderToStaticMarkup(
+            createElement(Alert, {variant: 'destructive'}, '오류'),
+        );
+        const statusMarkup = renderToStaticMarkup(createElement(Alert, {role: 'status'}, '완료'));
+
+        expect(errorMarkup).toContain('role="alert"');
+        expect(statusMarkup).toContain('role="status"');
+    });
+});

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {cn} from '@/lib/utils';
 
 const alertVariants = cva(
-    'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+    'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-base leading-6 has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-1 [&>svg]:text-current',
     {
         variants: {
             variant: {
@@ -21,13 +21,14 @@ const alertVariants = cva(
 
 function Alert({
     className,
-    variant,
+    variant = 'default',
+    role,
     ...props
 }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
     return (
         <div
             data-slot="alert"
-            role="alert"
+            role={role ?? (variant === 'destructive' ? 'alert' : undefined)}
             className={cn(alertVariants({variant}), className)}
             {...props}
         />
@@ -49,7 +50,7 @@ function AlertDescription({className, ...props}: React.ComponentProps<'div'>) {
         <div
             data-slot="alert-description"
             className={cn(
-                'col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed',
+                'col-start-2 grid justify-items-start gap-1 text-base leading-6 text-muted-foreground [&_p]:leading-relaxed',
                 className,
             )}
             {...props}

--- a/frontend/src/components/ui/button-variants.ts
+++ b/frontend/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import {cva} from 'class-variance-authority';
 
 export const buttonVariants = cva(
-    "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+    "inline-flex min-h-(--hit-area-min) min-w-(--hit-area-min) shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
     {
         variants: {
             variant: {
@@ -15,14 +15,14 @@ export const buttonVariants = cva(
                 link: 'text-primary underline-offset-4 hover:underline',
             },
             size: {
-                default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-                xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-                sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
-                lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-                icon: 'size-9',
-                'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-                'icon-sm': 'size-8',
-                'icon-lg': 'size-10',
+                default: 'h-(--control-height) px-4 py-2 has-[>svg]:px-3',
+                xs: "h-(--hit-area-min) gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+                sm: 'h-(--hit-area-min) gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+                lg: 'h-(--control-height-lg) rounded-md px-6 has-[>svg]:px-4',
+                icon: 'size-(--control-height)',
+                'icon-xs': "size-(--hit-area-min) rounded-md [&_svg:not([class*='size-'])]:size-3",
+                'icon-sm': 'size-(--hit-area-min)',
+                'icon-lg': 'size-(--control-height-lg)',
             },
         },
         defaultVariants: {

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -26,7 +26,7 @@ function Calendar({
         <DayPicker
             showOutsideDays={showOutsideDays}
             className={cn(
-                'group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+                'group/calendar max-w-full overflow-x-auto bg-background p-3 [--cell-size:var(--control-height)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
                 String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
                 String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
                 className,
@@ -37,7 +37,7 @@ function Calendar({
                 ...formatters,
             }}
             classNames={{
-                root: cn('w-fit', defaultClassNames.root),
+                root: cn('w-full max-w-full', defaultClassNames.root),
                 months: cn('relative flex flex-col gap-4 md:flex-row', defaultClassNames.months),
                 month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
                 nav: cn(
@@ -71,7 +71,7 @@ function Calendar({
                     'font-medium select-none',
                     captionLayout === 'label'
                         ? 'text-sm'
-                        : 'flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
+                        : 'flex h-(--control-height) items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
                     defaultClassNames.caption_label,
                 ),
                 month_grid: cn('w-full border-collapse', defaultClassNames.month_grid),

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({className, type, ...props}: React.ComponentProps<'input'>) {
             type={type}
             data-slot="input"
             className={cn(
-                'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
+                'h-(--control-height) w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-(--hit-area-min) file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30',
                 'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
                 'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
                 className,

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -29,7 +29,7 @@ function SelectTrigger({
             data-slot="select-trigger"
             data-size={size}
             className={cn(
-                "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+                "flex min-w-(--hit-area-min) items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-base whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-(--control-height) data-[size=sm]:h-(--hit-area-min) *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
                 className,
             )}
             {...props}
@@ -98,7 +98,7 @@ function SelectItem({
         <SelectPrimitive.Item
             data-slot="select-item"
             className={cn(
-                "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+                "relative flex min-h-(--hit-area-min) w-full cursor-default items-center gap-2 rounded-sm py-2 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
                 className,
             )}
             {...props}
@@ -136,7 +136,10 @@ function SelectScrollUpButton({
     return (
         <SelectPrimitive.ScrollUpButton
             data-slot="select-scroll-up-button"
-            className={cn('flex cursor-default items-center justify-center py-1', className)}
+            className={cn(
+                'flex min-h-(--hit-area-min) cursor-default items-center justify-center py-1',
+                className,
+            )}
             {...props}
         >
             <ChevronUpIcon className="size-4" />
@@ -151,7 +154,10 @@ function SelectScrollDownButton({
     return (
         <SelectPrimitive.ScrollDownButton
             data-slot="select-scroll-down-button"
-            className={cn('flex cursor-default items-center justify-center py-1', className)}
+            className={cn(
+                'flex min-h-(--hit-area-min) cursor-default items-center justify-center py-1',
+                className,
+            )}
             {...props}
         >
             <ChevronDownIcon className="size-4" />

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -53,24 +53,24 @@ function SheetContent({
             <SheetPrimitive.Content
                 data-slot="sheet-content"
                 className={cn(
-                    'fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500',
+                    'fixed z-50 flex max-h-dvh flex-col gap-4 overflow-y-auto overscroll-contain bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500',
                     side === 'right' &&
-                        'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+                        'inset-y-0 right-0 h-dvh w-3/4 border-l pt-(--safe-area-top) pr-(--safe-area-right) pb-(--safe-area-bottom) data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
                     side === 'left' &&
-                        'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+                        'inset-y-0 left-0 h-dvh w-3/4 border-r pt-(--safe-area-top) pb-(--safe-area-bottom) pl-(--safe-area-left) data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
                     side === 'top' &&
-                        'inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+                        'inset-x-0 top-0 h-auto border-b pt-(--safe-area-top) pr-(--safe-area-right) pl-(--safe-area-left) data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
                     side === 'bottom' &&
-                        'inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+                        'inset-x-0 bottom-0 h-auto border-t pr-(--safe-area-right) pb-(--safe-area-bottom) pl-(--safe-area-left) data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
                     className,
                 )}
                 {...props}
             >
                 {children}
                 {showCloseButton && (
-                    <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+                    <SheetPrimitive.Close className="absolute top-[max(1rem,var(--safe-area-top))] right-[max(1rem,var(--safe-area-right))] inline-flex size-(--hit-area-min) items-center justify-center rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
                         <XIcon className="size-4" />
-                        <span className="sr-only">Close</span>
+                        <span className="sr-only">닫기</span>
                     </SheetPrimitive.Close>
                 )}
             </SheetPrimitive.Content>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -236,7 +236,10 @@ function Sidebar({
                     data-sidebar="sidebar"
                     data-slot="sidebar"
                     data-mobile="true"
-                    className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+                    className={cn(
+                        'w-(--sidebar-width) max-w-full bg-sidebar p-0 pt-(--safe-area-top) pb-(--safe-area-bottom) text-sidebar-foreground [&>button]:hidden',
+                        side === 'left' ? 'pl-(--safe-area-left)' : 'pr-(--safe-area-right)',
+                    )}
                     style={MOBILE_SIDEBAR_STYLE}
                     side={side}
                 >
@@ -252,7 +255,7 @@ function Sidebar({
 
     return (
         <div
-            className="group peer hidden text-sidebar-foreground md:block"
+            className="group peer hidden text-sidebar-foreground lg:block"
             data-state={state}
             data-collapsible={state === 'collapsed' ? collapsible : ''}
             data-variant={variant}
@@ -274,7 +277,7 @@ function Sidebar({
             <div
                 data-slot="sidebar-container"
                 className={cn(
-                    'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear group-data-[sidebar-resizing=true]/sidebar-wrapper:transition-none md:flex',
+                    'fixed inset-y-0 z-10 hidden h-dvh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear group-data-[sidebar-resizing=true]/sidebar-wrapper:transition-none lg:flex',
                     side === 'left'
                         ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
                         : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -307,7 +310,7 @@ function SidebarTrigger({className, onClick, ...props}: React.ComponentProps<typ
             data-slot="sidebar-trigger"
             variant="ghost"
             size="icon"
-            className={cn('size-7', className)}
+            className={cn('size-(--control-height) lg:size-10', className)}
             onClick={(event) => {
                 onClick?.(event);
                 toggleSidebar();
@@ -503,7 +506,7 @@ function SidebarRail({
             }}
             title={resizable ? '드래그해 크기 조절 · 클릭해 전환' : '사이드바 전환'}
             className={cn(
-                'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex',
+                'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border lg:flex',
                 resizable
                     ? 'cursor-col-resize touch-none'
                     : 'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
@@ -524,7 +527,7 @@ function SidebarInset({className, ...props}: React.ComponentProps<'main'>) {
             data-slot="sidebar-inset"
             className={cn(
                 'relative flex w-full flex-1 flex-col bg-background',
-                'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+                'lg:peer-data-[variant=inset]:m-2 lg:peer-data-[variant=inset]:ml-0 lg:peer-data-[variant=inset]:rounded-xl lg:peer-data-[variant=inset]:shadow-sm lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
                 className,
             )}
             {...props}
@@ -537,7 +540,7 @@ function SidebarInput({className, ...props}: React.ComponentProps<typeof Input>)
         <Input
             data-slot="sidebar-input"
             data-sidebar="input"
-            className={cn('h-8 w-full bg-background shadow-none', className)}
+            className={cn('h-(--control-height) w-full bg-background shadow-none', className)}
             {...props}
         />
     );
@@ -636,7 +639,7 @@ function SidebarGroupAction({
             className={cn(
                 'absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
                 // Increases the hit area of the button on mobile.
-                'after:absolute after:-inset-2 md:after:hidden',
+                'after:absolute after:-inset-3 lg:after:hidden',
                 'group-data-[collapsible=icon]:hidden',
                 className,
             )}
@@ -679,7 +682,7 @@ function SidebarMenuItem({className, ...props}: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+    'peer/menu-button flex min-h-(--hit-area-min) w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:min-h-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
     {
         variants: {
             variant: {
@@ -688,8 +691,8 @@ const sidebarMenuButtonVariants = cva(
                     'bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
             },
             size: {
-                default: 'h-8 text-sm',
-                sm: 'h-7 text-xs',
+                default: 'h-(--hit-area-min) text-sm',
+                sm: 'h-(--hit-area-min) text-xs',
                 lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
             },
         },
@@ -768,13 +771,13 @@ function SidebarMenuAction({
             className={cn(
                 'absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
                 // Increases the hit area of the button on mobile.
-                'after:absolute after:-inset-2 md:after:hidden',
+                'after:absolute after:-inset-3 lg:after:hidden',
                 'peer-data-[size=sm]/menu-button:top-1',
                 'peer-data-[size=default]/menu-button:top-1.5',
                 'peer-data-[size=lg]/menu-button:top-2.5',
                 'group-data-[collapsible=icon]:hidden',
                 showOnHover &&
-                    'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0',
+                    'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 lg:opacity-0',
                 className,
             )}
             {...props}
@@ -873,7 +876,7 @@ function SidebarMenuSubButton({
             data-size={size}
             data-active={isActive}
             className={cn(
-                'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+                'flex min-h-(--hit-area-min) min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 lg:min-h-7 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
                 'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
                 size === 'sm' && 'text-xs',
                 size === 'md' && 'text-sm',

--- a/frontend/src/components/ui/switch.test.tsx
+++ b/frontend/src/components/ui/switch.test.tsx
@@ -1,0 +1,25 @@
+import {createElement} from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, test} from 'vitest';
+
+import {SwitchRow} from './switch';
+
+describe('SwitchRow', () => {
+    test('exposes a full-row label with an accessible description', () => {
+        const markup = renderToStaticMarkup(
+            createElement(SwitchRow, {
+                checked: false,
+                description: '브라우저에 저장됩니다.',
+                label: '사용량 통계 허용',
+                onCheckedChange: () => undefined,
+            }),
+        );
+
+        expect(markup).toContain('data-slot="switch-row"');
+        expect(markup).toContain('<label');
+        expect(markup).toContain('사용량 통계 허용');
+        expect(markup).toContain('브라우저에 저장됩니다.');
+        expect(markup).toMatch(/role="switch"[^>]+aria-labelledby=/u);
+        expect(markup).toMatch(/role="switch"[^>]+aria-describedby=/u);
+    });
+});

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -5,19 +5,17 @@ import * as React from 'react';
 
 import {cn} from '@/lib/utils';
 
-function Switch({
-    className,
-    size = 'default',
-    ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+type SwitchProps = React.ComponentProps<typeof SwitchPrimitive.Root> & {
     size?: 'sm' | 'default';
-}) {
+};
+
+function Switch({className, size = 'default', ...props}: SwitchProps) {
     return (
         <SwitchPrimitive.Root
             data-slot="switch"
             data-size={size}
             className={cn(
-                'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
+                "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:top-1/2 after:left-1/2 after:size-(--hit-area-min) after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-6 data-[size=default]:w-11 data-[size=sm]:h-5 data-[size=sm]:w-9 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
                 className,
             )}
             {...props}
@@ -25,11 +23,63 @@ function Switch({
             <SwitchPrimitive.Thumb
                 data-slot="switch-thumb"
                 className={cn(
-                    'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
+                    'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-5 group-data-[size=sm]/switch:size-4 data-[state=checked]:translate-x-5 group-data-[size=sm]/switch:data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
                 )}
             />
         </SwitchPrimitive.Root>
     );
 }
 
-export {Switch};
+type SwitchRowProps = Omit<
+    SwitchProps,
+    'aria-describedby' | 'aria-label' | 'aria-labelledby' | 'className'
+> & {
+    label: React.ReactNode;
+    description?: React.ReactNode;
+    className?: string;
+    switchClassName?: string;
+};
+
+function SwitchRow({
+    label,
+    description,
+    className,
+    switchClassName,
+    ...switchProps
+}: SwitchRowProps) {
+    const labelId = React.useId();
+    const descriptionId = React.useId();
+
+    return (
+        <label
+            data-slot="switch-row"
+            className={cn(
+                'flex min-h-(--control-height-lg) cursor-pointer items-center justify-between gap-4 rounded-md py-2 has-[button:disabled]:cursor-not-allowed has-[button:disabled]:opacity-60',
+                className,
+            )}
+        >
+            <span className="min-w-0">
+                <span id={labelId} className="block text-base font-medium">
+                    {label}
+                </span>
+                {description ? (
+                    <span
+                        id={descriptionId}
+                        className="mt-1 block text-sm leading-5 text-muted-foreground"
+                    >
+                        {description}
+                    </span>
+                ) : null}
+            </span>
+            <Switch
+                aria-labelledby={labelId}
+                aria-describedby={description ? descriptionId : undefined}
+                className={switchClassName}
+                {...switchProps}
+            />
+        </label>
+    );
+}
+
+export {Switch, SwitchRow};
+export type {SwitchProps, SwitchRowProps};

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -20,7 +20,7 @@ function TabsList({className, ...props}: React.ComponentProps<typeof TabsPrimiti
         <TabsPrimitive.List
             data-slot="tabs-list"
             className={cn(
-                'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+                'inline-flex min-h-(--control-height-lg) max-w-full items-center justify-start overflow-x-auto rounded-lg bg-muted p-1 text-muted-foreground sm:w-fit',
                 className,
             )}
             {...props}
@@ -33,7 +33,7 @@ function TabsTrigger({className, ...props}: React.ComponentProps<typeof TabsPrim
         <TabsPrimitive.Trigger
             data-slot="tabs-trigger"
             className={cn(
-                'inline-flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-3 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-xs',
+                'inline-flex h-(--control-height) min-w-(--hit-area-min) flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-3 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-xs',
                 className,
             )}
             {...props}

--- a/frontend/src/hooks/use-mobile.test.ts
+++ b/frontend/src/hooks/use-mobile.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, test} from 'vitest';
+
+import {DESKTOP_SHELL_BREAKPOINT, isMobileViewportWidth} from './use-mobile';
+
+describe('dashboard shell viewport contract', () => {
+    test('expanded sidebar starts at 1024 CSS px', () => {
+        expect(DESKTOP_SHELL_BREAKPOINT).toBe(1024);
+    });
+
+    test.each([
+        [320, true],
+        [390, true],
+        [760, true],
+        [768, true],
+        [1023, true],
+        [1024, false],
+        [1440, false],
+    ] as const)('%dpx uses the expected shell', (width, expectedMobileShell) => {
+        expect(isMobileViewportWidth(width)).toBe(expectedMobileShell);
+    });
+});

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -1,15 +1,21 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+export const DESKTOP_SHELL_BREAKPOINT = 1024;
+
+const MOBILE_MEDIA_QUERY = `(max-width: ${DESKTOP_SHELL_BREAKPOINT - 1}px)`;
+
+export function isMobileViewportWidth(viewportWidth: number): boolean {
+    return viewportWidth < DESKTOP_SHELL_BREAKPOINT;
+}
 
 function subscribeToViewport(onStoreChange: () => void): () => void {
-    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY);
     mediaQuery.addEventListener('change', onStoreChange);
     return () => mediaQuery.removeEventListener('change', onStoreChange);
 }
 
 function mobileViewportSnapshot(): boolean {
-    return window.innerWidth < MOBILE_BREAKPOINT;
+    return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
 }
 
 function serverMobileViewportSnapshot(): boolean {

--- a/frontend/src/tests/contracts/dashboard-ui.test.ts
+++ b/frontend/src/tests/contracts/dashboard-ui.test.ts
@@ -107,7 +107,7 @@ test('브라우저와 데스크톱은 동일한 SPA 경로 정책을 사용한�
     assert.match(shell, /<SidebarFooter className="border-t border-sidebar-border">/);
     assert.match(shell, /aria-label="개인 도구"/);
     assert.match(shell, /data-navigation-group="utilities"/);
-    assert.match(shell, /md:hidden[\s\S]*aria-label=\{notificationAriaLabel/);
+    assert.match(shell, /lg:hidden[\s\S]*aria-label=\{notificationAriaLabel/);
     assert.match(shell, /aria-label="설정"/);
     assert.match(shell, /aria-haspopup="dialog"/);
     assert.match(shell, /overlayClassName="backdrop-blur-sm"/);

--- a/frontend/src/tests/contracts/design-system.test.ts
+++ b/frontend/src/tests/contracts/design-system.test.ts
@@ -140,6 +140,37 @@ test('공통 상호작용 컴포넌트는 키보드 포커스와 비활성 상�
     assert.match(source('./app/shell/DashboardShell.tsx'), /focus-visible:ring-2/);
 });
 
+test('KRDS 조작 크기는 44px hit area와 48~56px 주요 control 토큰을 공유한다', () => {
+    assert.match(globals, /--hit-area-min:\s*2\.75rem/);
+    assert.match(globals, /--control-height:\s*3rem/);
+    assert.match(globals, /--control-height-lg:\s*3\.5rem/);
+
+    const contracts = [
+        ['./components/ui/button-variants.ts', /--control-height/],
+        ['./components/ui/input.tsx', /--control-height/],
+        ['./components/ui/select.tsx', /--control-height/],
+        ['./components/ui/tabs.tsx', /--control-height/],
+        ['./components/ui/calendar.tsx', /--control-height/],
+        ['./components/ui/switch.tsx', /--hit-area-min/],
+    ] as const;
+    for (const [path, contract] of contracts) {
+        assert.match(source(path), contract, `${path}가 KRDS control 토큰을 사용하지 않습니다.`);
+    }
+
+    const switchComponent = source('./components/ui/switch.tsx');
+    assert.match(switchComponent, /function SwitchRow\(/);
+    assert.match(switchComponent, /data-slot="switch-row"/);
+    assert.match(switchComponent, /<label/);
+});
+
+test('정적 Alert는 긴급 live region이 아니며 오류와 비긴급 상태를 구분할 수 있다', () => {
+    const alert = source('./components/ui/alert.tsx');
+
+    assert.doesNotMatch(alert, /role="alert"/);
+    assert.match(alert, /variant === 'destructive' \? 'alert' : undefined/);
+    assert.match(alert, /role=\{role \?\?/);
+});
+
 test('README 트레이 아이콘은 런타임과 같이 나침반 바깥의 배경 박스를 채운다', () => {
     for (const status of ['normal', 'offline', 'warning', 'alert', 'complete']) {
         const icon = source(`../../docs/assets/readme/readme-status-${status}.svg`);

--- a/frontend/src/tests/contracts/layout-contract.test.ts
+++ b/frontend/src/tests/contracts/layout-contract.test.ts
@@ -8,6 +8,12 @@ const source = (path: string) => readFileSync(new URL(path, srcRoot), 'utf8');
 const dashboard = source('../index.html');
 const app = source('./app/dashboard-app.tsx');
 const shell = source('./app/shell/DashboardShell.tsx');
+const footer = source('./app/shell/DashboardFooter.tsx');
+const globals = source('./app/styles/globals.css');
+const mobileHook = source('./hooks/use-mobile.ts');
+const sidebar = source('./components/ui/sidebar.tsx');
+const sheet = source('./components/ui/sheet.tsx');
+const alertDialog = source('./components/ui/alert-dialog.tsx');
 const routes = source('./app/routes.ts');
 
 test('HTML 문서는 레이아웃을 복제하지 않고 React 셸을 위한 단일 mount만 제공한다', () => {
@@ -32,7 +38,7 @@ test('모든 기능 경로는 하나의 DashboardShell과 main 콘텐츠 영역�
     assert.equal((shell.match(/id="dashboard-content"/g) ?? []).length, 1);
 });
 
-test('사이드바는 shadcn 접기·모바일 Sheet와 데스크톱 Rail 크기 조절을 사용한다', () => {
+test('사이드바는 1024px부터 shadcn 접기·데스크톱 Rail 크기 조절을 사용한다', () => {
     assert.match(shell, /<SidebarProvider[\s\S]{0,160}\bresizable/);
     assert.match(shell, /<Sidebar[\s\S]{0,120}collapsible="icon"/);
     assert.match(shell, /<SidebarTrigger[\s\S]{0,100}aria-label="사이드바 메뉴 열기"/);
@@ -46,26 +52,48 @@ test('사이드바는 shadcn 접기·모바일 Sheet와 데스크톱 Rail 크기
     assert.equal(existsSync(new URL('./app/sidebar-width.test.ts', srcRoot)), false);
     assert.doesNotMatch(shell, /<header\b/);
     assert.match(shell, /data-shell-top-spacer="true"/);
-    assert.match(shell, /h-14[\s\S]{0,120}sm:h-16/);
+    assert.match(shell, /min-h-\[calc\(3\.5rem\+var\(--safe-area-top\)\)\]/);
+    assert.match(shell, /sm:min-h-\[calc\(4rem\+var\(--safe-area-top\)\)\]/);
     assert.match(shell, /max-w-6xl/);
-    assert.match(shell, /md:p-5[\s\S]*lg:p-6/);
+    assert.match(mobileHook, /DESKTOP_SHELL_BREAKPOINT\s*=\s*1024/);
+    assert.doesNotMatch(sidebar, /\bmd:(?:block|flex)/);
+    assert.match(sidebar, /\blg:block/);
+    assert.match(sidebar, /\blg:flex/);
 });
 
-test('모바일은 safe-area를 반영한 하단 내비게이션과 충분한 본문 여백을 사용한다', () => {
+test('320~1023px 셸은 네 방향 safe-area와 하단 내비게이션 여유 공간을 사용한다', () => {
     assert.match(shell, /fixed inset-x-0 bottom-0 z-40/);
-    assert.match(shell, /pb-\[calc\(env\(safe-area-inset-bottom\)\+0\.375rem\)\]/);
-    assert.match(shell, /md:hidden/);
+    assert.match(shell, /lg:hidden/);
     assert.match(
         shell,
         /style=\{\{gridTemplateColumns: `repeat\(\$\{routes\.length\}, minmax\(0, 1fr\)\)`\}\}/,
     );
-    assert.match(shell, /p-3[\s\S]*sm:p-4[\s\S]*md:p-5[\s\S]*lg:p-6/);
     assert.match(shell, /max-w-lg/);
+    assert.match(shell, /data-mobile-navigation="true"/);
+    assert.match(shell, /data-shell-content="true"/);
+
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+        assert.match(
+            globals,
+            new RegExp(`safe-area-inset-${side}`),
+            `${side} safe-area 환경 변수 계약이 없습니다.`,
+        );
+        assert.match(
+            `${shell}\n${footer}`,
+            new RegExp(`var\\(--safe-area-${side}\\)`),
+            `${side} safe-area가 셸에 적용되지 않았습니다.`,
+        );
+    }
+
+    assert.match(footer, /--dashboard-mobile-navigation-height/);
+    assert.match(footer, /lg:pb-8/);
+    assert.match(globals, /min-height:\s*100dvh/);
+    assert.match(globals, /min-width:\s*min\(320px, 100%\)/);
+    assert.match(globals, /scroll-padding-bottom:/);
+    assert.match(globals, /overflow-x:\s*clip/);
 });
 
 test('공통 푸터는 외부 링크와 모바일 하단 메뉴 여백만 제공한다', () => {
-    const footer = source('./app/shell/DashboardFooter.tsx');
-
     assert.match(shell, /<DashboardFooter\s*\/>/);
     assert.match(footer, /<footer\b/);
     assert.match(footer, /max-w-6xl/);
@@ -75,7 +103,43 @@ test('공통 푸터는 외부 링크와 모바일 하단 메뉴 여백만 제공
     assert.doesNotMatch(footer, /\/discussions(?:\/|\b)/);
     assert.match(footer, /피드백 남기기/);
     assert.match(footer, /릴리즈/);
-    assert.match(footer, /pb-28[\s\S]{0,160}md:pb-8/);
+    assert.match(footer, /lg:pb-8/);
+});
+
+test('지원 viewport 계약은 clipping 없이 760px에서 768px로 본문 폭이 역전되지 않는다', () => {
+    const viewportWidths = [320, 390, 760, 768, 1023, 1024, 1440] as const;
+    const pageGutter = (width: number) => (width >= 768 ? 24 : width >= 640 ? 20 : 16);
+    const sidebarWidth = (width: number) => (width >= 1024 ? 256 : 0);
+    const contentWidth = (width: number) => width - sidebarWidth(width) - pageGutter(width) * 2;
+
+    for (const width of viewportWidths) {
+        assert.ok(contentWidth(width) > 0, `${width}px에서 본문 폭이 사라집니다.`);
+        assert.ok(contentWidth(width) <= width, `${width}px에서 페이지 가로 overflow가 납니다.`);
+    }
+
+    assert.ok(contentWidth(768) >= contentWidth(760));
+    assert.match(globals, /--dashboard-inline-gutter:\s*1rem/);
+    assert.match(globals, /min-width:\s*40rem[\s\S]*--dashboard-inline-gutter:\s*1\.25rem/);
+    assert.match(globals, /min-width:\s*48rem[\s\S]*--dashboard-inline-gutter:\s*1\.5rem/);
+});
+
+test('200% 확대·landscape·키보드 축소에서도 overlay와 CTA는 동적 viewport 안에서 스크롤된다', () => {
+    assert.match(globals, /min-height:\s*100svh[\s\S]*min-height:\s*100dvh/);
+    assert.match(globals, /scroll-padding-bottom:/);
+    assert.match(globals, /scroll-margin-block:/);
+    assert.match(sheet, /max-h-dvh[\s\S]*overflow-y-auto[\s\S]*overscroll-contain/);
+    assert.match(sheet, /h-dvh/);
+    assert.match(
+        alertDialog,
+        /max-h-\[calc\(100dvh-2rem-var\(--safe-area-top\)-var\(--safe-area-bottom\)\)\]/,
+    );
+    assert.match(alertDialog, /overflow-y-auto/);
+});
+
+test('하단 내비게이션 현재 위치는 aria-current와 비색상 indicator를 함께 제공한다', () => {
+    assert.match(shell, /aria-current=\{active \? 'page' : undefined\}/);
+    assert.match(shell, /data-active-indicator="true"/);
+    assert.match(shell, /aria-hidden="true"/);
 });
 
 test('브라우저와 데스크톱은 4개 주요 메뉴와 보조 기능을 공유한다', () => {
@@ -95,7 +159,7 @@ test('브라우저와 데스크톱은 4개 주요 메뉴와 보조 기능을 공
     assert.match(shell, /aria-label="설정"/);
     assert.match(shell, /aria-haspopup="dialog"/);
     assert.match(shell, /overlayClassName="backdrop-blur-sm"/);
-    assert.match(shell, /md:hidden/);
+    assert.match(shell, /lg:hidden/);
     assert.match(shell, /<Link to=\{dashboardRoutePath\('connections'\)\}>/);
 });
 


### PR DESCRIPTION
# 요약

768px layout cliff를 제거하고 KRDS 기준의 조작 영역·safe area·선택 표시를 적용합니다.

- 확장 sidebar 기준을 1024px로 조정
- 44/48/56px 상호작용 토큰
- 모바일 safe area와 색상 외 현재 위치 indicator

# 스택

4/9, base: `codex/issue-69-03-access-gates`

# 검증

- 독립 worktree: 성공
- `npm run check`: 106개 파일, 553개 테스트 통과
- React Doctor: 100점

Refs #69
