### PR TITLE
[stack 5/9] refactor(ui): 홈·설치 정보 위계 개선

### DIFF
--- a/frontend/src/components/app-showcase/app-showcase-card.test.ts
+++ b/frontend/src/components/app-showcase/app-showcase-card.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {
+    appShowcaseDismissed,
+    dismissAppShowcase,
+    HOME_INSTALL_PROMOTION_DISMISSED_KEY,
+} from './app-showcase-dismissal';
+
+describe('home install promotion dismissal', () => {
+    it('현재 브라우저 세션에서 닫은 안내를 다시 표시하지 않는다', () => {
+        const storage = {
+            getItem: vi.fn<(key: string) => string | null>(() => 'dismissed'),
+            setItem: vi.fn<(key: string, value: string) => void>(),
+        };
+
+        expect(appShowcaseDismissed(storage)).toBe(true);
+        dismissAppShowcase(storage);
+        expect(storage.setItem).toHaveBeenCalledWith(
+            HOME_INSTALL_PROMOTION_DISMISSED_KEY,
+            'dismissed',
+        );
+    });
+
+    it('저장소 접근이 차단되면 안내를 표시하고 닫기 동작은 계속 허용한다', () => {
+        const storage = {
+            getItem: vi.fn<(key: string) => string | null>(() => {
+                throw new Error('blocked');
+            }),
+            setItem: vi.fn<(key: string, value: string) => void>(() => {
+                throw new Error('blocked');
+            }),
+        };
+
+        expect(appShowcaseDismissed(storage)).toBe(false);
+        expect(() => dismissAppShowcase(storage)).not.toThrow();
+    });
+});

--- a/frontend/src/components/app-showcase/app-showcase-card.tsx
+++ b/frontend/src/components/app-showcase/app-showcase-card.tsx
@@ -1,29 +1,63 @@
 import {Link} from '@tanstack/react-router';
-import {ArrowRight} from 'lucide-react';
+import {ArrowRight, X} from 'lucide-react';
+import {useState} from 'react';
 
 import {Button} from '@/components/ui/button';
 import {Card} from '@/components/ui/card';
 
+import {
+    appShowcaseDismissed,
+    dismissAppShowcase,
+    type InstallPromotionStorage,
+} from './app-showcase-dismissal';
 import {DesktopAppMockup} from './desktop-app-mockup';
 import {MobileNotificationMockup} from './mobile-notification-mockup';
 
+function currentSessionStorage(): InstallPromotionStorage | undefined {
+    if (typeof window === 'undefined') return undefined;
+    try {
+        return window.sessionStorage;
+    } catch {
+        return undefined;
+    }
+}
+
 export function AppShowcaseCard() {
+    const [visible, setVisible] = useState(() => !appShowcaseDismissed(currentSessionStorage()));
+
+    if (!visible) return null;
+
+    const dismiss = () => {
+        dismissAppShowcase(currentSessionStorage());
+        setVisible(false);
+    };
+
     return (
         <Card
-            className="grid min-w-0 gap-0 overflow-hidden border-primary/15 py-0 shadow-[0_18px_48px_rgba(46,77,51,.08)] lg:grid-cols-[minmax(19rem,0.88fr)_minmax(28rem,1.12fr)]"
+            className="relative min-w-0 gap-0 overflow-hidden border-primary/15 py-0 shadow-[0_12px_32px_rgba(46,77,51,.07)]"
             data-app-showcase-card="true"
+            aria-labelledby="home-install-promotion-title"
         >
-            <div className="z-10 flex min-w-0 flex-col justify-center px-5 py-9 sm:px-8 sm:py-11 lg:px-10">
-                <h2 className="text-3xl leading-[1.17] font-bold tracking-[-0.045em] whitespace-nowrap sm:text-4xl lg:text-[clamp(1.5rem,calc(6.25vw_-_2.47rem),2.25rem)]">
-                    PC·모바일 앱을 설치해
-                    <br />
-                    <span className="text-primary">더 편리하게 사용하세요.</span>
-                </h2>
-                <p className="mt-5 max-w-xl text-sm leading-6 text-pretty text-muted-foreground sm:text-base sm:leading-7">
-                    출석 상태를 확인하고, 출석·식사·세탁 생활 알림과 앞으로 추가될 편의 기능까지
-                    이용할 수 있어요.
-                </p>
-                <Button asChild size="lg" className="mt-7 w-full sm:w-fit">
+            <div className="flex min-w-0 flex-col gap-4 p-4 pr-14 sm:flex-row sm:items-center sm:px-5 sm:py-4 lg:pr-52">
+                <div className="min-w-0 flex-1">
+                    <h2
+                        id="home-install-promotion-title"
+                        className="text-lg leading-6 font-bold tracking-[-0.025em] whitespace-normal sm:whitespace-nowrap"
+                    >
+                        PC·모바일 앱을 설치해
+                        <br />
+                        <span className="text-primary">더 편리하게 사용하세요.</span>
+                    </h2>
+                    <p className="mt-1.5 text-base leading-6 text-pretty text-muted-foreground">
+                        출석 상태를 확인하고, 출석·식사·세탁 생활 알림과 앞으로 추가될 편의 기능까지
+                        이용할 수 있어요.
+                    </p>
+                </div>
+
+                <Button
+                    asChild
+                    className="h-auto min-h-11 w-full min-w-0 px-4 py-2 whitespace-normal sm:w-auto"
+                >
                     <Link to="/install">
                         앱 안내 보기
                         <ArrowRight aria-hidden="true" />
@@ -31,16 +65,29 @@ export function AppShowcaseCard() {
                 </Button>
             </div>
 
-            <div className="relative min-h-[25rem] min-w-0 overflow-hidden bg-[#e6f0e3] sm:min-h-[29rem]">
+            <div
+                className="pointer-events-none absolute top-3 right-4 hidden h-24 w-40 gap-2 lg:flex"
+                aria-hidden="true"
+            >
                 <DesktopAppMockup
                     compact
-                    className="absolute top-12 left-[-6%] w-[78%] -rotate-[1.2deg] sm:left-[4%] sm:w-[70%]"
+                    className="h-24 min-h-24 w-24 flex-1 rounded-lg shadow-none"
                 />
                 <MobileNotificationMockup
                     phone
-                    className="absolute right-[-5%] bottom-[-2rem] w-[47%] rotate-[2deg] sm:right-[2%] sm:bottom-[-1rem] sm:w-[39%]"
+                    className="h-24 min-h-24 w-12 rounded-lg border-2 shadow-none"
                 />
             </div>
+
+            <Button
+                size="icon"
+                variant="ghost"
+                className="absolute top-1.5 right-1.5 size-11"
+                aria-label="설치 안내 닫기"
+                onClick={dismiss}
+            >
+                <X aria-hidden="true" className="size-4" />
+            </Button>
         </Card>
     );
 }

--- a/frontend/src/components/app-showcase/app-showcase-dismissal.ts
+++ b/frontend/src/components/app-showcase/app-showcase-dismissal.ts
@@ -1,0 +1,24 @@
+export const HOME_INSTALL_PROMOTION_DISMISSED_KEY = 'jungle-bell:home-install-promotion-dismissed';
+
+export interface InstallPromotionStorage {
+    getItem(key: string): string | null;
+    setItem(key: string, value: string): void;
+}
+
+export function appShowcaseDismissed(storage?: InstallPromotionStorage): boolean {
+    if (!storage) return false;
+    try {
+        return storage.getItem(HOME_INSTALL_PROMOTION_DISMISSED_KEY) === 'dismissed';
+    } catch {
+        return false;
+    }
+}
+
+export function dismissAppShowcase(storage?: InstallPromotionStorage): void {
+    if (!storage) return;
+    try {
+        storage.setItem(HOME_INSTALL_PROMOTION_DISMISSED_KEY, 'dismissed');
+    } catch {
+        // Storage can be blocked in private browsing. The in-memory dismissal still works.
+    }
+}

--- a/frontend/src/features/app-install/app-install-page.test.ts
+++ b/frontend/src/features/app-install/app-install-page.test.ts
@@ -1,0 +1,31 @@
+import {readFileSync} from 'node:fs';
+
+import {describe, expect, it} from 'vitest';
+
+import {installStepOrder} from './install-step-order';
+
+describe('app install guidance order', () => {
+    it('PC에서는 설치·로그인부터 푸시 테스트까지 선행 조건 순서로 안내한다', () => {
+        expect(installStepOrder(false)).toEqual(['pc', 'pairing', 'pwa', 'push']);
+    });
+
+    it('모바일에서는 현재 수행할 PWA 설치를 먼저 보여 준다', () => {
+        expect(installStepOrder(true)).toEqual(['pwa', 'pc', 'pairing', 'push']);
+    });
+
+    it('필수 적용 범위와 QR·코드·수동 설치·푸시 테스트를 명시한다', () => {
+        const source = readFileSync(new URL('./app-install-page.tsx', import.meta.url), 'utf8');
+
+        for (const text of [
+            'PC 앱 설치·로그인',
+            'QR 또는 코드로 연결',
+            'PWA 설치',
+            '푸시 알림 테스트',
+            '출석·개인 알림에 필요',
+            '수동 설치 방법',
+        ]) {
+            expect(source).toContain(text);
+        }
+        expect(source).not.toContain('badge="필수"');
+    });
+});

--- a/frontend/src/features/app-install/app-install-page.tsx
+++ b/frontend/src/features/app-install/app-install-page.tsx
@@ -1,70 +1,95 @@
 import {Link} from '@tanstack/react-router';
 import {
     ArrowLeft,
+    BellRing,
     CircleAlert,
     Download,
     ExternalLink,
+    KeyRound,
     LoaderCircle,
     Monitor,
+    QrCode,
     RotateCcw,
     ShieldCheck,
     Smartphone,
     type LucideIcon,
 } from 'lucide-react';
-import {useEffect, type ReactNode} from 'react';
+import {useEffect, useState, type ReactNode} from 'react';
 
 import {DesktopAppMockup} from '@/components/app-showcase/desktop-app-mockup';
 import {MobileNotificationMockup} from '@/components/app-showcase/mobile-notification-mockup';
 import {PageHeader} from '@/components/dashboard/page-header';
 import {Button} from '@/components/ui/button';
 import {Card, CardContent, CardHeader} from '@/components/ui/card';
+import {isMobileInstallClient} from '@/platform/pwa/install-client';
+
+import {installStepOrder, type InstallStepId} from './install-step-order';
 
 const PC_INSTALL_GUIDE_URL = 'https://github.com/YangSiJun528/jungle-bell#%EC%84%A4%EC%B9%98';
 
 export type MobileInstallHandoffStatus = 'none' | 'preparing' | 'ready' | 'error';
 
+const INSTALL_STEP_DETAILS: Record<
+    InstallStepId,
+    {number: number; eyebrow: string; title: string; icon: LucideIcon}
+> = {
+    pc: {number: 1, eyebrow: 'PC에서 먼저', title: 'PC 앱 설치·로그인', icon: Monitor},
+    pairing: {number: 2, eyebrow: 'PC와 휴대폰 연결', title: 'QR 또는 코드로 연결', icon: QrCode},
+    pwa: {number: 3, eyebrow: '휴대폰에서', title: 'PWA 설치', icon: Smartphone},
+    push: {number: 4, eyebrow: '마지막 확인', title: '푸시 알림 테스트', icon: BellRing},
+};
+
+function currentClientIsMobile(): boolean {
+    return typeof navigator !== 'undefined' && isMobileInstallClient(navigator);
+}
+
 function scrollToGuide(id: 'pc-install' | 'mobile-install'): void {
     document.getElementById(id)?.scrollIntoView({behavior: 'smooth', block: 'start'});
 }
 
-function DeviceCard({
-    icon: Icon,
-    eyebrow,
-    title,
-    badge,
+function InstallStepCard({
+    id,
+    current,
     children,
-    action,
-    emphasized = false,
 }: {
-    icon: LucideIcon;
-    eyebrow: string;
-    title: string;
-    badge?: string;
+    id: InstallStepId;
+    current: boolean;
     children: ReactNode;
-    action: ReactNode;
-    emphasized?: boolean;
 }) {
+    const {number, eyebrow, title, icon: Icon} = INSTALL_STEP_DETAILS[id];
+    const elementId = id === 'pc' ? 'pc-install' : id === 'pwa' ? 'mobile-install' : `${id}-step`;
+
     return (
-        <Card className={emphasized ? 'gap-0 border-primary/30 py-0 shadow-lg' : 'gap-0 py-0'}>
-            <CardHeader className="flex-row items-center gap-3 px-5 py-5 sm:px-6">
-                <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
-                    <Icon aria-hidden="true" className="size-5" />
-                </span>
-                <div className="min-w-0 flex-1">
-                    <p className="text-xs font-semibold text-primary">{eyebrow}</p>
-                    <h3 className="text-xl font-bold tracking-tight">{title}</h3>
-                </div>
-                {badge ? (
-                    <span className="rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
-                        {badge}
-                    </span>
-                ) : null}
-            </CardHeader>
-            <CardContent className="flex flex-1 flex-col gap-4 px-5 pb-5 sm:px-6 sm:pb-6">
-                {children}
-                <div className="mt-auto">{action}</div>
-            </CardContent>
-        </Card>
+        <li
+            id={elementId}
+            className="min-w-0 scroll-mt-5"
+            aria-current={current ? 'step' : undefined}
+        >
+            <Card className={current ? 'gap-0 border-primary/35 py-0 shadow-md' : 'gap-0 py-0'}>
+                <CardHeader className="min-w-0 px-4 py-5 sm:px-6">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
+                            <Icon aria-hidden="true" className="size-5" />
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <p className="text-sm leading-5 font-semibold text-primary">
+                                {current ? '현재 단계 · ' : ''}
+                                {number}. {eyebrow}
+                            </p>
+                            <h2 className="mt-0.5 text-xl leading-7 font-bold tracking-tight break-words">
+                                {title}
+                            </h2>
+                            {id === 'pc' ? (
+                                <p className="mt-2 w-fit max-w-full rounded-full bg-primary/10 px-2.5 py-1 text-sm leading-5 font-semibold whitespace-normal text-primary">
+                                    출석·개인 알림에 필요
+                                </p>
+                            ) : null}
+                        </div>
+                    </div>
+                </CardHeader>
+                <CardContent className="min-w-0 px-4 pb-5 sm:px-6 sm:pb-6">{children}</CardContent>
+            </Card>
+        </li>
     );
 }
 
@@ -101,11 +126,11 @@ function MobileInstallHandoffNotice({status}: {status: MobileInstallHandoffStatu
 
     return (
         <div
-            className={`mt-4 flex items-start gap-2 rounded-lg p-3 text-sm ${content.className}`}
+            className={`mt-4 flex items-start gap-2 rounded-lg p-3 text-base ${content.className}`}
             aria-live="polite"
         >
             {content.icon}
-            <div>
+            <div className="min-w-0">
                 <strong className="block">{content.title}</strong>
                 <p className="mt-1 leading-5">{content.description}</p>
             </div>
@@ -115,14 +140,16 @@ function MobileInstallHandoffNotice({status}: {status: MobileInstallHandoffStatu
 
 function MobileInstallAction({
     status,
+    mobileClient,
     onRequestMobileInstall,
     onRetryMobileHandoff,
 }: {
     status: MobileInstallHandoffStatus;
+    mobileClient: boolean;
     onRequestMobileInstall?: () => void;
     onRetryMobileHandoff?: () => void;
 }) {
-    const className = 'mt-4 w-full shrink-0 sm:mt-0 sm:w-auto';
+    const className = 'min-h-11 w-full whitespace-normal sm:w-auto';
     if (status === 'preparing') {
         return (
             <Button className={className} variant="outline" disabled>
@@ -145,9 +172,19 @@ function MobileInstallAction({
     }
     if (onRequestMobileInstall) {
         return (
-            <Button className={className} variant="outline" onClick={onRequestMobileInstall}>
-                모바일 앱 설치 안내 열기
-                <Smartphone aria-hidden="true" />
+            <Button className={className} onClick={onRequestMobileInstall}>
+                PWA 설치 시작
+                <Download aria-hidden="true" />
+            </Button>
+        );
+    }
+    if (mobileClient) {
+        return (
+            <Button asChild className={className} variant="outline">
+                <Link to="/connections">
+                    설치됨 · 푸시 설정 열기
+                    <BellRing aria-hidden="true" />
+                </Link>
             </Button>
         );
     }
@@ -157,6 +194,153 @@ function MobileInstallAction({
             <Smartphone aria-hidden="true" />
         </Button>
     );
+}
+
+function PcInstallStep({mobileClient}: {mobileClient: boolean}) {
+    return (
+        <div
+            className={
+                mobileClient
+                    ? 'min-w-0'
+                    : 'grid min-w-0 gap-5 md:grid-cols-[minmax(0,1fr)_15rem] md:items-center'
+            }
+        >
+            <div className="min-w-0">
+                <p className="text-base leading-7 text-muted-foreground">
+                    {mobileClient
+                        ? '출석 자동 확인과 개인 알림을 연결하려면 PC 앱 설치와 Jungle Campus 로그인을 먼저 완료하세요.'
+                        : '운영체제에 맞는 PC 앱을 설치한 뒤 Jungle Campus에 로그인합니다. 공개 세탁실과 식단만 볼 때는 이 단계가 필요하지 않습니다.'}
+                </p>
+                <Button asChild className="mt-4 h-auto min-h-11 w-full whitespace-normal sm:w-auto">
+                    <a href={PC_INSTALL_GUIDE_URL} target="_blank" rel="noopener noreferrer">
+                        PC 앱 설치 가이드
+                        <ExternalLink aria-hidden="true" />
+                    </a>
+                </Button>
+            </div>
+            {mobileClient ? null : (
+                <DesktopAppMockup compact className="min-h-56 w-full shadow-none" />
+            )}
+        </div>
+    );
+}
+
+function PairingStep() {
+    return (
+        <div className="min-w-0">
+            <p className="text-base leading-7 text-muted-foreground">
+                PC 앱의 모바일 연결 화면에서 QR을 만들고 휴대폰으로 스캔하세요. 카메라를 사용할 수
+                없으면 화면에 표시된 연결 코드를 직접 입력할 수 있습니다.
+            </p>
+            <div className="mt-4 grid min-w-0 gap-3 sm:grid-cols-2">
+                <div className="min-w-0 rounded-lg border bg-muted/35 p-4">
+                    <QrCode aria-hidden="true" className="size-5 text-primary" />
+                    <strong className="mt-2 block text-base">QR 스캔</strong>
+                    <p className="mt-1 text-base leading-6 text-muted-foreground">
+                        PC에 표시된 QR을 휴대폰 카메라로 엽니다.
+                    </p>
+                </div>
+                <div className="min-w-0 rounded-lg border bg-muted/35 p-4">
+                    <KeyRound aria-hidden="true" className="size-5 text-primary" />
+                    <strong className="mt-2 block text-base">연결 코드 입력</strong>
+                    <p className="mt-1 text-base leading-6 text-muted-foreground">
+                        QR을 읽지 못하면 같은 화면의 코드를 입력합니다.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function PwaInstallStep({
+    mobileClient,
+    mobileHandoffStatus,
+    onRequestMobileInstall,
+    onRetryMobileHandoff,
+}: {
+    mobileClient: boolean;
+    mobileHandoffStatus: MobileInstallHandoffStatus;
+    onRequestMobileInstall?: () => void;
+    onRetryMobileHandoff?: () => void;
+}) {
+    return (
+        <div className="min-w-0">
+            <p className="text-base leading-7 text-muted-foreground">
+                {mobileClient
+                    ? '지금 이 브라우저에서 Jungle Bell을 홈 화면에 설치하세요. PC 앱 설치·로그인과 QR 또는 코드 연결이 끝나지 않았다면 설치 후 이어서 완료할 수 있습니다.'
+                    : '연결할 휴대폰에서 이 페이지를 열고 Jungle Bell을 홈 화면에 설치합니다.'}
+            </p>
+            <MobileInstallHandoffNotice status={mobileHandoffStatus} />
+            <div className="mt-4 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start">
+                <MobileInstallAction
+                    status={mobileHandoffStatus}
+                    mobileClient={mobileClient}
+                    onRequestMobileInstall={onRequestMobileInstall}
+                    onRetryMobileHandoff={onRetryMobileHandoff}
+                />
+                <details className="min-w-0 flex-1 rounded-lg border bg-muted/30">
+                    <summary className="flex min-h-11 cursor-pointer items-center px-4 py-2 text-base font-semibold">
+                        수동 설치 방법
+                    </summary>
+                    <div className="grid gap-2 border-t px-4 py-3 text-base leading-6 text-muted-foreground">
+                        <p>iPhone·iPad: Safari 공유 메뉴에서 ‘홈 화면에 추가’를 선택합니다.</p>
+                        <p>
+                            Android: 브라우저 메뉴에서 ‘앱 설치’ 또는 ‘홈 화면에 추가’를 선택합니다.
+                        </p>
+                    </div>
+                </details>
+            </div>
+        </div>
+    );
+}
+
+function PushTestStep() {
+    return (
+        <div className="grid min-w-0 gap-5 md:grid-cols-[minmax(0,1fr)_12rem] md:items-center">
+            <div className="min-w-0">
+                <p className="text-base leading-7 text-muted-foreground">
+                    설치한 PWA에서 알림 권한을 허용하고 이 기기로 테스트 알림을 보냅니다. 실제로
+                    도착한 것을 확인해야 설정이 끝납니다.
+                </p>
+                <Button
+                    asChild
+                    className="mt-4 h-auto min-h-11 w-full whitespace-normal sm:w-auto"
+                    variant="outline"
+                >
+                    <Link to="/connections">
+                        푸시 설정과 테스트 열기
+                        <BellRing aria-hidden="true" />
+                    </Link>
+                </Button>
+            </div>
+            <MobileNotificationMockup
+                phone
+                className="hidden min-h-64 w-full shadow-none md:block"
+            />
+        </div>
+    );
+}
+
+function installStepContent(
+    id: InstallStepId,
+    options: {
+        mobileClient: boolean;
+        mobileHandoffStatus: MobileInstallHandoffStatus;
+        onRequestMobileInstall?: () => void;
+        onRetryMobileHandoff?: () => void;
+    },
+): ReactNode {
+    switch (id) {
+        case 'pc':
+            return <PcInstallStep mobileClient={options.mobileClient} />;
+        case 'pairing':
+            return <PairingStep />;
+        case 'pwa':
+            return <PwaInstallStep {...options} />;
+        case 'push':
+            return <PushTestStep />;
+    }
+    return null;
 }
 
 export function AppInstallPage({
@@ -170,14 +354,24 @@ export function AppInstallPage({
     mobileHandoffStatus?: MobileInstallHandoffStatus;
     onRetryMobileHandoff?: () => void;
 }) {
+    const [mobileClient] = useState(currentClientIsMobile);
+
     useEffect(() => {
         if (!focusMobileInstall) return undefined;
         const frame = window.requestAnimationFrame(() => scrollToGuide('mobile-install'));
         return () => window.cancelAnimationFrame(frame);
     }, [focusMobileInstall]);
 
+    const steps = installStepOrder(mobileClient);
+    const contentOptions = {
+        mobileClient,
+        mobileHandoffStatus,
+        onRequestMobileInstall,
+        onRetryMobileHandoff,
+    };
+
     return (
-        <div className="space-y-8">
+        <div className="min-w-0 space-y-6 sm:space-y-8">
             <PageHeader
                 title="앱 설치 안내"
                 actions={
@@ -191,105 +385,29 @@ export function AppInstallPage({
             />
 
             <section
-                className="mx-auto max-w-4xl py-3 text-center"
-                aria-labelledby="install-hero-title"
+                className="min-w-0 rounded-xl border bg-primary/5 p-4 sm:p-6"
+                aria-labelledby="install-guide-title"
             >
+                <p className="text-sm font-semibold text-primary">출석·개인 알림 설정</p>
                 <h2
-                    id="install-hero-title"
-                    className="text-3xl leading-tight font-bold tracking-[-0.045em] text-balance sm:text-5xl"
+                    id="install-guide-title"
+                    className="mt-1 text-2xl leading-8 font-bold tracking-[-0.035em] break-words sm:text-3xl sm:leading-10"
                 >
-                    PC·모바일 앱으로 Jungle Bell을{' '}
-                    <span className="text-primary">더 편리하게 사용하세요.</span>
+                    네 단계로 PC와 휴대폰 연결하기
                 </h2>
-                <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-pretty text-muted-foreground sm:text-base sm:leading-7">
-                    데스크톱에서는 출석 상태를 자동으로 확인하고, 모바일에서는 출석·세탁·식사 생활
-                    알림을 잠금 화면에서 받아볼 수 있어요.
+                <p className="mt-2 max-w-3xl text-base leading-7 text-muted-foreground">
+                    세탁실·식단은 설치 없이 바로 볼 수 있습니다. 아래 과정은 출석 자동 확인과 개인
+                    알림을 사용할 때만 필요합니다.
                 </p>
             </section>
 
-            <section
-                className="grid min-w-0 gap-4 lg:grid-cols-2"
-                aria-label="기기별 Jungle Bell 앱 안내"
-            >
-                <DeviceCard
-                    icon={Monitor}
-                    eyebrow="출석 상태 확인"
-                    title="PC 앱"
-                    badge="필수"
-                    emphasized
-                    action={
-                        <Button className="w-full" onClick={() => scrollToGuide('pc-install')}>
-                            내 PC 설치 방법 보기
-                            <Download aria-hidden="true" />
-                        </Button>
-                    }
-                >
-                    <DesktopAppMockup />
-                </DeviceCard>
-
-                <DeviceCard
-                    icon={Smartphone}
-                    eyebrow="홈 화면에 설치하는 PWA"
-                    title="모바일 앱"
-                    action={
-                        <Button
-                            className="w-full"
-                            variant="outline"
-                            onClick={() => scrollToGuide('mobile-install')}
-                        >
-                            휴대폰 설치 방법 보기
-                            <Download aria-hidden="true" />
-                        </Button>
-                    }
-                >
-                    <MobileNotificationMockup />
-                </DeviceCard>
-            </section>
-
-            <section
-                id="pc-install"
-                className="scroll-mt-5 rounded-xl border bg-card p-5 shadow-sm sm:flex sm:items-center sm:justify-between sm:gap-6 sm:p-6"
-                aria-labelledby="pc-install-title"
-            >
-                <div className="min-w-0">
-                    <p className="text-xs font-semibold text-primary">PC 앱 설치</p>
-                    <h2 id="pc-install-title" className="mt-1 text-xl font-bold tracking-tight">
-                        Windows 또는 macOS에 설치
-                    </h2>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                        운영체제에 맞는 최신 설치 파일을 내려받고 Jungle Campus에 로그인합니다.
-                    </p>
-                </div>
-                <Button asChild className="mt-4 w-full shrink-0 sm:mt-0 sm:w-auto">
-                    <a href={PC_INSTALL_GUIDE_URL} target="_blank" rel="noopener noreferrer">
-                        PC 앱 설치 가이드
-                        <ExternalLink aria-hidden="true" />
-                    </a>
-                </Button>
-            </section>
-
-            <section
-                id="mobile-install"
-                className="scroll-mt-5 rounded-xl border bg-card p-5 shadow-sm sm:flex sm:items-center sm:justify-between sm:gap-6 sm:p-6"
-                aria-labelledby="mobile-install-title"
-            >
-                <div className="min-w-0">
-                    <p className="text-xs font-semibold text-primary">모바일 앱 설치</p>
-                    <h2 id="mobile-install-title" className="mt-1 text-xl font-bold tracking-tight">
-                        브라우저에서 홈 화면에 추가
-                    </h2>
-                    <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                        iPhone은 공유 메뉴의 ‘홈 화면에 추가’, Android는 브라우저 메뉴의 ‘앱 설치’를
-                        선택합니다.
-                    </p>
-                    <MobileInstallHandoffNotice status={mobileHandoffStatus} />
-                </div>
-                <MobileInstallAction
-                    status={mobileHandoffStatus}
-                    onRequestMobileInstall={onRequestMobileInstall}
-                    onRetryMobileHandoff={onRetryMobileHandoff}
-                />
-            </section>
+            <ol className="grid min-w-0 gap-4" aria-label="Jungle Bell 설치 단계">
+                {steps.map((id, index) => (
+                    <InstallStepCard key={id} id={id} current={mobileClient && index === 0}>
+                        {installStepContent(id, contentOptions)}
+                    </InstallStepCard>
+                ))}
+            </ol>
         </div>
     );
 }

--- a/frontend/src/features/app-install/install-step-order.ts
+++ b/frontend/src/features/app-install/install-step-order.ts
@@ -1,0 +1,8 @@
+export type InstallStepId = 'pc' | 'pairing' | 'pwa' | 'push';
+
+const DESKTOP_INSTALL_STEP_ORDER: readonly InstallStepId[] = ['pc', 'pairing', 'pwa', 'push'];
+const MOBILE_INSTALL_STEP_ORDER: readonly InstallStepId[] = ['pwa', 'pc', 'pairing', 'push'];
+
+export function installStepOrder(mobileClient: boolean): readonly InstallStepId[] {
+    return mobileClient ? MOBILE_INSTALL_STEP_ORDER : DESKTOP_INSTALL_STEP_ORDER;
+}

--- a/frontend/src/features/home/home-page.tsx
+++ b/frontend/src/features/home/home-page.tsx
@@ -3,9 +3,14 @@ import {ArrowRight, RefreshCw, Utensils, WashingMachine, type LucideIcon} from '
 import type {ReactNode} from 'react';
 
 import {useDashboardEnvironment} from '@/app/dashboard-context';
-import {useRefreshHomeMutation, useSuspenseCampusQueries} from '@/app/use-dashboard-queries';
+import {
+    useRefreshHomeMutation,
+    useSuspenseLaundryQuery,
+    useSuspenseMealsQuery,
+} from '@/app/use-dashboard-queries';
 import {AppShowcaseCard} from '@/components/app-showcase/app-showcase-card';
 import {AsyncBoundary} from '@/components/dashboard/async-boundary';
+import {LoadingState} from '@/components/dashboard/async-state';
 import {laundryZonePresentation} from '@/components/dashboard/laundry-zone-presentation';
 import {PageHeader} from '@/components/dashboard/page-header';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
@@ -50,114 +55,137 @@ function SummaryCard({
     );
 }
 
-function HomeLivingSummaries() {
-    const {laundry, meals} = useSuspenseCampusQueries();
+function HomeLaundrySummary() {
+    const laundry = useSuspenseLaundryQuery();
     const laundrySummary = homeLaundrySummary({
         snapshot: laundry.data,
     });
-    const todayMealSlots = homeTodayMealSlots(meals.data);
     const laundryRefreshFailed = laundry.isError;
     const laundryCollectorUnavailable = !laundry.data.quality.collectorHealthy;
+
+    return (
+        <SummaryCard
+            icon={WashingMachine}
+            title="세탁실"
+            footer={
+                <Button asChild size="sm" variant="link" className="px-0">
+                    <Link to="/laundry">
+                        기기별 현황 보기 <ArrowRight />
+                    </Link>
+                </Button>
+            }
+        >
+            {laundryCollectorUnavailable ? (
+                <p className="text-xs text-destructive">
+                    수집 서버 장애로 마지막 정상 상태를 표시합니다.
+                </p>
+            ) : laundryRefreshFailed ? (
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                    최신 상태를 가져오지 못해 마지막 확인값을 표시합니다.
+                </p>
+            ) : null}
+            {laundry.data.machines.length === 0 ? (
+                <p className="text-sm leading-6 text-muted-foreground">
+                    {laundryRefreshFailed
+                        ? '마지막으로 확인한 데이터에 표시할 워시타워가 없습니다.'
+                        : '표시할 워시타워 정보가 아직 없습니다.'}
+                </p>
+            ) : (
+                <div className="grid grid-cols-2 gap-2">
+                    <div
+                        className={cn(
+                            'rounded-lg border p-3',
+                            laundryZonePresentation('men').surfaceClassName,
+                        )}
+                    >
+                        <p className="text-xs font-medium">남성 가능</p>
+                        <p className="mt-1 flex items-baseline gap-2">
+                            <strong className="text-2xl text-foreground">
+                                {laundrySummary.men === null ? '—' : `${laundrySummary.men}회`}
+                            </strong>
+                            {laundrySummary.men === null ? null : (
+                                <span className="text-xs text-muted-foreground">
+                                    지금 시작 가능
+                                </span>
+                            )}
+                        </p>
+                    </div>
+                    <div
+                        className={cn(
+                            'rounded-lg border p-3',
+                            laundryZonePresentation('women').surfaceClassName,
+                        )}
+                    >
+                        <p className="text-xs font-medium">여성 가능</p>
+                        <p className="mt-1 flex items-baseline gap-2">
+                            <strong className="text-2xl text-foreground">
+                                {laundrySummary.women === null ? '—' : `${laundrySummary.women}회`}
+                            </strong>
+                            {laundrySummary.women === null ? null : (
+                                <span className="text-xs text-muted-foreground">
+                                    지금 시작 가능
+                                </span>
+                            )}
+                        </p>
+                    </div>
+                </div>
+            )}
+        </SummaryCard>
+    );
+}
+
+function HomeMealsSummary() {
+    const meals = useSuspenseMealsQuery();
+    const todayMealSlots = homeTodayMealSlots(meals.data);
     const mealsRefreshFailed = meals.isError;
 
     return (
-        <section className="grid gap-4 lg:grid-cols-2" aria-label="오늘의 생활 정보">
-            <SummaryCard
-                icon={WashingMachine}
-                title="세탁실"
-                footer={
-                    <Button asChild size="sm" variant="link" className="px-0">
-                        <Link to="/laundry">
-                            기기별 현황 보기 <ArrowRight />
-                        </Link>
-                    </Button>
-                }
-            >
-                {laundryCollectorUnavailable ? (
-                    <p className="text-xs text-destructive">
-                        수집 서버 장애로 마지막 정상 상태를 표시합니다.
-                    </p>
-                ) : laundryRefreshFailed ? (
-                    <p className="text-xs text-amber-700 dark:text-amber-300">
-                        최신 상태를 가져오지 못해 마지막 확인값을 표시합니다.
-                    </p>
-                ) : null}
-                {laundry.data.machines.length === 0 ? (
-                    <p className="text-sm leading-6 text-muted-foreground">
-                        {laundryRefreshFailed
-                            ? '마지막으로 확인한 데이터에 표시할 워시타워가 없습니다.'
-                            : '표시할 워시타워 정보가 아직 없습니다.'}
-                    </p>
-                ) : (
-                    <div className="grid grid-cols-2 gap-2">
-                        <div
-                            className={cn(
-                                'rounded-lg border p-3',
-                                laundryZonePresentation('men').surfaceClassName,
-                            )}
-                        >
-                            <p className="text-xs font-medium">남성 가능</p>
-                            <p className="mt-1 flex items-baseline gap-2">
-                                <strong className="text-2xl text-foreground">
-                                    {laundrySummary.men === null ? '—' : `${laundrySummary.men}회`}
-                                </strong>
-                                {laundrySummary.men === null ? null : (
-                                    <span className="text-xs text-muted-foreground">
-                                        지금 시작 가능
-                                    </span>
-                                )}
-                            </p>
-                        </div>
-                        <div
-                            className={cn(
-                                'rounded-lg border p-3',
-                                laundryZonePresentation('women').surfaceClassName,
-                            )}
-                        >
-                            <p className="text-xs font-medium">여성 가능</p>
-                            <p className="mt-1 flex items-baseline gap-2">
-                                <strong className="text-2xl text-foreground">
-                                    {laundrySummary.women === null
-                                        ? '—'
-                                        : `${laundrySummary.women}회`}
-                                </strong>
-                                {laundrySummary.women === null ? null : (
-                                    <span className="text-xs text-muted-foreground">
-                                        지금 시작 가능
-                                    </span>
-                                )}
-                            </p>
-                        </div>
-                    </div>
-                )}
-            </SummaryCard>
+        <SummaryCard
+            icon={Utensils}
+            title="오늘 급식"
+            footer={
+                <Button asChild size="sm" variant="link" className="px-0">
+                    <Link to="/meals">
+                        전체 식단 보기 <ArrowRight />
+                    </Link>
+                </Button>
+            }
+        >
+            {mealsRefreshFailed ? (
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                    최신 식단을 가져오지 못해 마지막 확인값을 표시합니다.
+                </p>
+            ) : null}
+            {todayMealSlots === null ? (
+                <p className="text-sm leading-6 text-muted-foreground">
+                    {mealsRefreshFailed
+                        ? '마지막으로 확인한 데이터에는 오늘 식단이 없습니다.'
+                        : '오늘 식단이 아직 게시되지 않았습니다.'}
+                </p>
+            ) : (
+                <HomeMealSlotsList slots={todayMealSlots} />
+            )}
+        </SummaryCard>
+    );
+}
 
-            <SummaryCard
-                icon={Utensils}
-                title="오늘 급식"
-                footer={
-                    <Button asChild size="sm" variant="link" className="px-0">
-                        <Link to="/meals">
-                            전체 식단 보기 <ArrowRight />
-                        </Link>
-                    </Button>
-                }
+function HomeLivingSummaries() {
+    return (
+        <section className="grid gap-4 lg:grid-cols-2" aria-label="오늘의 생활 정보">
+            <AsyncBoundary
+                errorTitle="세탁실 요약을 불러오지 못했습니다."
+                errorDescription="식단 요약은 계속 확인할 수 있습니다. 세탁실 정보만 다시 시도해 주세요."
+                fallback={<LoadingState label="세탁실 요약을 불러오는 중" />}
             >
-                {mealsRefreshFailed ? (
-                    <p className="text-xs text-amber-700 dark:text-amber-300">
-                        최신 식단을 가져오지 못해 마지막 확인값을 표시합니다.
-                    </p>
-                ) : null}
-                {todayMealSlots === null ? (
-                    <p className="text-sm leading-6 text-muted-foreground">
-                        {mealsRefreshFailed
-                            ? '마지막으로 확인한 데이터에는 오늘 식단이 없습니다.'
-                            : '오늘 식단이 아직 게시되지 않았습니다.'}
-                    </p>
-                ) : (
-                    <HomeMealSlotsList slots={todayMealSlots} />
-                )}
-            </SummaryCard>
+                <HomeLaundrySummary />
+            </AsyncBoundary>
+            <AsyncBoundary
+                errorTitle="식단 요약을 불러오지 못했습니다."
+                errorDescription="세탁실 요약은 계속 확인할 수 있습니다. 식단 정보만 다시 시도해 주세요."
+                fallback={<LoadingState label="식단 요약을 불러오는 중" />}
+            >
+                <HomeMealsSummary />
+            </AsyncBoundary>
         </section>
     );
 }
@@ -188,7 +216,7 @@ export function HomePage() {
                 }
             />
 
-            {showAttendanceSummary ? <JungleCampusSummary /> : <AppShowcaseCard />}
+            <HomeLivingSummaries />
 
             {refreshHome.isError ? (
                 <Alert variant="destructive">
@@ -208,12 +236,7 @@ export function HomePage() {
                 </Alert>
             ) : null}
 
-            <AsyncBoundary
-                errorTitle="오늘의 생활 정보를 불러오지 못했습니다."
-                errorDescription="상단 정보는 계속 확인할 수 있습니다. 잠시 후 다시 시도해 주세요."
-            >
-                <HomeLivingSummaries />
-            </AsyncBoundary>
+            {showAttendanceSummary ? <JungleCampusSummary /> : <AppShowcaseCard />}
         </div>
     );
 }

--- a/frontend/src/features/home/home-view-model.test.ts
+++ b/frontend/src/features/home/home-view-model.test.ts
@@ -48,7 +48,9 @@ describe('home feature boundaries', () => {
         expect(source).not.toContain('href="#notifications"');
         expect(source).not.toContain('title="알림"');
         expect(source).not.toContain('useCampusDataIssue');
-        expect(source).toContain('useSuspenseCampusQueries');
+        expect(source).not.toContain('useSuspenseCampusQueries');
+        expect(source).toContain('useSuspenseLaundryQuery');
+        expect(source).toContain('useSuspenseMealsQuery');
         expect(source).toContain('const laundryRefreshFailed = laundry.isError');
         expect(source).toContain(
             'const laundryCollectorUnavailable = !laundry.data.quality.collectorHealthy',
@@ -62,17 +64,46 @@ describe('home feature boundaries', () => {
         expect(source).not.toContain('CompactError');
     });
 
+    it('세탁실과 식단 query를 각각의 오류 경계와 재시도 CTA로 격리한다', () => {
+        const source = readFileSync(new URL('./home-page.tsx', import.meta.url), 'utf8');
+
+        expect(source).toMatch(/function HomeLaundrySummary[\s\S]*useSuspenseLaundryQuery\(\)/u);
+        expect(source).toMatch(/function HomeMealsSummary[\s\S]*useSuspenseMealsQuery\(\)/u);
+        expect(source.match(/<AsyncBoundary\b/gu)).toHaveLength(2);
+        expect(source).toMatch(
+            /errorTitle="세탁실 요약을 불러오지 못했습니다\."[\s\S]*<HomeLaundrySummary \/>/u,
+        );
+        expect(source).toMatch(
+            /errorTitle="식단 요약을 불러오지 못했습니다\."[\s\S]*<HomeMealsSummary \/>/u,
+        );
+        expect(source).toContain('식단 요약은 계속 확인할 수 있습니다.');
+        expect(source).toContain('세탁실 요약은 계속 확인할 수 있습니다.');
+    });
+
     it('PC와 설치형 PWA에는 출석 요약을, 일반 웹에는 앱 소개를 표시한다', () => {
         const source = readFileSync(new URL('./home-page.tsx', import.meta.url), 'utf8');
 
         expect(source).toContain("platform.kind === 'desktop' || platform.pwa.installed");
         expect(source).toContain('<JungleCampusSummary />');
         expect(source).toContain('<AppShowcaseCard />');
-        expect(source.indexOf('<JungleCampusSummary')).toBeLessThan(
-            source.lastIndexOf('<AsyncBoundary'),
+        expect(source.indexOf('<AsyncBoundary')).toBeLessThan(
+            source.indexOf('{showAttendanceSummary'),
         );
         expect(source).not.toContain('title="출석"');
         expect(source).not.toContain('<CardTitle>공식 정글캠퍼스</CardTitle>');
+    });
+
+    it('일반 웹의 설치 안내는 320px에서 줄바꿈되고 닫을 수 있는 compact 안내다', () => {
+        const showcaseSource = readFileSync(
+            new URL('../../components/app-showcase/app-showcase-card.tsx', import.meta.url),
+            'utf8',
+        );
+
+        expect(showcaseSource).toContain('aria-label="설치 안내 닫기"');
+        expect(showcaseSource).toContain('sessionStorage');
+        expect(showcaseSource).toContain('min-w-0');
+        expect(showcaseSource).toContain('whitespace-normal');
+        expect(showcaseSource).toContain('sm:whitespace-nowrap');
     });
 
     it('centers compact living summaries and keeps their footer divider tight', () => {

--- a/frontend/src/platform/pwa/install-prompt-state.ts
+++ b/frontend/src/platform/pwa/install-prompt-state.ts
@@ -1,0 +1,47 @@
+import type {PwaInstallPrompt} from '@/platform/contracts';
+
+export type InstallPromptStatus =
+    | 'available'
+    | 'unsupported'
+    | 'dismissed'
+    | 'completed'
+    | 'already-installed';
+
+export type InstallPromptState =
+    | {status: 'available'; prompt: PwaInstallPrompt}
+    | {status: Exclude<InstallPromptStatus, 'available'>};
+
+export type InstallPromptAction =
+    | {type: 'prompt-available'; prompt: PwaInstallPrompt}
+    | {type: 'prompt-dismissed'}
+    | {type: 'prompt-accepted'}
+    | {type: 'prompt-failed'}
+    | {type: 'retry'}
+    | {type: 'app-installed'};
+
+export function initialInstallPromptState(installed: boolean): InstallPromptState {
+    return installed ? {status: 'already-installed'} : {status: 'unsupported'};
+}
+
+export function reduceInstallPromptState(
+    state: InstallPromptState,
+    action: InstallPromptAction,
+): InstallPromptState {
+    switch (action.type) {
+        case 'prompt-available':
+            return state.status === 'already-installed' || state.status === 'completed'
+                ? state
+                : {status: 'available', prompt: action.prompt};
+        case 'prompt-dismissed':
+            return {status: 'dismissed'};
+        case 'prompt-accepted':
+        case 'app-installed':
+            return {status: 'completed'};
+        case 'prompt-failed':
+        case 'retry':
+            return state.status === 'already-installed' || state.status === 'completed'
+                ? state
+                : {status: 'unsupported'};
+    }
+    return state;
+}

--- a/frontend/src/platform/pwa/install-prompt.test.ts
+++ b/frontend/src/platform/pwa/install-prompt.test.ts
@@ -1,8 +1,14 @@
 import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
 
-import {test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 
 import {isMobileInstallClient} from './install-client';
+import {
+    initialInstallPromptState,
+    reduceInstallPromptState,
+    type InstallPromptState,
+} from './install-prompt-state';
 
 test('iOS·Android와 iPad 데스크톱 UA를 모바일 설치 대상으로 판정한다', () => {
     assert.equal(
@@ -42,4 +48,54 @@ test('일반 PC 브라우저는 PC 앱 설치 대상으로 판정한다', () => 
         }),
         false,
     );
+});
+
+describe('PWA install prompt state', () => {
+    const prompt = {prompt: async () => 'accepted' as const};
+
+    test('초기 상태에서 자동 설치 미지원과 이미 설치됨을 구분한다', () => {
+        expect(initialInstallPromptState(false)).toEqual({status: 'unsupported'});
+        expect(initialInstallPromptState(true)).toEqual({status: 'already-installed'});
+    });
+
+    test('설치 가능 이벤트와 사용자 선택 결과를 별도 상태로 보존한다', () => {
+        const available = reduceInstallPromptState(initialInstallPromptState(false), {
+            type: 'prompt-available',
+            prompt,
+        });
+
+        expect(available).toEqual({status: 'available', prompt});
+        expect(
+            reduceInstallPromptState(available, {type: 'prompt-dismissed'}),
+        ).toEqual<InstallPromptState>({status: 'dismissed'});
+        expect(
+            reduceInstallPromptState(available, {type: 'prompt-accepted'}),
+        ).toEqual<InstallPromptState>({status: 'completed'});
+    });
+
+    test('거절 후 재확인과 브라우저 설치 완료 이벤트를 복구 경로로 처리한다', () => {
+        expect(
+            reduceInstallPromptState({status: 'dismissed'}, {type: 'retry'}),
+        ).toEqual<InstallPromptState>({status: 'unsupported'});
+        expect(
+            reduceInstallPromptState({status: 'unsupported'}, {type: 'app-installed'}),
+        ).toEqual<InstallPromptState>({status: 'completed'});
+    });
+
+    test('각 설치 상태에 사용자 설명과 재시도·수동 설치 행동을 제공한다', () => {
+        const source = readFileSync(new URL('./install-prompt.tsx', import.meta.url), 'utf8');
+
+        for (const text of [
+            'Jungle Bell을 홈 화면에 추가',
+            '자동 설치를 사용할 수 없습니다.',
+            '설치를 취소했습니다.',
+            '설치 요청을 완료했습니다.',
+            'Jungle Bell이 이미 설치되어 있습니다.',
+            '설치 다시 시도',
+            '다시 확인했지만 자동 설치 버튼이 없습니다.',
+            '수동 설치 방법',
+        ]) {
+            expect(source).toContain(text);
+        }
+    });
 });

--- a/frontend/src/platform/pwa/install-prompt.tsx
+++ b/frontend/src/platform/pwa/install-prompt.tsx
@@ -1,10 +1,16 @@
-import {Download, MonitorDown, X} from 'lucide-react';
-import {useCallback, useEffect, useState} from 'react';
+import {BadgeCheck, CircleAlert, Download, MonitorDown, RotateCcw, X} from 'lucide-react';
+import {useCallback, useEffect, useReducer, useState, type ReactNode} from 'react';
 
 import {useDashboardEnvironment} from '@/app/dashboard-context';
 import {Button} from '@/components/ui/button';
 import {Card, CardContent} from '@/components/ui/card';
-import type {PwaInstallPrompt} from '@/platform/contracts';
+
+import {
+    initialInstallPromptState,
+    reduceInstallPromptState,
+    type InstallPromptState,
+    type InstallPromptStatus,
+} from './install-prompt-state';
 
 interface InstallPromptProps {
     open: boolean;
@@ -31,66 +37,228 @@ export function useInstallPromptVisibility(): {
     return {installPromptOpen, openInstallPrompt, setInstallPromptVisibility};
 }
 
+function ManualInstallGuide() {
+    return (
+        <details className="w-full min-w-0 rounded-lg border bg-muted/30" open>
+            <summary className="flex min-h-11 cursor-pointer items-center px-3 py-2 text-base font-semibold">
+                수동 설치 방법
+            </summary>
+            <div className="grid gap-1 border-t px-3 py-2 text-base leading-6 text-muted-foreground">
+                <p>iPhone·iPad: Safari 공유 메뉴에서 ‘홈 화면에 추가’를 선택하세요.</p>
+                <p>Android: 브라우저 메뉴에서 ‘앱 설치’를 선택하세요.</p>
+            </div>
+        </details>
+    );
+}
+
+function mobileInstallPresentation(
+    status: InstallPromptStatus,
+    installRechecked: boolean,
+): {
+    title: string;
+    description: string;
+} {
+    switch (status) {
+        case 'available':
+            return {
+                title: 'Jungle Bell을 홈 화면에 추가',
+                description: '설치를 누르면 브라우저의 PWA 설치 화면이 열립니다.',
+            };
+        case 'dismissed':
+            return {
+                title: '설치를 취소했습니다.',
+                description:
+                    '다시 확인하거나 아래 수동 설치 방법으로 언제든 홈 화면에 추가할 수 있습니다.',
+            };
+        case 'completed':
+            return {
+                title: '설치 요청을 완료했습니다.',
+                description: '홈 화면에서 Jungle Bell을 열고 연결과 푸시 테스트를 이어가세요.',
+            };
+        case 'already-installed':
+            return {
+                title: 'Jungle Bell이 이미 설치되어 있습니다.',
+                description: '홈 화면의 Jungle Bell에서 개인 기능을 사용할 수 있습니다.',
+            };
+        case 'unsupported':
+            return {
+                title: '자동 설치를 사용할 수 없습니다.',
+                description: installRechecked
+                    ? '다시 확인했지만 자동 설치 버튼이 없습니다. 아래 방법으로 직접 설치하세요.'
+                    : '브라우저가 설치 버튼을 제공하지 않았습니다. 아래 방법으로 직접 설치하세요.',
+            };
+    }
+    throw new Error('INSTALL_PROMPT_STATUS_INVALID');
+}
+
+function MobileInstallStatusIcon({status}: {status: InstallPromptStatus}) {
+    if (status === 'completed' || status === 'already-installed') {
+        return <BadgeCheck aria-hidden="true" className="size-5" />;
+    }
+    if (status === 'dismissed') {
+        return <RotateCcw aria-hidden="true" className="size-5" />;
+    }
+    if (status === 'unsupported') {
+        return <CircleAlert aria-hidden="true" className="size-5" />;
+    }
+    return <Download aria-hidden="true" className="size-5" />;
+}
+
+function MobileInstallActions({
+    state,
+    onInstall,
+    onRetry,
+    onClose,
+}: {
+    state: InstallPromptState;
+    onInstall: () => void;
+    onRetry: () => void;
+    onClose: () => void;
+}) {
+    let action: ReactNode;
+    switch (state.status) {
+        case 'available':
+            action = (
+                <Button
+                    className="h-auto min-h-11 w-full whitespace-normal sm:w-auto"
+                    onClick={onInstall}
+                >
+                    <Download aria-hidden="true" className="size-4" />홈 화면에 추가
+                </Button>
+            );
+            break;
+        case 'dismissed':
+            action = (
+                <Button
+                    className="h-auto min-h-11 w-full whitespace-normal sm:w-auto"
+                    variant="outline"
+                    onClick={onRetry}
+                >
+                    <RotateCcw aria-hidden="true" className="size-4" />
+                    설치 다시 시도
+                </Button>
+            );
+            break;
+        case 'unsupported':
+            action = (
+                <Button
+                    className="h-auto min-h-11 w-full whitespace-normal sm:w-auto"
+                    variant="outline"
+                    onClick={onRetry}
+                >
+                    <RotateCcw aria-hidden="true" className="size-4" />
+                    설치 가능 여부 다시 확인
+                </Button>
+            );
+            break;
+        case 'completed':
+        case 'already-installed':
+            action = (
+                <Button className="min-h-11 w-full sm:w-auto" variant="outline" onClick={onClose}>
+                    확인
+                </Button>
+            );
+            break;
+    }
+
+    const showManualGuide = state.status === 'unsupported' || state.status === 'dismissed';
+    return (
+        <>
+            {action}
+            {showManualGuide ? <ManualInstallGuide /> : null}
+        </>
+    );
+}
+
 export function InstallPrompt({open, onOpenChange}: InstallPromptProps) {
     const {platform} = useDashboardEnvironment();
-    const [prompt, setPrompt] = useState<PwaInstallPrompt | null>(null);
+    const [state, dispatch] = useReducer(
+        reduceInstallPromptState,
+        platform.pwa.installed,
+        initialInstallPromptState,
+    );
     const [mobile] = useState(() => platform.pwa.isMobileInstallClient());
+    const [installRechecked, setInstallRechecked] = useState(false);
 
     useEffect(() => {
         if (!platform.pwa.available) return undefined;
-        return platform.pwa.subscribeInstallPrompt(setPrompt);
+        const unlistenPrompt = platform.pwa.subscribeInstallPrompt((prompt) => {
+            setInstallRechecked(false);
+            dispatch({type: 'prompt-available', prompt});
+        });
+        const handleInstalled = () => dispatch({type: 'app-installed'});
+        window.addEventListener('appinstalled', handleInstalled);
+        return () => {
+            unlistenPrompt();
+            window.removeEventListener('appinstalled', handleInstalled);
+        };
     }, [platform.pwa]);
 
     if (!platform.pwa.available) return null;
     if (!open) return null;
 
-    const title = mobile ? '홈 화면에 Jungle Bell 추가' : 'PC 앱으로 개인 기능 사용';
+    const requestInstall = async () => {
+        if (state.status !== 'available') return;
+        try {
+            const choice = await state.prompt.prompt();
+            dispatch({type: choice === 'accepted' ? 'prompt-accepted' : 'prompt-dismissed'});
+        } catch {
+            dispatch({type: 'prompt-failed'});
+        }
+    };
+
+    const mobileContent = mobileInstallPresentation(state.status, installRechecked);
+
+    const title = mobile ? mobileContent.title : 'PC 앱으로 개인 기능 사용';
     const description = mobile
-        ? prompt
-            ? '설치를 누르면 Jungle Bell이 홈 화면에 추가됩니다.'
-            : 'iPhone·iPad는 공유 메뉴에서 ‘홈 화면에 추가’를, Android는 브라우저 메뉴에서 ‘앱 설치’를 선택하세요.'
+        ? mobileContent.description
         : '출석 상태 갱신과 운영체제 알림을 사용하려면 PC 앱을 설치하세요.';
 
     return (
-        <Card className="fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] z-50 mx-auto max-w-2xl border-primary/25 bg-card/96 py-3 shadow-xl backdrop-blur md:bottom-5">
-            <CardContent className="flex flex-col gap-3 px-3 sm:flex-row sm:items-center sm:px-4">
-                <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
-                    <MonitorDown aria-hidden="true" className="size-5" />
+        <Card className="fixed inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+4.5rem)] z-50 mx-auto max-w-2xl gap-0 border-primary/25 bg-card/96 py-3 shadow-xl backdrop-blur md:bottom-5">
+            <CardContent className="grid min-w-0 gap-3 px-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:px-4">
+                <span className="grid size-11 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+                    {mobile ? (
+                        <MobileInstallStatusIcon status={state.status} />
+                    ) : (
+                        <MonitorDown aria-hidden="true" className="size-5" />
+                    )}
                 </span>
-                <div className="min-w-0 flex-1">
-                    <strong className="block text-sm">{title}</strong>
-                    <span className="block text-xs leading-5 text-muted-foreground">
+                <div className="min-w-0" aria-live="polite">
+                    <strong className="block text-base leading-6">{title}</strong>
+                    <span className="block text-base leading-6 text-muted-foreground">
                         {description}
                     </span>
                 </div>
-                <div className="flex shrink-0 items-center gap-1 self-end sm:self-auto">
-                    {mobile && prompt ? (
-                        <Button
-                            size="sm"
-                            onClick={async () => {
-                                const choice = await prompt.prompt();
-                                setPrompt(null);
-                                if (choice === 'accepted') onOpenChange(false);
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    className="absolute top-1 right-1 size-11 sm:static"
+                    aria-label="설치 안내 닫기"
+                    onClick={() => onOpenChange(false)}
+                >
+                    <X aria-hidden="true" className="size-4" />
+                </Button>
+
+                <div className="col-span-full flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:pl-14">
+                    {mobile ? (
+                        <MobileInstallActions
+                            state={state}
+                            onInstall={() => void requestInstall()}
+                            onRetry={() => {
+                                dispatch({type: 'retry'});
+                                setInstallRechecked(true);
                             }}
-                        >
-                            <Download aria-hidden="true" className="size-4" />홈 화면에 추가
-                        </Button>
-                    ) : !mobile ? (
-                        <Button asChild size="sm">
+                            onClose={() => onOpenChange(false)}
+                        />
+                    ) : (
+                        <Button asChild className="min-h-11 w-full sm:w-auto">
                             <a href={RELEASE_URL} target="_blank" rel="noopener noreferrer">
                                 <Download aria-hidden="true" className="size-4" />
                                 PC 앱 다운로드
                             </a>
                         </Button>
-                    ) : null}
-                    <Button
-                        size="icon-sm"
-                        variant="ghost"
-                        aria-label="설치 안내 닫기"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        <X aria-hidden="true" className="size-4" />
-                    </Button>
+                    )}
                 </div>
             </CardContent>
         </Card>


### PR DESCRIPTION
# 요약

홈의 생활 정보를 우선하고 설치 과정을 실제 작업 순서로 재구성합니다.

- 세탁·식단 독립 query boundary
- compact/dismissible 설치 안내
- PC 로그인 → 연결 → PWA 설치 → 푸시 테스트 단계
- 설치 가능/미지원/거절/완료/설치됨 상태

# 스택

5/9, base: `codex/issue-69-04-responsive`

# 검증

- 독립 worktree: 성공
- `npm run check`: 105개 파일, 548개 테스트 통과
- `npm run build:web`: PWA 산출물 검증 통과

Refs #69
