### PR TITLE
[stack 6/9] feat(ui): 생활 정보 상태 피드백 표준화

### DIFF
--- a/frontend/src/components/dashboard/async-boundary.test.tsx
+++ b/frontend/src/components/dashboard/async-boundary.test.tsx
@@ -3,6 +3,7 @@ import {readFileSync} from 'node:fs';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, it} from 'vitest';
 
+import {AsyncBoundary} from './async-boundary';
 import {MealHistorySkeleton, PageSkeleton} from './async-state';
 
 const source = readFileSync(new URL('./async-boundary.tsx', import.meta.url), 'utf8');
@@ -24,5 +25,28 @@ describe('AsyncBoundary', () => {
         expect(page).toContain('data-slot="skeleton"');
         expect(meals).toContain('aria-label="지난 급식 기록을 불러오는 중"');
         expect(meals).toContain('lg:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)]');
+    });
+
+    it('header prop으로 이름 붙은 지역(role=region)을 제공한다', () => {
+        const markup = renderToStaticMarkup(
+            <AsyncBoundary header="대시보드 섹션">
+                <div>로딩 콘텐츠</div>
+            </AsyncBoundary>,
+        );
+
+        expect(markup).toContain('role="region"');
+        expect(markup).toContain('aria-label="대시보드 섹션"');
+    });
+
+    it('외부 헤더 id를 사용해 지역 라벨링이 가능하다', () => {
+        const markup = renderToStaticMarkup(
+            <AsyncBoundary regionLabelledBy="dashboard-heading">
+                <h2 id="dashboard-heading">대시보드 헤더</h2>
+                <div>로딩 콘텐츠</div>
+            </AsyncBoundary>,
+        );
+
+        expect(markup).toContain('role="region"');
+        expect(markup).toContain('aria-labelledby="dashboard-heading"');
     });
 });

--- a/frontend/src/components/dashboard/async-boundary.tsx
+++ b/frontend/src/components/dashboard/async-boundary.tsx
@@ -4,37 +4,87 @@ import {ErrorBoundary} from 'react-error-boundary';
 
 import {ErrorState, PageSkeleton} from './async-state';
 
-interface AsyncBoundaryProps {
+export interface AsyncBoundaryErrorFallbackProps {
+    error: unknown;
+    retry: () => void;
+}
+
+export interface AsyncBoundaryProps {
     children: ReactNode;
     errorDescription?: string;
     errorTitle?: string;
     fallback?: ReactNode;
+    header?: string;
+    regionLabel?: string;
+    regionLabelledBy?: string;
+    renderError?: (props: AsyncBoundaryErrorFallbackProps) => ReactNode;
     resetKeys?: unknown[];
 }
 
-/** Declarative loading and error boundary for query-backed dashboard regions. */
+function getBoundaryRegionAttributes({
+    header,
+    regionLabel,
+    regionLabelledBy,
+}: Pick<AsyncBoundaryProps, 'header' | 'regionLabel' | 'regionLabelledBy'>) {
+    if (regionLabelledBy) {
+        return {'aria-labelledby': regionLabelledBy, role: 'region' as const};
+    }
+
+    if (regionLabel) {
+        return {'aria-label': regionLabel, role: 'region' as const};
+    }
+
+    if (header) {
+        return {'aria-label': header, role: 'region' as const};
+    }
+
+    return null;
+}
+
 export function AsyncBoundary({
     children,
     errorDescription,
     errorTitle,
     fallback = <PageSkeleton />,
+    header,
+    regionLabel,
+    regionLabelledBy,
+    renderError,
     resetKeys,
 }: AsyncBoundaryProps) {
+    const regionAttributes = getBoundaryRegionAttributes({header, regionLabel, regionLabelledBy});
+
     return (
         <QueryErrorResetBoundary>
             {({reset}) => (
                 <ErrorBoundary
-                    fallbackRender={({resetErrorBoundary}) => (
-                        <ErrorState
-                            description={errorDescription}
-                            retry={resetErrorBoundary}
-                            title={errorTitle}
-                        />
-                    )}
+                    fallbackRender={({error, resetErrorBoundary}) => {
+                        const feedback = renderError ? (
+                            renderError({error, retry: resetErrorBoundary})
+                        ) : (
+                            <ErrorState
+                                description={errorDescription}
+                                retry={resetErrorBoundary}
+                                title={errorTitle}
+                            />
+                        );
+
+                        return regionAttributes ? (
+                            <section {...regionAttributes}>{feedback}</section>
+                        ) : (
+                            feedback
+                        );
+                    }}
                     onReset={reset}
                     resetKeys={resetKeys}
                 >
-                    <Suspense fallback={fallback}>{children}</Suspense>
+                    {regionAttributes ? (
+                        <section {...regionAttributes}>
+                            <Suspense fallback={fallback}>{children}</Suspense>
+                        </section>
+                    ) : (
+                        <Suspense fallback={fallback}>{children}</Suspense>
+                    )}
                 </ErrorBoundary>
             )}
         </QueryErrorResetBoundary>

--- a/frontend/src/components/dashboard/async-state.test.tsx
+++ b/frontend/src/components/dashboard/async-state.test.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {renderToStaticMarkup} from 'react-dom/server';
 import {test} from 'vitest';
 
-import {ErrorState} from './async-state';
+import {AsyncState, ErrorState} from './async-state';
 
 test('오류 재시도 버튼은 Alert 설명 열 안에 배치한다', () => {
     const markup = renderToStaticMarkup(
@@ -14,4 +14,97 @@ test('오류 재시도 버튼은 Alert 설명 열 안에 배치한다', () => {
         markup,
         /data-slot="alert-description"[^>]*>[\s\S]*연결 상태를 확인해 주세요\.[\s\S]*새로고침[\s\S]*<\/div>/u,
     );
+});
+
+test('로딩/빈값/오프라인/복구/스테일 상태는 status + polite 역할을 사용한다', () => {
+    const loading = renderToStaticMarkup(<AsyncState type="loading" regionLabel="로딩 영역" />);
+    const empty = renderToStaticMarkup(
+        <AsyncState type="empty" title="데이터 없음" regionLabel="빈 상태 영역" />,
+    );
+    const stale = renderToStaticMarkup(
+        <AsyncState type="stale" lastUpdatedAt="2026-09-08 10:00" reason="요청 타임아웃" />,
+    );
+    const offline = renderToStaticMarkup(
+        <AsyncState type="offline" regionLabelledBy="offline-title" />,
+    );
+    const recovered = renderToStaticMarkup(<AsyncState type="recovered" regionLabel="복구 영역" />);
+
+    for (const markup of [loading, empty, stale, offline, recovered]) {
+        assert.match(markup, /role="status"/u);
+        assert.match(markup, /aria-live="polite"/u);
+    }
+
+    assert.match(loading, /aria-label="로딩 영역"/u);
+    assert.match(empty, /aria-label="빈 상태 영역"/u);
+    assert.match(recovered, /aria-label="복구 영역"/u);
+});
+
+test('재시도 텍스트/핸들러는 stale/offline/recovered에서 주입 가능하고 마지막 정상 시각·이유를 렌더링한다', () => {
+    let called = false;
+    const markup = renderToStaticMarkup(
+        <AsyncState
+            type="stale"
+            lastUpdatedAt="2026-09-08 11:00"
+            reason="일시적 장애"
+            retryLabel="다시 시도"
+            retry={() => {
+                called = true;
+            }}
+        />,
+    );
+
+    assert.match(markup, /마지막 정상 시각/iu);
+    assert.match(markup, /2026-09-08 11:00/u);
+    assert.match(markup, /일시적 장애/u);
+    assert.match(markup, /다시 시도/u);
+
+    assert.equal(called, false);
+});
+
+test('normal은 이름 있는 region, error는 즉시 알리는 alert로 렌더링한다', () => {
+    const normal = renderToStaticMarkup(
+        <AsyncState type="normal" regionLabel="정상 데이터 영역">
+            <p>정상 데이터</p>
+        </AsyncState>,
+    );
+    const error = renderToStaticMarkup(
+        <AsyncState type="error" title="조회 실패" description="다시 시도해 주세요." />,
+    );
+
+    assert.match(normal, /role="region"/u);
+    assert.match(normal, /aria-label="정상 데이터 영역"/u);
+    assert.match(error, /role="alert"/u);
+});
+
+test('loading/empty/error/degraded 본문은 16px 이상 안내 토큰을 사용한다', () => {
+    const states = [
+        renderToStaticMarkup(<AsyncState type="loading" />),
+        renderToStaticMarkup(
+            <AsyncState type="empty" title="내용 없음" description="표시할 내용이 없습니다." />,
+        ),
+        renderToStaticMarkup(
+            <AsyncState type="error" title="조회 실패" description="다시 시도해 주세요." />,
+        ),
+        renderToStaticMarkup(
+            <AsyncState type="stale" description="마지막 정상 데이터를 표시합니다." />,
+        ),
+        renderToStaticMarkup(
+            <AsyncState type="recovered" description="최신 데이터로 복구했습니다." />,
+        ),
+    ];
+
+    for (const markup of states) {
+        assert.match(markup, /text-base/u);
+        assert.match(markup, /leading-6/u);
+    }
+
+    assert.match(states[2]!, /data-slot="alert-title"[^>]*text-base[^>]*leading-6/u);
+});
+
+test('오류와 stale 복구 버튼은 최소 44px 조작 영역을 사용한다', () => {
+    const error = renderToStaticMarkup(<AsyncState type="error" retry={() => undefined} />);
+    const stale = renderToStaticMarkup(<AsyncState type="stale" retry={() => undefined} />);
+
+    assert.match(error, /min-h-11/u);
+    assert.match(stale, /min-h-11/u);
 });

--- a/frontend/src/components/dashboard/async-state.tsx
+++ b/frontend/src/components/dashboard/async-state.tsx
@@ -1,8 +1,122 @@
+import {onlineManager} from '@tanstack/react-query';
 import {AlertCircle, Inbox, LoaderCircle} from 'lucide-react';
+import {type ReactNode, useSyncExternalStore} from 'react';
 
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
 import {Button} from '@/components/ui/button';
 import {Skeleton} from '@/components/ui/skeleton';
+
+export type AsyncStateType =
+    | 'loading'
+    | 'normal'
+    | 'empty'
+    | 'stale'
+    | 'offline'
+    | 'error'
+    | 'recovered';
+
+export interface AsyncRegionProps {
+    regionLabel?: string;
+    regionLabelledBy?: string;
+}
+
+interface BaseAsyncStateProps extends AsyncRegionProps {
+    title?: string;
+    description?: string;
+}
+
+interface LoadingStateProps extends Omit<BaseAsyncStateProps, 'title' | 'description'> {
+    label?: string;
+}
+
+interface EmptyStateProps extends BaseAsyncStateProps {
+    title: string;
+}
+
+interface TimedStateProps extends BaseAsyncStateProps {
+    lastUpdatedAt?: string;
+    reason?: string;
+    retryLabel?: string;
+    retry?: () => void;
+}
+
+type TimedStateType = Extract<AsyncStateType, 'stale' | 'offline' | 'recovered'>;
+
+const TIMED_STATE_LABELS: Readonly<Record<TimedStateType, string>> = {
+    stale: '데이터가 최신이 아닙니다.',
+    offline: '네트워크 연결이 일시 중단되었습니다.',
+    recovered: '마지막 상태를 복구했습니다.',
+};
+
+export type AsyncStateProps =
+    | ({type: 'normal'} & AsyncRegionProps & {children?: ReactNode})
+    | ({type: 'loading'} & LoadingStateProps)
+    | ({type: 'empty'} & EmptyStateProps)
+    | ({type: 'stale' | 'offline' | 'recovered'} & TimedStateProps)
+    | ({type: 'error'} & BaseAsyncStateProps & {retry?: () => void; retryLabel?: string});
+
+function getRegionAttributes(regionProps: AsyncRegionProps) {
+    const {regionLabel, regionLabelledBy} = regionProps;
+
+    if (regionLabelledBy) {
+        return {'aria-labelledby': regionLabelledBy};
+    }
+
+    if (regionLabel) {
+        return {'aria-label': regionLabel};
+    }
+
+    return null;
+}
+
+function withRegion(children: ReactNode, regionProps: AsyncRegionProps) {
+    const regionAttributes = getRegionAttributes(regionProps);
+
+    if (!regionAttributes) {
+        return children;
+    }
+
+    return (
+        <div role="region" {...regionAttributes}>
+            {children}
+        </div>
+    );
+}
+
+function subscribeToOnlineStatus(notify: () => void) {
+    return onlineManager.subscribe(() => notify());
+}
+
+/** Shares TanStack Query's online source without adding duplicate window listeners. */
+export function useOnlineStatus(): boolean {
+    return useSyncExternalStore(
+        subscribeToOnlineStatus,
+        () => onlineManager.isOnline(),
+        () => true,
+    );
+}
+
+function withStatus(children: ReactNode, regionProps: AsyncRegionProps) {
+    return withRegion(
+        <div role="status" aria-live="polite">
+            {children}
+        </div>,
+        regionProps,
+    );
+}
+
+function statusDescriptionRows(lastUpdatedAt?: string, reason?: string) {
+    return (
+        <>
+            {lastUpdatedAt ? (
+                <p className="text-sm leading-5 text-muted-foreground">
+                    마지막 정상 시각: <span className="font-medium">{lastUpdatedAt}</span>
+                </p>
+            ) : null}
+            {reason ? <p className="text-base leading-6">이유: {reason}</p> : null}
+        </>
+    );
+}
 
 export function PageSkeleton() {
     return (
@@ -36,12 +150,21 @@ export function MealHistorySkeleton() {
     );
 }
 
-export function LoadingState({label = '정보를 불러오고 있습니다.'}: {label?: string}) {
-    return (
-        <div className="flex min-h-32 items-center justify-center gap-2 rounded-lg bg-muted/60 p-6 text-sm text-muted-foreground">
+export function LoadingState({
+    label = '정보를 불러오고 있습니다.',
+    regionLabel,
+    regionLabelledBy,
+}: {
+    label?: string;
+    regionLabel?: string;
+    regionLabelledBy?: string;
+}) {
+    return withStatus(
+        <div className="flex min-h-32 items-center justify-center gap-2 rounded-lg bg-muted/60 p-6 text-base leading-6 text-muted-foreground">
             <LoaderCircle aria-hidden="true" className="size-4 animate-spin" />
             {label}
-        </div>
+        </div>,
+        {regionLabel, regionLabelledBy},
     );
 }
 
@@ -49,37 +172,122 @@ export function ErrorState({
     title = '정보를 불러오지 못했습니다.',
     description,
     retry,
+    retryLabel = '새로고침',
+    regionLabel,
+    regionLabelledBy,
 }: {
     title?: string;
     description?: string;
     retry?: () => void;
+    retryLabel?: string;
+    regionLabel?: string;
+    regionLabelledBy?: string;
 }) {
-    return (
+    return withRegion(
         <Alert variant="destructive">
             <AlertCircle aria-hidden="true" />
-            <AlertTitle>{title}</AlertTitle>
+            <AlertTitle className="text-base leading-6">{title}</AlertTitle>
             {description || retry ? (
-                <AlertDescription>
+                <AlertDescription className="text-base leading-6">
                     {description ? <p>{description}</p> : null}
                     {retry ? (
-                        <Button className="mt-2" size="sm" variant="outline" onClick={retry}>
-                            새로고침
+                        <Button
+                            className="mt-2 min-h-11"
+                            size="sm"
+                            variant="outline"
+                            onClick={retry}
+                        >
+                            {retryLabel}
                         </Button>
                     ) : null}
                 </AlertDescription>
             ) : null}
-        </Alert>
+        </Alert>,
+        {regionLabel, regionLabelledBy},
     );
 }
 
-export function EmptyState({title, description}: {title: string; description?: string}) {
-    return (
+export function EmptyState({
+    title,
+    description,
+    regionLabel,
+    regionLabelledBy,
+}: {
+    title: string;
+    description?: string;
+    regionLabel?: string;
+    regionLabelledBy?: string;
+}) {
+    return withStatus(
         <div className="flex min-h-32 flex-col items-center justify-center rounded-lg border border-dashed bg-muted/30 p-6 text-center">
             <Inbox aria-hidden="true" className="mb-2 size-5 text-muted-foreground" />
-            <strong className="text-sm">{title}</strong>
+            <strong className="text-base leading-6">{title}</strong>
             {description ? (
-                <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p>
+                <p className="mt-1 text-base leading-6 text-muted-foreground">{description}</p>
             ) : null}
-        </div>
+        </div>,
+        {regionLabel, regionLabelledBy},
+    );
+}
+
+export function AsyncState(props: AsyncStateProps) {
+    if (props.type === 'normal') {
+        return withRegion(props.children ?? null, {
+            regionLabel: props.regionLabel,
+            regionLabelledBy: props.regionLabelledBy,
+        });
+    }
+
+    if (props.type === 'loading') {
+        return (
+            <LoadingState
+                label={props.label}
+                regionLabel={props.regionLabel}
+                regionLabelledBy={props.regionLabelledBy}
+            />
+        );
+    }
+
+    if (props.type === 'empty') {
+        return (
+            <EmptyState
+                title={props.title}
+                description={props.description}
+                regionLabel={props.regionLabel}
+                regionLabelledBy={props.regionLabelledBy}
+            />
+        );
+    }
+
+    if (props.type === 'error') {
+        return (
+            <ErrorState
+                description={props.description}
+                regionLabel={props.regionLabel}
+                regionLabelledBy={props.regionLabelledBy}
+                retry={props.retry}
+                retryLabel={props.retryLabel}
+                title={props.title}
+            />
+        );
+    }
+
+    return withStatus(
+        <div className="space-y-2 text-base leading-6 text-muted-foreground">
+            <p className="font-medium text-foreground">
+                {props.title ?? TIMED_STATE_LABELS[props.type]}
+            </p>
+            {props.description ? <p>{props.description}</p> : null}
+            {statusDescriptionRows(props.lastUpdatedAt, props.reason)}
+            {props.retry ? (
+                <Button className="mt-2 min-h-11" size="sm" variant="outline" onClick={props.retry}>
+                    {props.retryLabel ?? '다시 시도'}
+                </Button>
+            ) : null}
+        </div>,
+        {
+            regionLabel: props.regionLabel,
+            regionLabelledBy: props.regionLabelledBy,
+        },
     );
 }

--- a/frontend/src/features/laundry/components/laundry-feature-boundary.tsx
+++ b/frontend/src/features/laundry/components/laundry-feature-boundary.tsx
@@ -1,0 +1,53 @@
+import type {ReactNode} from 'react';
+
+import {AsyncBoundary} from '@/components/dashboard/async-boundary';
+import {AsyncState, LoadingState, useOnlineStatus} from '@/components/dashboard/async-state';
+
+export interface LaundryFeatureBoundaryProps {
+    children: ReactNode;
+}
+
+/** Keeps laundry loading and query failures local when the feature is embedded elsewhere. */
+export function LaundryFeatureBoundary({children}: LaundryFeatureBoundaryProps) {
+    const isOnline = useOnlineStatus();
+
+    return (
+        <AsyncBoundary
+            errorTitle="세탁실 상태를 불러오지 못했습니다."
+            errorDescription="연결 상태를 확인한 뒤 다시 시도해 주세요."
+            fallback={
+                isOnline ? (
+                    <LoadingState label="세탁실 상태를 불러오는 중입니다." />
+                ) : (
+                    <AsyncState
+                        type="offline"
+                        title="현재 오프라인 상태입니다."
+                        description="저장된 세탁실 정보가 없어 인터넷 연결 후 다시 확인해야 합니다."
+                        reason="네트워크 연결 끊김"
+                    />
+                )
+            }
+            regionLabel="세탁실 데이터"
+            renderError={({retry}) =>
+                isOnline ? (
+                    <AsyncState
+                        type="error"
+                        title="세탁실 상태를 불러오지 못했습니다."
+                        description="연결 상태를 확인한 뒤 다시 시도해 주세요."
+                        retry={retry}
+                        retryLabel="다시 시도"
+                    />
+                ) : (
+                    <AsyncState
+                        type="offline"
+                        title="현재 오프라인 상태입니다."
+                        description="인터넷 연결 후 세탁실 상태를 다시 확인해 주세요."
+                        reason="네트워크 연결 끊김"
+                    />
+                )
+            }
+        >
+            {children}
+        </AsyncBoundary>
+    );
+}

--- a/frontend/src/features/laundry/components/laundry-machine-list.test.tsx
+++ b/frontend/src/features/laundry/components/laundry-machine-list.test.tsx
@@ -1,9 +1,13 @@
+import {readFileSync} from 'node:fs';
+
 import {renderToStaticMarkup} from 'react-dom/server';
 import {describe, expect, it} from 'vitest';
 
 import type {DashboardLaundryMachine} from '@/domain/laundry/capacity';
 
 import {LaundryMachineList} from './laundry-machine-list';
+
+const source = readFileSync(new URL('./laundry-machine-list.tsx', import.meta.url), 'utf8');
 
 const NOW_MS = Date.parse('2026-08-11T03:00:00.000Z');
 
@@ -179,5 +183,36 @@ describe('LaundryMachineList', () => {
         expect(markup.match(/data-laundry-machine-card="true"/gu)).toHaveLength(9);
         expect(markup).toContain('auto-rows-fr');
         expect(markup.match(/grid flex-1 grid-rows-2/gu)).toHaveLength(9);
+    });
+
+    it('구역·상태 필터, 문제 우선 정렬, 기기별 accordion을 제공한다', () => {
+        const markup = renderToStaticMarkup(
+            <LaundryMachineList machines={machines} nowMs={NOW_MS} />,
+        );
+
+        expect(markup).toContain('aria-label="구역"');
+        expect(markup).toContain('aria-label="상태"');
+        expect(markup).toContain('문제 우선 정렬');
+        expect(markup).toContain('aria-expanded="true"');
+        expect(markup).toContain('상세 접기');
+        expect(markup).toContain('min-h-11');
+        expect(source).not.toContain('if (views.length === 0) return null');
+        expect(source).toContain('필터 조건에 맞는 기기가 없습니다.');
+    });
+
+    it('stale 상세 카드마다 실시간 데이터가 아님을 표시한다', () => {
+        const markup = renderToStaticMarkup(
+            <LaundryMachineList
+                dataStale
+                machines={machines}
+                nowMs={NOW_MS}
+                staleLabel="오전 11:30"
+            />,
+        );
+
+        expect(markup).toContain('실시간 정보가 아닙니다 · 마지막 정상 시각 오전 11:30');
+        expect(markup.match(/data-data-state="stale"/gu)).toHaveLength(2);
+        expect(markup).toMatch(/실시간 정보가 아닙니다[^<]*<\/p>/u);
+        expect(source).toContain('text-base leading-6');
     });
 });

--- a/frontend/src/features/laundry/components/laundry-machine-list.tsx
+++ b/frontend/src/features/laundry/components/laundry-machine-list.tsx
@@ -1,22 +1,23 @@
 import {CircleAlert, CircleCheck, CircleDashed, Clock3, TriangleAlert} from 'lucide-react';
-import {useId} from 'react';
+import {useId, useMemo, useState} from 'react';
 
+import {EmptyState} from '@/components/dashboard/async-state';
 import {Card, CardContent, CardHeader} from '@/components/ui/card';
 import {Progress} from '@/components/ui/progress';
 import {TooltipProvider} from '@/components/ui/tooltip';
 import type {DashboardLaundryMachine} from '@/domain/laundry/capacity';
 import {cn} from '@/lib/utils';
 
-import {
-    laundryMachineDetail,
-    type LaundryApplianceDetailView,
-    type LaundryApplianceTone,
-} from '../lib/laundry-machine-detail';
+import type {LaundryApplianceDetailView, LaundryApplianceTone} from '../lib/laundry-machine-detail';
 import {
     LAUNDRY_WARNING_PROGRESS_CLASS_NAME,
     LAUNDRY_WARNING_TEXT_CLASS_NAME,
 } from '../lib/laundry-warning';
-import {sortWashTowers} from '../lib/wash-tower';
+import {
+    filterAndSortLaundryMachineViews,
+    type LaundryMachineStateFilter,
+    type LaundryMachineZoneFilter,
+} from '../pages/laundry-page-view';
 import {LaundryStatusHint} from './laundry-status-hint';
 import {LaundryZoneBadge} from './laundry-zone-badge';
 
@@ -24,6 +25,8 @@ export interface LaundryMachineListProps {
     machines: readonly DashboardLaundryMachine[];
     nowMs: number;
     showRiskWarnings?: boolean;
+    dataStale?: boolean;
+    staleLabel?: string | null;
 }
 
 const clockFormatter = new Intl.DateTimeFormat('ko-KR', {
@@ -46,6 +49,29 @@ function clockLabel(value: string): string {
     return clockFormatter.format(new Date(value));
 }
 
+const machineFilters = [
+    {id: 'all', label: '전체'},
+    {id: 'men', label: '남성'},
+    {id: 'common', label: '공용'},
+    {id: 'women', label: '여성'},
+    {id: 'other', label: '기타'},
+] as const;
+
+const stateFilters = [
+    {id: 'all', label: '전체'},
+    {id: 'running', label: '가동 중'},
+    {id: 'available', label: '사용 가능'},
+    {id: 'problem', label: '문제'},
+] as const;
+
+function isLaundryMachineListFilter(value: string): value is LaundryMachineListFilter {
+    return machineFilters.some((item) => item.id === value);
+}
+
+function isLaundryMachineStateFilter(value: string): value is LaundryMachineStateFilter {
+    return stateFilters.some((item) => item.id === value);
+}
+
 function StatusIcon({tone}: {tone: LaundryApplianceTone}) {
     const className = 'size-4 shrink-0';
     if (tone === 'available') return <CircleCheck className={className} />;
@@ -63,7 +89,7 @@ function RecentRiskNotice({view}: {view: LaundryApplianceDetailView}) {
     return (
         <div
             className={cn(
-                'rounded-md border px-3 py-2 text-xs leading-5',
+                'rounded-md border px-3 py-2 text-base leading-6',
                 view.riskLevel === 'caution'
                     ? 'border-destructive/40 bg-destructive/5 text-destructive'
                     : 'border-orange-400/60 bg-orange-50 text-orange-900 dark:border-orange-500/60 dark:bg-orange-950/40 dark:text-orange-200',
@@ -106,13 +132,13 @@ function ApplianceDetail({
             data-kind={view.kind}
         >
             <div className="flex min-w-0 items-center justify-between gap-3">
-                <h4 className="text-sm font-medium" id={titleId}>
+                <h4 className="text-base leading-6 font-medium" id={titleId}>
                     {view.label}
                 </h4>
                 <div className="flex min-w-0 items-center gap-0.5">
                     <span
                         className={cn(
-                            'inline-flex min-w-0 items-center gap-1.5 text-sm font-medium',
+                            'inline-flex min-w-0 items-center gap-1.5 text-base leading-6 font-medium',
                             statusClasses[view.tone],
                         )}
                         data-state={view.tone}
@@ -174,52 +200,165 @@ function ApplianceDetail({
     );
 }
 
+type CollapsibleMachineState = Record<string, boolean>;
+
+type LaundryMachineListFilter = LaundryMachineZoneFilter | 'all';
+
 export function LaundryMachineList({
     machines,
     nowMs,
     showRiskWarnings = false,
+    dataStale = false,
+    staleLabel,
 }: LaundryMachineListProps) {
     const titleId = useId();
-    const views = sortWashTowers(machines).map((machine) => laundryMachineDetail(machine, nowMs));
-    if (views.length === 0) return null;
+    const [zoneFilter, setZoneFilter] = useState<LaundryMachineListFilter>('all');
+    const [stateFilter, setStateFilter] = useState<LaundryMachineStateFilter>('all');
+    const [prioritizeProblems, setPrioritizeProblems] = useState(true);
+    const [expanded, setExpanded] = useState<CollapsibleMachineState>({});
+
+    const views = useMemo(
+        () =>
+            filterAndSortLaundryMachineViews({
+                machines,
+                nowMs,
+                zoneFilter,
+                stateFilter,
+                prioritizeProblems,
+            }).views,
+        [machines, nowMs, zoneFilter, stateFilter, prioritizeProblems],
+    );
 
     return (
         <section className="space-y-3" aria-labelledby={titleId} data-laundry-detail-list="true">
             <h2 className="font-semibold" id={titleId}>
                 기기별 상세 상태
             </h2>
-            <TooltipProvider delayDuration={200}>
-                <div className="grid auto-rows-fr gap-3 md:grid-cols-2 lg:grid-cols-3">
-                    {views.map((machine, machineIndex) => (
-                        <Card
-                            className="h-full gap-0 overflow-hidden py-0 shadow-none"
-                            data-laundry-machine-card="true"
-                            key={machine.id}
-                        >
-                            <CardHeader className="flex flex-row items-center justify-between gap-3 border-b px-4 py-3 [.border-b]:pb-3">
-                                <h3 className="text-base leading-none font-semibold">
-                                    {machine.title}
-                                </h3>
-                                <LaundryZoneBadge zone={machine.zone} />
-                            </CardHeader>
-                            <CardContent className="grid flex-1 grid-rows-2 p-0">
-                                <ApplianceDetail
-                                    machineTitle={machine.title}
-                                    showRiskWarning={showRiskWarnings}
-                                    titleId={`${titleId}-${machineIndex}-dryer`}
-                                    view={machine.dryer}
-                                />
-                                <ApplianceDetail
-                                    machineTitle={machine.title}
-                                    showRiskWarning={showRiskWarnings}
-                                    titleId={`${titleId}-${machineIndex}-washer`}
-                                    view={machine.washer}
-                                />
-                            </CardContent>
-                        </Card>
-                    ))}
-                </div>
-            </TooltipProvider>
+            {dataStale ? (
+                <p className="text-base leading-6 text-amber-700 dark:text-amber-300">
+                    실시간 정보가 아닙니다 · 마지막 정상 시각 {staleLabel ?? '확인 기록 없음'}
+                </p>
+            ) : null}
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <label className="flex flex-col text-base">
+                    <span className="mb-1 text-sm text-muted-foreground">구역</span>
+                    <select
+                        aria-label="구역"
+                        className="h-11 min-h-11 rounded-md border border-input bg-background px-3"
+                        value={zoneFilter}
+                        onChange={(event) => {
+                            if (isLaundryMachineListFilter(event.target.value)) {
+                                setZoneFilter(event.target.value);
+                            }
+                        }}
+                    >
+                        {machineFilters.map((item) => (
+                            <option key={item.id} value={item.id}>
+                                {item.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex flex-col text-base">
+                    <span className="mb-1 text-sm text-muted-foreground">상태</span>
+                    <select
+                        aria-label="상태"
+                        className="h-11 min-h-11 rounded-md border border-input bg-background px-3"
+                        value={stateFilter}
+                        onChange={(event) => {
+                            if (isLaundryMachineStateFilter(event.target.value)) {
+                                setStateFilter(event.target.value);
+                            }
+                        }}
+                    >
+                        {stateFilters.map((item) => (
+                            <option key={item.id} value={item.id}>
+                                {item.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+                <label className="flex min-h-11 items-center gap-3 text-base sm:col-span-2">
+                    <input
+                        className="size-5"
+                        checked={prioritizeProblems}
+                        onChange={(event) => {
+                            setPrioritizeProblems(event.target.checked);
+                        }}
+                        type="checkbox"
+                    />
+                    <span>문제 우선 정렬</span>
+                </label>
+            </div>
+
+            {views.length > 0 ? (
+                <TooltipProvider delayDuration={200}>
+                    <div className="grid auto-rows-fr gap-3 md:grid-cols-2 lg:grid-cols-3">
+                        {views.map((machine, machineIndex) => {
+                            const detailId = `${titleId}-detail-${machine.id}`;
+                            const isOpen = expanded[machine.id] ?? true;
+
+                            return (
+                                <Card
+                                    className="h-full gap-0 overflow-hidden py-0 shadow-none"
+                                    data-data-state={dataStale ? 'stale' : 'current'}
+                                    data-laundry-machine-card="true"
+                                    key={machine.id}
+                                >
+                                    <CardHeader className="flex flex-row items-center justify-between gap-3 border-b px-4 py-3 [.border-b]:pb-3">
+                                        <h3 className="text-base leading-none font-semibold">
+                                            {machine.title}
+                                        </h3>
+                                        <div className="flex items-center gap-2">
+                                            {dataStale ? (
+                                                <span className="text-base leading-6 text-amber-700 dark:text-amber-300">
+                                                    실시간 아님
+                                                </span>
+                                            ) : null}
+                                            <LaundryZoneBadge zone={machine.zone} />
+                                        </div>
+                                    </CardHeader>
+                                    <CardContent className="grid flex-1 grid-rows-2 p-0">
+                                        <button
+                                            aria-controls={detailId}
+                                            aria-expanded={isOpen}
+                                            className="min-h-11 rounded-none border-b px-4 py-3 text-left text-base font-semibold"
+                                            onClick={() => {
+                                                setExpanded((previous) => ({
+                                                    ...previous,
+                                                    [machine.id]: !isOpen,
+                                                }));
+                                            }}
+                                            type="button"
+                                        >
+                                            상세 {isOpen ? '접기' : '펼치기'}
+                                        </button>
+                                        <div id={detailId} hidden={!isOpen}>
+                                            <ApplianceDetail
+                                                machineTitle={machine.title}
+                                                showRiskWarning={showRiskWarnings}
+                                                titleId={`${titleId}-${machineIndex}-dryer`}
+                                                view={machine.dryer}
+                                            />
+                                            <ApplianceDetail
+                                                machineTitle={machine.title}
+                                                showRiskWarning={showRiskWarnings}
+                                                titleId={`${titleId}-${machineIndex}-washer`}
+                                                view={machine.washer}
+                                            />
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
+                    </div>
+                </TooltipProvider>
+            ) : (
+                <EmptyState
+                    title="필터 조건에 맞는 기기가 없습니다."
+                    description="구역이나 상태 필터를 바꿔 다시 확인해 주세요."
+                />
+            )}
         </section>
     );
 }

--- a/frontend/src/features/laundry/components/laundry-status-hint.test.tsx
+++ b/frontend/src/features/laundry/components/laundry-status-hint.test.tsx
@@ -8,7 +8,8 @@ describe('LaundryStatusHint', () => {
     it('정보 아이콘과 한국어 단어 단위 줄바꿈을 사용한다', () => {
         expect(source).toContain("import {Info} from 'lucide-react'");
         expect(source).toContain('<Info className="size-4" />');
-        expect(source).toContain('space-y-1.5 leading-5 break-keep');
+        expect(source).toContain('max-w-72 text-base');
+        expect(source).toContain('space-y-1.5 leading-6 break-keep');
         expect(source).not.toMatch(/CircleHelp|CircleInfo/u);
     });
 });

--- a/frontend/src/features/laundry/components/laundry-status-hint.tsx
+++ b/frontend/src/features/laundry/components/laundry-status-hint.tsx
@@ -20,8 +20,8 @@ export function LaundryStatusHint({children, label}: {children: ReactNode; label
                     <Info className="size-4" />
                 </button>
             </TooltipTrigger>
-            <TooltipContent className="max-w-72" sideOffset={6}>
-                <div className="space-y-1.5 leading-5 break-keep">{children}</div>
+            <TooltipContent className="max-w-72 text-base" sideOffset={6}>
+                <div className="space-y-1.5 leading-6 break-keep">{children}</div>
             </TooltipContent>
         </Tooltip>
     );

--- a/frontend/src/features/laundry/components/personal-laundry-section.test.tsx
+++ b/frontend/src/features/laundry/components/personal-laundry-section.test.tsx
@@ -126,6 +126,7 @@ function renderPersonalLaundry(
         personalAccess?: string;
         platformKind?: string;
         attendanceStatus?: string;
+        canCreateWatch?: boolean;
         serverSession?: string;
     } = {},
 ): string {
@@ -144,7 +145,10 @@ function renderPersonalLaundry(
 
     return renderToStaticMarkup(
         <QueryClientProvider client={client}>
-            <PersonalLaundrySection machines={options.machines ?? machines} />
+            <PersonalLaundrySection
+                canCreateWatch={options.canCreateWatch}
+                machines={options.machines ?? machines}
+            />
         </QueryClientProvider>,
     );
 }
@@ -215,5 +219,16 @@ describe('PersonalLaundrySection', () => {
         expect(markup).toContain('완료 확정');
         expect(addButton).toContain('w-full');
         expect(markup).toMatch(/data-slot="card"[^>]*class="[^"]*min-w-0/u);
+    });
+
+    test('stale 데이터에서는 새 알림만 막고 기존 알림 취소는 유지한다', () => {
+        const markup = renderPersonalLaundry({canCreateWatch: false});
+        const addButton = markup.match(/<button[^>]*data-laundry-watch-add="true"[^>]*>/u)?.[0];
+        const removeButton = markup.match(/<button[^>]*aria-label="1번 알림 취소"[^>]*>/u)?.[0];
+
+        expect(addButton).toContain('disabled=""');
+        expect(removeButton).not.toContain('disabled=""');
+        expect(markup).toContain('실시간 정보가 아닐 때는 새 세탁 알림을 설정할 수 없습니다.');
+        expect(markup).toContain('text-base leading-6');
     });
 });

--- a/frontend/src/features/laundry/components/personal-laundry-section.tsx
+++ b/frontend/src/features/laundry/components/personal-laundry-section.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/features/laundry/lib/personal-laundry';
 
 interface PersonalLaundrySectionProps {
+    canCreateWatch?: boolean;
     machines: DashboardLaundrySnapshot['machines'];
 }
 
@@ -45,6 +46,7 @@ interface LaundryWatchCardProps {
     activeWatches: readonly LaundryWatch[];
     adding: boolean;
     busy: boolean;
+    canCreateWatch: boolean;
     loading: boolean;
     notificationMode: LaundryNotificationMode;
     notifyBeforeMinutes: number;
@@ -74,6 +76,7 @@ function LaundryWatchCard({
     activeWatches,
     adding,
     busy,
+    canCreateWatch,
     loading,
     notificationMode,
     notifyBeforeMinutes,
@@ -98,7 +101,7 @@ function LaundryWatchCard({
                     <Bell className="size-4 text-primary" />
                     내 세탁 알림
                 </CardTitle>
-                <CardDescription>
+                <CardDescription className="text-base leading-6">
                     워시타워와 기기, 알림 시점을 선택해 한 가지 조건만 설정합니다.
                 </CardDescription>
             </CardHeader>
@@ -195,7 +198,7 @@ function LaundryWatchCard({
                                 </div>
                             </div>
                         ) : (
-                            <p className="rounded-lg bg-muted/50 p-4 text-sm text-muted-foreground">
+                            <p className="rounded-lg bg-muted/50 p-4 text-base leading-6 text-muted-foreground">
                                 기기 상태가 확인되면 알림 대상을 선택할 수 있습니다.
                             </p>
                         )}
@@ -222,7 +225,7 @@ function LaundryWatchCard({
                                         />
                                     </div>
                                 ) : (
-                                    <p className="min-w-0 flex-1 text-sm text-muted-foreground">
+                                    <p className="min-w-0 flex-1 text-base leading-6 text-muted-foreground">
                                         {notificationMode === 'estimated-completion'
                                             ? '예상 종료 시각에 알립니다.'
                                             : '기기에서 완료가 확인되면 알립니다.'}
@@ -232,6 +235,7 @@ function LaundryWatchCard({
                                     data-laundry-watch-add="true"
                                     className="w-full shrink-0 sm:w-auto"
                                     disabled={
+                                        !canCreateWatch ||
                                         !selectedTarget ||
                                         sessionUnavailable ||
                                         (notificationMode === 'before-completion' &&
@@ -252,8 +256,14 @@ function LaundryWatchCard({
                             </div>
                         ) : null}
 
+                        {!canCreateWatch ? (
+                            <p className="text-base leading-6 text-amber-700 dark:text-amber-300">
+                                실시간 정보가 아닐 때는 새 세탁 알림을 설정할 수 없습니다.
+                            </p>
+                        ) : null}
+
                         {sessionUnavailable ? (
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-base leading-6 text-muted-foreground">
                                 현재 동작 중인 기기만 알림을 설정할 수 있습니다.
                             </p>
                         ) : null}
@@ -288,7 +298,7 @@ function LaundryWatchCard({
                                 ))}
                             </ul>
                         ) : (
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-base leading-6 text-muted-foreground">
                                 설정된 세탁 알림이 없습니다.
                             </p>
                         )}
@@ -299,7 +309,10 @@ function LaundryWatchCard({
     );
 }
 
-function AuthenticatedPersonalLaundrySection({machines}: PersonalLaundrySectionProps) {
+function AuthenticatedPersonalLaundrySection({
+    canCreateWatch = true,
+    machines,
+}: PersonalLaundrySectionProps) {
     const {api, platform} = useDashboardEnvironment();
     const account = useDashboardAccount();
     const attendance = useAttendanceQuery();
@@ -420,6 +433,7 @@ function AuthenticatedPersonalLaundrySection({machines}: PersonalLaundrySectionP
                 activeWatches={activeWatches}
                 adding={addWatch.isPending}
                 busy={personalBusy}
+                canCreateWatch={canCreateWatch}
                 loading={watches.isPending}
                 notificationMode={notificationMode}
                 notifyBeforeMinutes={notifyBeforeMinutes}

--- a/frontend/src/features/laundry/components/wash-tower-grid.test.tsx
+++ b/frontend/src/features/laundry/components/wash-tower-grid.test.tsx
@@ -216,4 +216,20 @@ describe('WashTowerGrid', () => {
         expect(markup).toContain('title="워시타워_1 건조기 1시간 5분"');
         expect(markup).not.toContain('예상');
     });
+
+    it('모바일 가로 스크롤 안내와 stale 시각을 표 문맥 안에 표시한다', () => {
+        const markup = renderToStaticMarkup(
+            <WashTowerGrid
+                dataStale
+                dataStaleLabel="오전 11:30"
+                machines={machines}
+                nowMs={NOW_MS}
+            />,
+        );
+
+        expect(markup).toContain('좌우로 스크롤');
+        expect(markup).toContain('실시간 정보가 아닙니다 · 마지막 정상 시각 오전 11:30');
+        expect(markup).toContain('overflow-x-auto');
+        expect(markup.match(/text-base leading-6/gu)?.length).toBeGreaterThanOrEqual(2);
+    });
 });

--- a/frontend/src/features/laundry/components/wash-tower-grid.tsx
+++ b/frontend/src/features/laundry/components/wash-tower-grid.tsx
@@ -16,19 +16,35 @@ export interface WashTowerGridProps {
     machines: readonly DashboardLaundryMachine[];
     nowMs: number;
     showRiskIndicators?: boolean;
+    dataStale?: boolean;
+    dataStaleLabel?: string | null;
 }
 
-export function WashTowerGrid({machines, nowMs, showRiskIndicators = false}: WashTowerGridProps) {
+export function WashTowerGrid({
+    machines,
+    nowMs,
+    showRiskIndicators = false,
+    dataStale = false,
+    dataStaleLabel,
+}: WashTowerGridProps) {
     const towers = sortWashTowers(machines);
     if (towers.length === 0) return null;
 
     return (
         <div
             aria-label="워시타워 상태표"
-            className="overflow-x-auto pb-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            className="overflow-x-auto overscroll-x-contain pb-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
             role="region"
             tabIndex={0}
         >
+            {dataStale ? (
+                <p className="mb-2 text-base leading-6 text-amber-700 dark:text-amber-300">
+                    실시간 정보가 아닙니다 · 마지막 정상 시각 {dataStaleLabel ?? '확인 기록 없음'}
+                </p>
+            ) : null}
+            <p className="mb-2 block text-base leading-6 text-muted-foreground sm:hidden">
+                표가 화면을 벗어나면 좌우로 스크롤해 자세히 확인하세요.
+            </p>
             <table className="w-full min-w-[620px] table-fixed border-separate border-spacing-1">
                 <caption className="sr-only">워시타워 번호별 세탁기와 건조기 상태</caption>
                 <thead>

--- a/frontend/src/features/laundry/pages/laundry-page-view.test.ts
+++ b/frontend/src/features/laundry/pages/laundry-page-view.test.ts
@@ -1,8 +1,15 @@
 import {describe, expect, it} from 'vitest';
 
-import type {LaundryCapacitySnapshot} from '@/domain/laundry/capacity';
+import type {DashboardLaundrySnapshot} from '@/api/dashboard-api';
+import type {DashboardLaundryMachine, LaundryCapacitySnapshot} from '@/domain/laundry/capacity';
 
-import {capacityCards} from './laundry-page-view';
+import {
+    capacityCards,
+    filterAndSortLaundryMachineViews,
+    laundryPageState,
+    laundrySummaryFromSnapshot,
+    type LaundryMachineFilterInput,
+} from './laundry-page-view';
 
 const capacity: LaundryCapacitySnapshot = {
     basis: 'WASHER_AND_DRYER_HEADROOM_60_MIN',
@@ -51,3 +58,305 @@ describe('capacityCards', () => {
         ]);
     });
 });
+
+describe('laundrySummaryFromSnapshot', () => {
+    it('신뢰할 수 있는 스냅샷만 카운트를 노출한다', () => {
+        expect(
+            laundrySummaryFromSnapshot({
+                snapshot: {
+                    ...baseSnapshot,
+                    machines: [{...baseMachine, id: '워시타워_1'}],
+                },
+            }),
+        ).toEqual({men: 1, women: 1});
+
+        expect(
+            laundrySummaryFromSnapshot({
+                snapshot: {
+                    ...baseSnapshot,
+                    quality: {
+                        ...baseSnapshot.quality,
+                        collectorHealthy: false,
+                    },
+                },
+            }),
+        ).toEqual({men: null, women: null});
+    });
+});
+
+describe('laundryPageState', () => {
+    it('loading/normal/empty/stale/offline/error/recovered를 구분하고 캐시 재사용 문구를 준비한다', () => {
+        expect(
+            laundryPageState({
+                snapshot: null,
+                queryError: null,
+                manualRefreshError: null,
+            }).kind,
+        ).toBe('loading');
+
+        const normal = laundryPageState({
+            snapshot: baseSnapshot,
+            queryError: null,
+            manualRefreshError: null,
+        });
+        expect(normal.kind).toBe('normal');
+        expect(normal.allowWatchCreation).toBe(true);
+        expect(normal.lastKnownLabel).toBe('방금 전');
+
+        expect(
+            laundryPageState({
+                snapshot: {...baseSnapshot, machines: []},
+                queryError: null,
+                manualRefreshError: null,
+            }),
+        ).toMatchObject({kind: 'empty', allowWatchCreation: false});
+
+        expect(
+            laundryPageState({
+                snapshot: {
+                    ...baseSnapshot,
+                    quality: {
+                        ...baseSnapshot.quality,
+                        collectorHealthy: false,
+                    },
+                },
+                queryError: null,
+                manualRefreshError: null,
+            }),
+        ).toMatchObject({
+            kind: 'stale',
+            canRetry: true,
+            allowWatchCreation: false,
+            reason: 'collector-unavailable',
+            message: expect.stringContaining('실시간 정보가 아닙니다.'),
+        });
+
+        expect(
+            laundryPageState({
+                snapshot: baseSnapshot,
+                isOffline: true,
+                queryError: null,
+                manualRefreshError: null,
+            }),
+        ).toMatchObject({
+            kind: 'offline',
+            canRetry: false,
+            reason: 'offline',
+            allowWatchCreation: false,
+        });
+
+        expect(
+            laundryPageState({
+                snapshot: {
+                    ...baseSnapshot,
+                    quality: {
+                        ...baseSnapshot.quality,
+                        collection: 'STALE',
+                        sourceFreshness: 'REFRESH_OVERDUE',
+                    },
+                },
+                queryError: null,
+                manualRefreshError: null,
+            }),
+        ).toMatchObject({
+            kind: 'stale',
+            canRetry: true,
+            message: expect.stringContaining('실시간 정보가 아닙니다.'),
+        });
+
+        expect(
+            laundryPageState({
+                snapshot: baseSnapshot,
+                queryError: new Error('refresh failed'),
+                manualRefreshError: null,
+            }),
+        ).toMatchObject({
+            kind: 'stale',
+            canRetry: true,
+            reason: 'refresh-failed',
+            message: expect.stringContaining('실시간 정보가 아닙니다.'),
+        });
+
+        expect(
+            laundryPageState({
+                snapshot: baseSnapshot,
+                queryError: null,
+                manualRefreshError: null,
+                recovered: true,
+            }).kind,
+        ).toBe('recovered');
+    });
+
+    it('데이터가 없는 최초 요청은 loading/offline/error를 구분한다', () => {
+        expect(
+            laundryPageState({
+                snapshot: null,
+                isPending: true,
+                queryError: null,
+                manualRefreshError: null,
+            }).kind,
+        ).toBe('loading');
+        expect(
+            laundryPageState({
+                snapshot: null,
+                isOffline: true,
+                queryError: null,
+                manualRefreshError: null,
+            }).kind,
+        ).toBe('offline');
+        expect(
+            laundryPageState({
+                snapshot: null,
+                queryError: new Error('initial failure'),
+                manualRefreshError: null,
+            }).kind,
+        ).toBe('error');
+    });
+});
+
+describe('filterAndSortLaundryMachineViews', () => {
+    const filterInput: Omit<LaundryMachineFilterInput, 'zoneFilter' | 'stateFilter'> = {
+        machines: [
+            {
+                ...baseMachine,
+                id: '워시타워_1',
+                zone: 'men',
+                washer: {
+                    appliance: 'washer',
+                    operationalStatus: 'IDLE',
+                    projection: {status: 'IDLE', remainingMinutes: 0},
+                },
+                dryer: {
+                    appliance: 'dryer',
+                    operationalStatus: 'RUNNING',
+                    projection: {status: 'ESTIMATED_RUNNING', remainingMinutes: 15},
+                },
+            },
+            {
+                ...baseMachine,
+                id: '워시타워_2',
+                zone: 'common',
+                washer: {
+                    appliance: 'washer',
+                    operationalStatus: 'ERROR',
+                    errorCode: 'OE',
+                    projection: {status: 'ERROR', remainingMinutes: 0},
+                },
+                dryer: {
+                    appliance: 'dryer',
+                    operationalStatus: 'IDLE',
+                    projection: {status: 'IDLE', remainingMinutes: 0},
+                },
+            },
+            {
+                ...baseMachine,
+                id: '워시타워_3',
+                zone: 'women',
+                washer: {
+                    appliance: 'washer',
+                    operationalStatus: 'RUNNING',
+                    projection: {status: 'ESTIMATED_RUNNING', remainingMinutes: 10},
+                },
+                dryer: {
+                    appliance: 'dryer',
+                    operationalStatus: 'PAUSED',
+                    projection: {status: 'PAUSED', remainingMinutes: 0},
+                },
+            },
+        ],
+        nowMs: NOW_MS,
+        prioritizeProblems: true,
+    };
+
+    it('구역 필터와 상태 필터로 대상 리스트를 축소한다', () => {
+        const {views} = filterAndSortLaundryMachineViews({
+            ...filterInput,
+            zoneFilter: 'common',
+            stateFilter: 'problem',
+        });
+
+        expect(views).toHaveLength(1);
+        expect(views[0]?.id).toBe('워시타워_2');
+    });
+
+    it('문제 우선 정렬이 오류 기기를 앞에 둔다', () => {
+        const {views} = filterAndSortLaundryMachineViews({
+            ...filterInput,
+            zoneFilter: 'all',
+            stateFilter: 'all',
+        });
+
+        expect(views[0]?.id).toBe('워시타워_2');
+        expect(views[0]?.dryer.tone === 'available' || views[0]?.washer.tone === 'error').toBe(
+            true,
+        );
+    });
+});
+
+const NOW_MS = Date.parse('2026-08-11T03:00:00.000Z');
+
+const baseMachine: DashboardLaundryMachine = {
+    id: '워시타워_0',
+    zone: 'men',
+    washer: {
+        appliance: 'washer',
+        operationalStatus: 'IDLE',
+        projection: {status: 'IDLE', remainingMinutes: 0},
+    },
+    dryer: {
+        appliance: 'dryer',
+        operationalStatus: 'IDLE',
+        projection: {status: 'IDLE', remainingMinutes: 0},
+    },
+};
+
+const baseSnapshot: DashboardLaundrySnapshot = {
+    schemaVersion: 1,
+    asOf: '2026-08-11T03:00:00.000Z',
+    final: true,
+    quality: {
+        collectorHealthy: true,
+        collection: 'SUCCESS',
+        sourceFreshness: 'REFRESH_OBSERVED',
+        lastCheckedAt: '2026-08-11T03:00:00.000Z',
+        expectedRefreshIntervalSeconds: 30,
+    },
+    machines: [
+        {
+            ...baseMachine,
+            id: '워시타워_1',
+            zone: 'men',
+            washer: {
+                appliance: 'washer',
+                operationalStatus: 'IDLE',
+                projection: {status: 'IDLE', remainingMinutes: 0},
+            },
+            dryer: {
+                appliance: 'dryer',
+                operationalStatus: 'RUNNING',
+                projection: {status: 'ESTIMATED_RUNNING', remainingMinutes: 20},
+            },
+        },
+    ],
+    capacity: {
+        basis: 'WASHER_AND_DRYER_HEADROOM_60_MIN',
+        men: {
+            access: 'men',
+            washerAvailable: 1,
+            projectedDryerSupply: 1,
+            pendingDryerLoads: 0,
+            dryerHeadroom: 1,
+            startableLoads: 1,
+            reliable: true,
+        },
+        women: {
+            access: 'women',
+            washerAvailable: 1,
+            projectedDryerSupply: 1,
+            pendingDryerLoads: 0,
+            dryerHeadroom: 1,
+            startableLoads: 1,
+            reliable: true,
+        },
+    },
+};

--- a/frontend/src/features/laundry/pages/laundry-page-view.ts
+++ b/frontend/src/features/laundry/pages/laundry-page-view.ts
@@ -1,4 +1,17 @@
-import type {LaundryCapacityEstimate, LaundryCapacitySnapshot} from '@/domain/laundry/capacity';
+import type {DashboardLaundrySnapshot} from '@/api/dashboard-api';
+import type {
+    DashboardLaundryMachine,
+    LaundryCapacityEstimate,
+    LaundryCapacitySnapshot,
+} from '@/domain/laundry/capacity';
+import {laundryCapacity} from '@/domain/laundry/capacity';
+import {laundrySituationDataIsReliable} from '@/domain/laundry/freshness';
+import type {LaundryMachineZone} from '@/domain/laundry/status';
+import {relativeTimeLabel} from '@/lib/format';
+
+import type {LaundryMachineDetailView} from '../lib/laundry-machine-detail';
+import {laundryMachineDetail} from '../lib/laundry-machine-detail';
+import {sortWashTowers} from '../lib/wash-tower';
 
 export interface CapacityCardView {
     access: LaundryCapacityEstimate['access'];
@@ -6,6 +19,291 @@ export interface CapacityCardView {
     description: string;
     label: string;
     status: 'available' | 'full' | 'checking';
+}
+
+export type LaundryMachineZoneFilter = 'all' | LaundryMachineZone;
+
+export type LaundryMachineStateFilter = 'all' | 'running' | 'available' | 'problem';
+
+export interface LaundryMachineFilterInput {
+    machines: readonly DashboardLaundryMachine[];
+    nowMs: number;
+    zoneFilter: LaundryMachineZoneFilter;
+    stateFilter: LaundryMachineStateFilter;
+    prioritizeProblems: boolean;
+}
+
+export interface LaundryMachineFilterResult {
+    views: LaundryMachineDetailView[];
+}
+
+export interface LaundrySummaryCounts {
+    men: number | null;
+    women: number | null;
+}
+
+export type LaundryPageStateKind =
+    | 'loading'
+    | 'normal'
+    | 'empty'
+    | 'stale'
+    | 'offline'
+    | 'error'
+    | 'recovered';
+
+export type LaundryPageStateReason =
+    | 'offline'
+    | 'refresh-failed'
+    | 'collector-unavailable'
+    | 'collection-incomplete'
+    | 'source-stale'
+    | 'no-machines'
+    | 'recovered'
+    | null;
+
+export interface LaundryPageStatus {
+    kind: LaundryPageStateKind;
+    title: string;
+    message: string;
+    reason: LaundryPageStateReason;
+    retryLabel: string;
+    lastKnownAt: string | null;
+    lastKnownLabel: string;
+    canRetry: boolean;
+    allowWatchCreation: boolean;
+}
+
+export interface LaundryPageReliabilityFlags {
+    hasData: boolean;
+    isCollectorHealthy: boolean;
+    isCollectionSuccess: boolean;
+    isFreshEnough: boolean;
+}
+
+function zoneMatches(
+    machine: {zone: LaundryMachineFilterInput['machines'][number]['zone']},
+    zoneFilter: LaundryMachineZoneFilter,
+): boolean {
+    return zoneFilter === 'all' ? true : machine.zone === zoneFilter;
+}
+
+function toneSeverity(tone: LaundryMachineDetailView['washer']['tone']): number {
+    if (tone === 'error') return 0;
+    if (tone === 'warning') return 1;
+    if (tone === 'confirming') return 2;
+    if (tone === 'active') return 3;
+    if (tone === 'neutral') return 4;
+    return 5;
+}
+
+function hasProblem(view: LaundryMachineDetailView): boolean {
+    return [view.washer.tone, view.dryer.tone].some(
+        (tone) => tone === 'error' || tone === 'warning',
+    );
+}
+
+function hasState(view: LaundryMachineDetailView, stateFilter: LaundryMachineStateFilter): boolean {
+    if (stateFilter === 'all') return true;
+    if (stateFilter === 'problem') return hasProblem(view);
+    const tones = [view.washer.tone, view.dryer.tone];
+    if (stateFilter === 'available') {
+        return tones.some((tone) => tone === 'available');
+    }
+
+    return tones.some((tone) => tone === 'active' || tone === 'confirming');
+}
+
+function snapshotReliabilityFlags(input: {
+    snapshot: DashboardLaundrySnapshot;
+    nowMs: number;
+}): LaundryPageReliabilityFlags {
+    const freshness = laundrySituationDataIsReliable({
+        hasData: input.snapshot.machines.length > 0,
+        error: null,
+        sourceFreshness: input.snapshot.quality.sourceFreshness,
+        expectedRefreshIntervalSeconds: input.snapshot.quality.expectedRefreshIntervalSeconds,
+        snapshotSavedAt: Date.parse(input.snapshot.asOf),
+        nowMs: input.nowMs,
+    });
+
+    return {
+        hasData: input.snapshot.machines.length > 0,
+        isCollectorHealthy: input.snapshot.quality.collectorHealthy,
+        isCollectionSuccess: input.snapshot.quality.collection === 'SUCCESS',
+        isFreshEnough: freshness,
+    };
+}
+
+export function laundrySummaryFromSnapshot(input: {
+    snapshot: DashboardLaundrySnapshot;
+    nowMs?: number;
+}): LaundrySummaryCounts {
+    const snapshotTime = Date.parse(input.snapshot.quality.lastCheckedAt ?? input.snapshot.asOf);
+    return laundryCapacity(
+        input.snapshot.capacity,
+        isLaundrySnapshotReliable({
+            snapshot: input.snapshot,
+            nowMs: input.nowMs ?? (Number.isFinite(snapshotTime) ? snapshotTime : Date.now()),
+        }),
+    );
+}
+
+export function filterAndSortLaundryMachineViews(
+    input: LaundryMachineFilterInput,
+): LaundryMachineFilterResult {
+    const views: LaundryMachineDetailView[] = [];
+    for (const machine of sortWashTowers(input.machines)) {
+        const view = laundryMachineDetail(machine, input.nowMs);
+        if (!zoneMatches(view, input.zoneFilter) || !hasState(view, input.stateFilter)) continue;
+        views.push(view);
+    }
+
+    if (input.prioritizeProblems) {
+        views.sort((left, right) => {
+            const leftSeverity = Math.min(
+                toneSeverity(left.washer.tone),
+                toneSeverity(left.dryer.tone),
+            );
+            const rightSeverity = Math.min(
+                toneSeverity(right.washer.tone),
+                toneSeverity(right.dryer.tone),
+            );
+            if (leftSeverity !== rightSeverity) return leftSeverity - rightSeverity;
+            return left.title.localeCompare(right.title, 'ko');
+        });
+    }
+
+    return {views};
+}
+
+function isLaundrySnapshotReliable(input: {
+    snapshot: DashboardLaundrySnapshot;
+    nowMs: number;
+}): boolean {
+    const flags = snapshotReliabilityFlags({snapshot: input.snapshot, nowMs: input.nowMs});
+    return (
+        flags.hasData &&
+        flags.isCollectorHealthy &&
+        flags.isCollectionSuccess &&
+        flags.isFreshEnough
+    );
+}
+
+function lastKnownAtLabel(snapshot: DashboardLaundrySnapshot, nowMs: number): string {
+    const lastChecked = snapshot.quality.lastCheckedAt ?? snapshot.asOf;
+    return relativeTimeLabel(lastChecked, nowMs);
+}
+
+export function laundryPageState(input: {
+    snapshot: DashboardLaundrySnapshot | null;
+    nowMs?: number;
+    isPending?: boolean;
+    isOffline?: boolean;
+    queryError: unknown;
+    manualRefreshError: unknown;
+    recovered?: boolean;
+}): LaundryPageStatus {
+    if (!input.snapshot) {
+        const kind: LaundryPageStateKind = input.isOffline
+            ? 'offline'
+            : input.queryError || input.manualRefreshError
+              ? 'error'
+              : input.isPending === false
+                ? 'empty'
+                : 'loading';
+
+        return {
+            kind,
+            title:
+                kind === 'offline'
+                    ? '현재 오프라인 상태입니다.'
+                    : kind === 'error'
+                      ? '세탁실 상태를 불러오지 못했습니다.'
+                      : kind === 'empty'
+                        ? '표시할 세탁실 정보가 없습니다.'
+                        : '세탁 상태를 불러오는 중입니다.',
+            message:
+                kind === 'offline'
+                    ? '인터넷 연결 후 다시 시도해 주세요.'
+                    : kind === 'error'
+                      ? '연결 상태를 확인하고 다시 시도해 주세요.'
+                      : kind === 'empty'
+                        ? '수집된 기기 데이터가 없습니다.'
+                        : '세탁실 상태를 불러오는 중입니다.',
+            reason: kind === 'offline' ? 'offline' : kind === 'error' ? 'refresh-failed' : null,
+            retryLabel: '새로고침',
+            lastKnownAt: null,
+            lastKnownLabel: '확인 기록 없음',
+            canRetry: kind === 'error',
+            allowWatchCreation: false,
+        };
+    }
+
+    const snapshotTime = Date.parse(input.snapshot.quality.lastCheckedAt ?? input.snapshot.asOf);
+    const nowMs = input.nowMs ?? (Number.isFinite(snapshotTime) ? snapshotTime : Date.now());
+    const backgroundError = Boolean(input.queryError || input.manualRefreshError);
+    const collectorUnavailable = !input.snapshot.quality.collectorHealthy;
+    const collectionIncomplete = input.snapshot.quality.collection !== 'SUCCESS';
+    const sourceStale =
+        input.snapshot.machines.length > 0 &&
+        !snapshotReliabilityFlags({snapshot: input.snapshot, nowMs}).isFreshEnough;
+
+    let kind: LaundryPageStateKind = 'normal';
+    let title = '세탁실 상태를 표시합니다.';
+    let message = '실시간 상태를 확인했습니다.';
+    let reason: LaundryPageStateReason = null;
+
+    if (input.isOffline) {
+        kind = 'offline';
+        title = '현재 오프라인 상태입니다.';
+        message = '인터넷 연결이 없어 마지막 정상 데이터를 표시합니다. 실시간 정보가 아닙니다.';
+        reason = 'offline';
+    } else if (backgroundError) {
+        kind = 'stale';
+        title = '최신 세탁실 상태를 불러오지 못했습니다.';
+        message = '조회 실패로 마지막 정상 데이터를 표시합니다. 실시간 정보가 아닙니다.';
+        reason = 'refresh-failed';
+    } else if (collectorUnavailable) {
+        kind = 'stale';
+        title = '세탁실 수집 서버에 문제가 있습니다.';
+        message = '수집 서버 문제로 마지막 정상 데이터를 표시합니다. 실시간 정보가 아닙니다.';
+        reason = 'collector-unavailable';
+    } else if (collectionIncomplete) {
+        kind = 'stale';
+        title = '세탁실 수집이 완료되지 않았습니다.';
+        message = '일부 수집이 완료되지 않아 실시간 정보가 아닙니다.';
+        reason = 'collection-incomplete';
+    } else if (sourceStale) {
+        kind = 'stale';
+        title = '세탁실 상태가 늦게 반영됩니다.';
+        message = '수집이 지연되어 실시간 정보가 아닙니다.';
+        reason = 'source-stale';
+    } else if (input.snapshot.machines.length === 0) {
+        kind = 'empty';
+        title = '표시할 워시타워가 없습니다.';
+        message = '현재 표시할 기기 데이터가 없습니다.';
+        reason = 'no-machines';
+    } else if (input.recovered) {
+        kind = 'recovered';
+        title = '세탁실 상태가 복구되었습니다.';
+        message = '이전 조회 문제에서 정상 조회로 전환되었습니다.';
+        reason = 'recovered';
+    }
+
+    const allowsCreation =
+        input.snapshot.machines.length > 0 && (kind === 'normal' || kind === 'recovered');
+
+    return {
+        kind,
+        title,
+        message,
+        reason,
+        retryLabel: '새로고침',
+        lastKnownAt: input.snapshot.quality.lastCheckedAt ?? input.snapshot.asOf,
+        lastKnownLabel: lastKnownAtLabel(input.snapshot, nowMs),
+        canRetry: kind === 'stale',
+        allowWatchCreation: allowsCreation,
+    };
 }
 
 export function capacityCards(

--- a/frontend/src/features/laundry/pages/laundry-page.test.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.test.tsx
@@ -3,6 +3,10 @@ import {readFileSync} from 'node:fs';
 import {describe, expect, it} from 'vitest';
 
 const source = readFileSync(new URL('./laundry-page.tsx', import.meta.url), 'utf8');
+const boundarySource = readFileSync(
+    new URL('../components/laundry-feature-boundary.tsx', import.meta.url),
+    'utf8',
+);
 const zoneSource = readFileSync(
     new URL('../../../components/dashboard/laundry-zone-presentation.ts', import.meta.url),
     'utf8',
@@ -53,5 +57,16 @@ describe('LaundryPage capacity summary', () => {
         expect(source).toContain('showRiskWarnings={showRisk}');
         expect(source).not.toContain('전체 에러율');
         expect(source).not.toContain('에러 위험 요약');
+    });
+
+    it('페이지 헤더 밖의 local async boundary로 세탁 실패를 격리한다', () => {
+        const pageSource = source.slice(source.indexOf('export function LaundryPage()'));
+
+        expect(pageSource.indexOf('<PageHeader')).toBeLessThan(
+            pageSource.indexOf('<LaundryDataRegion'),
+        );
+        expect(boundarySource).toContain('<AsyncBoundary');
+        expect(boundarySource).toContain('regionLabel="세탁실 데이터"');
+        expect(boundarySource).toContain('type="offline"');
     });
 });

--- a/frontend/src/features/laundry/pages/laundry-page.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.tsx
@@ -1,41 +1,147 @@
-import {CircleAlert, RefreshCw, WashingMachine} from 'lucide-react';
+import {RefreshCw, WashingMachine} from 'lucide-react';
 import {useId, useState} from 'react';
 
 import {useDashboardEnvironment} from '@/app/dashboard-context';
 import {useCampusManualRefresh, useSuspenseLaundryQuery} from '@/app/use-dashboard-queries';
+import {AsyncState, useOnlineStatus} from '@/components/dashboard/async-state';
 import {laundryZonePresentation} from '@/components/dashboard/laundry-zone-presentation';
 import {PageHeader} from '@/components/dashboard/page-header';
-import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
 import {Button} from '@/components/ui/button';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
 import {Label} from '@/components/ui/label';
 import {Switch} from '@/components/ui/switch';
 import {laundrySituationDataIsReliable} from '@/domain/laundry/freshness';
-import {relativeTimeLabel} from '@/lib/format';
+import {dateTimeLabel, relativeTimeLabel} from '@/lib/format';
 import {cn} from '@/lib/utils';
 
+import {LaundryFeatureBoundary} from '../components/laundry-feature-boundary';
 import {LaundryMachineList} from '../components/laundry-machine-list';
 import {LaundryWarningBadge} from '../components/laundry-warning-badge';
 import {LaundryZoneBadge} from '../components/laundry-zone-badge';
 import {PersonalLaundrySection} from '../components/personal-laundry-section';
 import {WashTowerGrid} from '../components/wash-tower-grid';
-import {capacityCards, type CapacityCardView} from './laundry-page-view';
+import {
+    capacityCards,
+    laundryPageState,
+    type CapacityCardView,
+    type LaundryPageStatus,
+} from './laundry-page-view';
+
+export {LaundryFeatureBoundary} from '../components/laundry-feature-boundary';
+
+const LAUNDRY_JUMPS = [
+    ['요약', 'laundry-capacity-title'],
+    ['워시타워', 'laundry-tower-title'],
+    ['기기 상세', 'laundry-detail-title'],
+    ['내 알림', 'laundry-watch-title'],
+] as const;
+
+type LaundryFailureKind = 'error' | 'offline' | 'stale';
+
+function isFailureKind(kind: LaundryPageStatus['kind']): kind is LaundryFailureKind {
+    return kind === 'stale' || kind === 'offline' || kind === 'error';
+}
 
 function capacityTone(card: CapacityCardView): string {
     if (card.status === 'checking') return 'border-border bg-muted/30';
     return laundryZonePresentation(card.access).surfaceClassName;
 }
 
-export function LaundryPage() {
+function staleBanner(status: LaundryPageStatus): string | null {
+    if (!isFailureKind(status.kind)) return null;
+    return `실시간 정보가 아닙니다. 마지막 정상 시각: ${status.lastKnownLabel}`;
+}
+
+const COLLECTOR_UNAVAILABLE_TITLE = '세탁실 수집 서버에 문제가 있습니다.';
+const COLLECTOR_UNAVAILABLE_MESSAGE =
+    '실시간 상태를 확인할 수 없어 마지막 정상 데이터를 표시합니다.';
+
+function laundryReasonLabel(reason: LaundryPageStatus['reason']): string | undefined {
+    if (reason === 'offline') return '네트워크 연결 끊김';
+    if (reason === 'refresh-failed') return '최신 세탁실 상태 갱신 실패';
+    if (reason === 'collector-unavailable') return '수집 서버 응답 없음';
+    if (reason === 'collection-incomplete') return '일부 기기 수집 미완료';
+    if (reason === 'source-stale') return '세탁실 데이터 갱신 지연';
+    if (reason === 'no-machines') return '수집된 기기 없음';
+    if (reason === 'recovered') return '정상 조회 재개';
+    return undefined;
+}
+
+function LaundryStatusNotice({
+    manualRefresh,
+    status,
+    title,
+    message,
+}: {
+    manualRefresh: ReturnType<typeof useCampusManualRefresh>;
+    status: LaundryPageStatus;
+    title: string;
+    message: string;
+}) {
+    if (status.kind === 'normal' || status.kind === 'loading') return null;
+
+    if (status.kind === 'empty') {
+        return (
+            <AsyncState
+                type="empty"
+                title={title}
+                description={message}
+                regionLabel="세탁실 데이터 상태"
+            />
+        );
+    }
+
+    if (status.kind === 'error') {
+        return (
+            <AsyncState
+                type="error"
+                title={title}
+                description={message}
+                regionLabel="세탁실 데이터 상태"
+                retry={
+                    status.canRetry && !manualRefresh.isPending ? manualRefresh.mutate : undefined
+                }
+                retryLabel={status.retryLabel}
+            />
+        );
+    }
+
+    return (
+        <AsyncState
+            type={status.kind}
+            title={title}
+            description={message}
+            lastUpdatedAt={status.lastKnownAt ? dateTimeLabel(status.lastKnownAt) : undefined}
+            reason={laundryReasonLabel(status.reason)}
+            regionLabel="세탁실 데이터 상태"
+            retry={status.canRetry && !manualRefresh.isPending ? manualRefresh.mutate : undefined}
+            retryLabel={status.retryLabel}
+        />
+    );
+}
+
+function LaundryPageBody({
+    manualRefresh,
+}: {
+    manualRefresh: ReturnType<typeof useCampusManualRefresh>;
+}) {
     const {platform} = useDashboardEnvironment();
-    const laundry = useSuspenseLaundryQuery();
-    const manualRefresh = useCampusManualRefresh('laundry');
+    const isOnline = useOnlineStatus();
     const riskToggleId = useId();
     const riskIndicatorAvailable = platform.capabilities.laundryRiskIndicator;
     const [showRisk, setShowRisk] = useState(riskIndicatorAvailable);
 
+    const laundry = useSuspenseLaundryQuery();
     const snapshot = laundry.data;
     const nowMs = laundry.dataUpdatedAt;
+    const manualRefreshFailureIsCurrent =
+        manualRefresh.isError && manualRefresh.submittedAt >= laundry.dataUpdatedAt;
+    const recoveredFromManualRefresh =
+        manualRefresh.isError &&
+        manualRefresh.submittedAt > 0 &&
+        laundry.dataUpdatedAt > manualRefresh.submittedAt;
+
+    const collectorUnavailable = !snapshot.quality.collectorHealthy;
     const reliable =
         snapshot.quality.collectorHealthy &&
         snapshot.quality.collection === 'SUCCESS' &&
@@ -47,42 +153,47 @@ export function LaundryPage() {
             snapshotSavedAt: Date.parse(snapshot.asOf),
             nowMs,
         });
+
+    const status = laundryPageState({
+        snapshot,
+        nowMs,
+        isOffline: !isOnline || laundry.fetchStatus === 'paused',
+        queryError: laundry.error,
+        manualRefreshError: manualRefreshFailureIsCurrent ? manualRefresh.error : null,
+        recovered:
+            (recoveredFromManualRefresh ||
+                (laundry.errorUpdatedAt > 0 && laundry.dataUpdatedAt > laundry.errorUpdatedAt)) &&
+            !laundry.isError &&
+            !laundry.isStale &&
+            !manualRefreshFailureIsCurrent,
+    });
+
+    const dataStale = collectorUnavailable || isFailureKind(status.kind);
+    const staleLabel = staleBanner(status);
+    const statusTitle = collectorUnavailable ? COLLECTOR_UNAVAILABLE_TITLE : status.title;
+    const statusMessage = collectorUnavailable ? COLLECTOR_UNAVAILABLE_MESSAGE : status.message;
     const summaries = capacityCards(snapshot.capacity, reliable);
-    const refreshFailed = laundry.isError || manualRefresh.isError;
-    const refreshing = laundry.isFetching || manualRefresh.isPending;
-    const collectorUnavailable = !snapshot.quality.collectorHealthy;
 
     return (
         <div className="space-y-6">
-            <PageHeader
-                title="세탁실"
-                actions={
-                    <Button
-                        disabled={refreshing}
-                        variant="outline"
-                        onClick={() => manualRefresh.mutate()}
-                    >
-                        <RefreshCw className={cn(refreshing && 'animate-spin')} />
-                        {refreshing ? '새로고침 중' : '새로고침'}
-                    </Button>
-                }
+            <LaundryStatusNotice
+                manualRefresh={manualRefresh}
+                message={statusMessage}
+                status={status}
+                title={statusTitle}
             />
 
-            {collectorUnavailable ? (
-                <Alert variant="destructive">
-                    <CircleAlert />
-                    <AlertTitle>세탁실 수집 서버에 문제가 있습니다.</AlertTitle>
-                    <AlertDescription>
-                        실시간 상태를 확인할 수 없어 마지막 정상 데이터를 표시합니다.
-                    </AlertDescription>
-                </Alert>
-            ) : refreshFailed ? (
-                <Alert variant="destructive">
-                    <CircleAlert />
-                    <AlertTitle>최신 기기 상태를 불러오지 못했습니다.</AlertTitle>
-                    <AlertDescription>마지막으로 확인한 기기 상태를 표시합니다.</AlertDescription>
-                </Alert>
-            ) : null}
+            <nav aria-label="세부 섹션 이동" className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {LAUNDRY_JUMPS.map(([label, anchor]) => (
+                    <a
+                        key={anchor}
+                        className="min-h-11 rounded-md border border-border px-3 py-3 text-center text-base hover:bg-muted/50"
+                        href={`#${anchor}`}
+                    >
+                        {label}
+                    </a>
+                ))}
+            </nav>
 
             <section aria-labelledby="laundry-capacity-title">
                 <div className="mb-3">
@@ -91,8 +202,13 @@ export function LaundryPage() {
                     </h2>
                     <p className="text-xs text-muted-foreground">
                         마지막 확인{' '}
-                        {relativeTimeLabel(snapshot.quality.lastCheckedAt ?? snapshot.asOf)}
+                        {relativeTimeLabel(snapshot.quality.lastCheckedAt ?? snapshot.asOf, nowMs)}
                     </p>
+                    {staleLabel ? (
+                        <p className="text-base leading-6 text-amber-700 dark:text-amber-300">
+                            {staleLabel}
+                        </p>
+                    ) : null}
                 </div>
                 <div className="grid gap-3 sm:grid-cols-2">
                     {summaries.map((card) => (
@@ -109,14 +225,14 @@ export function LaundryPage() {
                                 <CardTitle className="flex items-baseline gap-2 text-3xl tabular-nums">
                                     {card.count === null ? '—' : `${card.count}회`}
                                     {card.count === null ? null : (
-                                        <span className="text-xs font-normal text-muted-foreground">
+                                        <span className="text-sm font-normal text-muted-foreground">
                                             지금 시작 가능
                                         </span>
                                     )}
                                 </CardTitle>
                             </CardHeader>
                             {card.status !== 'available' ? (
-                                <CardContent className="px-5 text-xs leading-5 text-muted-foreground">
+                                <CardContent className="px-5 text-base leading-6 text-muted-foreground">
                                     {card.description}
                                 </CardContent>
                             ) : null}
@@ -125,7 +241,7 @@ export function LaundryPage() {
                 </div>
             </section>
 
-            <Card className="gap-0 overflow-hidden py-0">
+            <Card className="gap-0 overflow-hidden py-0" id="laundry-tower-title">
                 <CardHeader className="flex items-center justify-between gap-2 border-b px-4 py-3 sm:px-6 [.border-b]:pb-3">
                     <h2 className="flex items-center gap-2 leading-none font-semibold">
                         <WashingMachine className="size-4 text-primary" />
@@ -154,27 +270,92 @@ export function LaundryPage() {
                     </div>
                 ) : null}
                 <CardContent className="px-4 pt-0 pb-3 sm:px-6">
+                    {staleLabel ? (
+                        <p className="mb-2 text-base leading-6 text-amber-700 dark:text-amber-300">
+                            {staleLabel}
+                        </p>
+                    ) : null}
                     {snapshot.machines.length > 0 ? (
                         <WashTowerGrid
                             machines={snapshot.machines}
                             nowMs={nowMs}
                             showRiskIndicators={showRisk}
+                            dataStale={dataStale}
+                            dataStaleLabel={status.lastKnownLabel}
                         />
                     ) : (
-                        <p className="py-5 text-center text-sm text-muted-foreground">
+                        <p className="py-5 text-center text-base leading-6 text-muted-foreground">
                             표시할 워시타워가 없습니다.
                         </p>
                     )}
                 </CardContent>
             </Card>
 
-            <LaundryMachineList
-                machines={snapshot.machines}
-                nowMs={nowMs}
-                showRiskWarnings={showRisk}
-            />
+            <section aria-label="기기별 상세 상태" id="laundry-detail-title">
+                <LaundryMachineList
+                    machines={snapshot.machines}
+                    nowMs={nowMs}
+                    showRiskWarnings={showRisk}
+                    dataStale={dataStale}
+                    staleLabel={status.lastKnownLabel}
+                />
+            </section>
 
-            <PersonalLaundrySection machines={snapshot.machines} />
+            <section aria-label="내 세탁 알림" id="laundry-watch-title">
+                {status.allowWatchCreation ? (
+                    <PersonalLaundrySection machines={snapshot.machines} />
+                ) : (
+                    <PersonalLaundrySection canCreateWatch={false} machines={snapshot.machines} />
+                )}
+                {status.kind === 'recovered' ? (
+                    <p className="mt-2 text-base leading-6 text-emerald-700 dark:text-emerald-300">
+                        이전 오류에서 복구되어 실시간 조회가 재개됩니다.
+                    </p>
+                ) : null}
+            </section>
+        </div>
+    );
+}
+
+export interface LaundryDataRegionProps {
+    manualRefresh: ReturnType<typeof useCampusManualRefresh>;
+}
+
+/** Query and failure boundary that can be mounted independently from sibling features. */
+export function LaundryDataRegion({manualRefresh}: LaundryDataRegionProps) {
+    return (
+        <LaundryFeatureBoundary>
+            <LaundryPageBody manualRefresh={manualRefresh} />
+        </LaundryFeatureBoundary>
+    );
+}
+
+export function LaundryFeature() {
+    const manualRefresh = useCampusManualRefresh('laundry');
+    return <LaundryDataRegion manualRefresh={manualRefresh} />;
+}
+
+export function LaundryPage() {
+    const manualRefresh = useCampusManualRefresh('laundry');
+    const isOnline = useOnlineStatus();
+    const refreshing = manualRefresh.isPending;
+
+    return (
+        <div className="space-y-6">
+            <PageHeader
+                title="세탁실"
+                actions={
+                    <Button
+                        disabled={refreshing || !isOnline}
+                        variant="outline"
+                        onClick={() => manualRefresh.mutate()}
+                    >
+                        <RefreshCw className={cn(refreshing && 'animate-spin')} />
+                        {!isOnline ? '오프라인' : refreshing ? '새로고침 중' : '새로고침'}
+                    </Button>
+                }
+            />
+            <LaundryDataRegion manualRefresh={manualRefresh} />
         </div>
     );
 }

--- a/frontend/src/features/meals/components/meal-history-section.tsx
+++ b/frontend/src/features/meals/components/meal-history-section.tsx
@@ -88,7 +88,10 @@ function MealHistoryMonth({
                     />
                 </Card>
                 <section aria-labelledby="selected-history-date-title" className="min-w-0">
-                    <h3 className="mb-3 text-sm font-semibold" id="selected-history-date-title">
+                    <h3
+                        className="mb-3 text-base leading-6 font-semibold"
+                        id="selected-history-date-title"
+                    >
                         {activeHistoryDate ? mealDateLabel(activeHistoryDate) : '선택한 날짜 식단'}
                     </h3>
                     {activeHistoryMeals.length > 0 ? (
@@ -103,7 +106,10 @@ function MealHistoryMonth({
                 </section>
             </div>
             <section aria-labelledby="selected-history-week-title" data-meal-history-weekly="true">
-                <h3 className="mb-3 text-sm font-semibold" id="selected-history-week-title">
+                <h3
+                    className="mb-3 text-base leading-6 font-semibold"
+                    id="selected-history-week-title"
+                >
                     선택한 주 급식표
                 </h3>
                 {activeWeeklyMenu ? (

--- a/frontend/src/features/meals/components/meal-post-card.test.tsx
+++ b/frontend/src/features/meals/components/meal-post-card.test.tsx
@@ -64,7 +64,25 @@ describe('MealPostCard', () => {
         expect(markup).toContain('메뉴가 아직 올라오지 않았습니다.');
         expect(markup).toContain('bg-muted/60');
         expect(markup).toContain('text-muted-foreground');
+        expect(markup.match(/text-base/gu)?.length).toBeGreaterThanOrEqual(2);
+        expect(markup.match(/leading-6/gu)?.length).toBeGreaterThanOrEqual(2);
         expect(markup).not.toContain('animate-pulse');
+    });
+
+    it('텍스트가 이미지보다 먼저 렌더링되고 이미지에 펼치기/접기 토글이 존재한다', () => {
+        const markup = renderToStaticMarkup(<MealPostCard meal={meal} />);
+        const titleIndex = markup.indexOf('중식 메뉴');
+        const imageContainerIndex = markup.indexOf('aria-label="8월 11일(화) 중식 메뉴 이미지"');
+
+        expect(titleIndex).toBeGreaterThan(-1);
+        expect(imageContainerIndex).toBeGreaterThan(titleIndex);
+        expect(markup).toContain('aria-controls="lunch-image-preview"');
+        expect(markup).toContain('aria-expanded="false"');
+        expect(markup).toContain('이미지 펼치기');
+        expect(markup).toContain('class="mt-3 min-h-11 w-full"');
+        expect(markup).toContain('max-h-44');
+        expect(markup).toContain('aria-hidden="true"');
+        expect(markup).toContain('tabindex="-1"');
     });
 
     it('게시물 전체가 없으면 빈 상태를 한 번만 표시한다', () => {

--- a/frontend/src/features/meals/components/meal-post-card.tsx
+++ b/frontend/src/features/meals/components/meal-post-card.tsx
@@ -13,11 +13,13 @@ function MealImage({
     compact,
     eager,
     image,
+    interactive,
     label,
 }: {
     compact: boolean;
     eager: boolean;
     image: NonNullable<DashboardMealPost['images']>[number];
+    interactive: boolean;
     label: string;
 }) {
     const [failed, setFailed] = useState(false);
@@ -43,6 +45,7 @@ function MealImage({
             className="block focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
             href={image.url}
             rel="noopener noreferrer"
+            tabIndex={interactive ? undefined : -1}
             target="_blank"
         >
             <img
@@ -72,34 +75,16 @@ export function MealPostCard({
     meal: DashboardMealPost;
 }) {
     const images = meal.images ?? [];
-    const title = meal.title ?? '\uC2DD\uB2E8 \uC548\uB0B4';
+    const title = meal.title ?? '식단 안내';
     const text = meal.text.trim();
+    const imageSectionId = `${meal.id}-image-preview`;
+    const [isImageExpanded, setIsImageExpanded] = useState(false);
+
     return (
         <Card
             className={cn('overflow-hidden py-0 shadow-none', compact && 'gap-4')}
             data-meal-state="available"
         >
-            {images.length > 0 ? (
-                <div className={cn('grid gap-px bg-border', images.length > 1 && 'grid-cols-2')}>
-                    {images.map((image, index) => (
-                        <MealImage
-                            compact={compact}
-                            eager={eagerImage && index === 0}
-                            image={image}
-                            key={image.sha}
-                            label={`${title} \uC0AC\uC9C4${images.length > 1 ? ` ${index + 1}` : ''}`}
-                        />
-                    ))}
-                </div>
-            ) : (
-                <div
-                    aria-label={`${title} \uC0AC\uC9C4 \uC5C6\uC74C`}
-                    className="flex aspect-[4/3] items-center justify-center border-b bg-muted/60 px-5 text-center text-xs text-muted-foreground"
-                    role="img"
-                >
-                    급식 사진이 아직 올라오지 않았습니다.
-                </div>
-            )}
             <CardHeader className="px-5 pt-5">
                 <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
@@ -126,18 +111,62 @@ export function MealPostCard({
                 {text ? (
                     <p
                         className={cn(
-                            'text-sm leading-6 whitespace-pre-wrap text-foreground/85',
+                            'text-base leading-6 whitespace-pre-wrap text-foreground/85',
                             compact && 'line-clamp-5',
                         )}
                     >
                         {text}
                     </p>
                 ) : (
-                    <p className="rounded-md bg-muted/60 p-3 text-sm leading-6 text-muted-foreground">
+                    <p className="rounded-md bg-muted/60 p-3 text-base leading-6 text-muted-foreground">
                         메뉴가 아직 올라오지 않았습니다.
                     </p>
                 )}
             </CardContent>
+            {images.length > 0 ? (
+                <section aria-label={`${title} 이미지`} className="px-5 pb-5">
+                    <div
+                        aria-hidden={!isImageExpanded}
+                        className={cn(
+                            'grid gap-px overflow-hidden rounded-lg border bg-border transition-[max-height] duration-200',
+                            images.length > 1 && 'grid-cols-2',
+                            isImageExpanded ? 'max-h-none' : 'max-h-44',
+                        )}
+                        id={imageSectionId}
+                    >
+                        {images.map((image, index) => (
+                            <MealImage
+                                compact={compact}
+                                eager={eagerImage && index === 0}
+                                image={image}
+                                interactive={isImageExpanded}
+                                key={image.sha}
+                                label={`${title} 사진${images.length > 1 ? ` ${index + 1}` : ''}`}
+                            />
+                        ))}
+                    </div>
+                    <div className="mt-3 min-h-11 w-full">
+                        <Button
+                            aria-controls={imageSectionId}
+                            aria-expanded={isImageExpanded}
+                            className="min-h-11 w-full"
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setIsImageExpanded((current) => !current)}
+                        >
+                            {isImageExpanded ? '이미지 접기' : '이미지 펼치기'}
+                        </Button>
+                    </div>
+                </section>
+            ) : (
+                <div
+                    aria-label={`${title} 사진 없음`}
+                    className="flex aspect-[4/3] items-center justify-center border-b bg-muted/60 px-5 text-center text-base leading-6 text-muted-foreground"
+                    role="img"
+                >
+                    급식 사진이 아직 올라오지 않았습니다.
+                </div>
+            )}
         </Card>
     );
 }
@@ -146,7 +175,7 @@ export function MissingMealPostCard({period}: {period: TodayMealPeriod}) {
     return (
         <Card className="gap-0 overflow-hidden py-0 shadow-none" data-meal-state="missing">
             <div
-                aria-label={`${period} \uC2DD\uB2E8 \uAC8C\uC2DC \uB300\uAE30`}
+                aria-label={`${period} 식단 게시 대기`}
                 className="flex aspect-[4/3] items-center justify-center border-b bg-muted/60 text-muted-foreground"
                 role="img"
             >
@@ -154,7 +183,9 @@ export function MissingMealPostCard({period}: {period: TodayMealPeriod}) {
             </div>
             <CardHeader className="p-5">
                 <CardTitle className="text-base leading-6">{period}</CardTitle>
-                <CardDescription className="mt-1">아직 올라오지 않았습니다.</CardDescription>
+                <CardDescription className="mt-1 text-base leading-6">
+                    아직 올라오지 않았습니다.
+                </CardDescription>
             </CardHeader>
         </Card>
     );

--- a/frontend/src/features/meals/components/weekly-meal-menu.test.tsx
+++ b/frontend/src/features/meals/components/weekly-meal-menu.test.tsx
@@ -68,7 +68,7 @@ describe('WeeklyMealMenu', () => {
             id: 'weekly-text',
             title: '8월 2주차 식단표',
             text: '월요일 중식: 잡곡밥, 육개장',
-            publishedAt: null,
+            publishedAt: '2026-08-10T00:00:00.000Z',
             permalink: null,
             images: [],
         };
@@ -77,5 +77,62 @@ describe('WeeklyMealMenu', () => {
 
         expect(markup).toContain('급식표 텍스트 내용');
         expect(markup).toContain('월요일 중식: 잡곡밥, 육개장');
+    });
+
+    it('주간 급식도 텍스트가 이미지보다 먼저 렌더링되고 이미지 토글을 가진다', () => {
+        const sha = 'a'.repeat(64);
+        const meal: DashboardMealPost = {
+            id: 'weekly-toggle',
+            title: '8월 2주차 식단표',
+            text: '월요일 중식: 잡곡밥, 육개장',
+            publishedAt: '2026-08-10T00:00:00.000Z',
+            permalink: null,
+            images: [
+                {
+                    sha,
+                    url: `https://campus.example.com/api/public/assets/${sha}.jpg`,
+                    contentType: 'image/jpeg',
+                    extension: 'jpg',
+                    width: 1439,
+                    height: 1079,
+                    byteLength: 120_000,
+                },
+            ],
+        };
+
+        const markup = renderToStaticMarkup(<WeeklyMealMenu meal={meal} weekKey="2026-08-10" />);
+
+        expect(markup.indexOf('급식표 텍스트 내용')).toBeGreaterThan(-1);
+        expect(markup.indexOf('aria-label="8월 2주차 식단표 새 탭에서 열기"')).toBe(-1);
+        expect(markup).toContain('aria-label="8월 2주차 식단표 급식표 새 탭에서 열기"');
+        const textIndex = markup.indexOf('급식표 텍스트 내용');
+        const imageIndex = markup.indexOf('aria-label="8월 2주차 식단표 급식표 새 탭에서 열기"');
+        expect(imageIndex).toBeGreaterThan(textIndex);
+        expect(markup).toContain('aria-controls="weekly-toggle-image-preview"');
+        expect(markup).toContain('aria-expanded="false"');
+        expect(markup).toContain('이미지 펼치기');
+        expect(markup).toContain('class="min-h-11 w-full"');
+        expect(markup).toContain('max-h-44');
+        expect(markup).toContain('aria-hidden="true"');
+        expect(markup).toContain('tabindex="-1"');
+    });
+
+    it('이미지와 텍스트가 모두 없을 때 empty 본문을 16px 이상으로 표시한다', () => {
+        const markup = renderToStaticMarkup(
+            <WeeklyMealMenu
+                meal={{
+                    id: 'weekly-empty',
+                    title: '이번 주 급식표',
+                    text: '',
+                    publishedAt: null,
+                    permalink: null,
+                    images: [],
+                }}
+                weekKey="2026-08-10"
+            />,
+        );
+
+        expect(markup).toContain('급식표 이미지와 텍스트 내용이 아직 등록되지 않았습니다.');
+        expect(markup).toContain('text-base leading-6');
     });
 });

--- a/frontend/src/features/meals/components/weekly-meal-menu.tsx
+++ b/frontend/src/features/meals/components/weekly-meal-menu.tsx
@@ -1,4 +1,5 @@
 import {ExternalLink} from 'lucide-react';
+import {useState} from 'react';
 
 import type {DashboardMealPost} from '@/api/dashboard-api';
 import {Button} from '@/components/ui/button';
@@ -19,6 +20,9 @@ export function WeeklyMealMenu({
     const title = meal.title ?? '이번 주 급식표';
     const range = weekRangeLabel(weekKey);
     const textAlternative = meal.text.trim();
+    const [isImageExpanded, setIsImageExpanded] = useState(false);
+    const imageSectionId = `${meal.id}-image-preview`;
+
     return (
         <Card className="overflow-hidden py-0 shadow-none">
             <CardHeader className="px-5 pt-5">
@@ -27,42 +31,64 @@ export function WeeklyMealMenu({
             </CardHeader>
             <CardContent className="px-5 pb-5">
                 <div className="grid gap-4">
-                    {images.length > 0 ? (
-                        <div className="grid gap-3">
-                            {images.map((image, index) => (
-                                <a
-                                    aria-label={`${title} 급식표${images.length > 1 ? ` ${index + 1}` : ''} 새 탭에서 열기`}
-                                    className="block rounded-lg focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-                                    href={image.url}
-                                    key={image.sha}
-                                    rel="noopener noreferrer"
-                                    target="_blank"
-                                >
-                                    <img
-                                        alt={`${title}, ${range} 급식표${images.length > 1 ? ` ${index + 1}` : ''}`}
-                                        className="max-h-[72vh] w-full rounded-lg border bg-muted object-contain"
-                                        decoding="async"
-                                        height={image.height ?? undefined}
-                                        loading="lazy"
-                                        src={image.url}
-                                        width={image.width ?? undefined}
-                                    />
-                                </a>
-                            ))}
-                        </div>
-                    ) : null}
                     {textAlternative ? (
                         <section aria-label="급식표 텍스트 내용" className="grid gap-2">
-                            <h3 className="text-sm font-semibold">급식표 텍스트 내용</h3>
-                            <p className="text-sm leading-6 whitespace-pre-wrap">
+                            <h3 className="text-base leading-6 font-semibold">
+                                급식표 텍스트 내용
+                            </h3>
+                            <p className="text-base leading-6 whitespace-pre-wrap">
                                 {textAlternative}
                             </p>
                         </section>
-                    ) : images.length === 0 ? (
-                        <p className="text-sm text-muted-foreground" role="status">
+                    ) : null}
+                    {images.length > 0 ? (
+                        <>
+                            <div
+                                aria-hidden={!isImageExpanded}
+                                className={`grid gap-3 overflow-hidden rounded-lg border bg-muted/30 transition-[max-height] duration-200 ${
+                                    isImageExpanded ? 'max-h-none' : 'max-h-44'
+                                }`}
+                                id={imageSectionId}
+                            >
+                                {images.map((image, index) => (
+                                    <a
+                                        aria-label={`${title} 급식표${images.length > 1 ? ` ${index + 1}` : ''} 새 탭에서 열기`}
+                                        className="block rounded-lg focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                        href={image.url}
+                                        key={image.sha}
+                                        rel="noopener noreferrer"
+                                        tabIndex={isImageExpanded ? undefined : -1}
+                                        target="_blank"
+                                    >
+                                        <img
+                                            alt={`${title}, ${range} 급식표${images.length > 1 ? ` ${index + 1}` : ''}`}
+                                            className="w-full rounded-lg border bg-muted object-contain"
+                                            decoding="async"
+                                            height={image.height ?? undefined}
+                                            loading="lazy"
+                                            src={image.url}
+                                            width={image.width ?? undefined}
+                                        />
+                                    </a>
+                                ))}
+                            </div>
+                            <div className="min-h-11 w-full">
+                                <Button
+                                    aria-controls={imageSectionId}
+                                    aria-expanded={isImageExpanded}
+                                    className="min-h-11 w-full"
+                                    variant="outline"
+                                    onClick={() => setIsImageExpanded((current) => !current)}
+                                >
+                                    {isImageExpanded ? '이미지 접기' : '이미지 펼치기'}
+                                </Button>
+                            </div>
+                        </>
+                    ) : textAlternative ? null : (
+                        <p className="text-base leading-6 text-muted-foreground" role="status">
                             급식표 이미지와 텍스트 내용이 아직 등록되지 않았습니다.
                         </p>
-                    ) : null}
+                    )}
                     {showSourceLink && meal.permalink ? (
                         <Button asChild className="justify-self-start" variant="outline">
                             <a href={meal.permalink} rel="noreferrer" target="_blank">

--- a/frontend/src/features/meals/lib/meal-view.test.ts
+++ b/frontend/src/features/meals/lib/meal-view.test.ts
@@ -4,6 +4,8 @@ import type {DashboardMealsSnapshot} from '@/api/dashboard-api';
 
 import {
     mealsGroupedByDate,
+    mealsPageLoadState,
+    type MealsPageLoadInput,
     todayMealSlots,
     weekKeyForDate,
     weekRangeLabel,
@@ -89,5 +91,179 @@ describe('급식 이력 보조 모델', () => {
         expect(weeklyMenuForDate(weekly, '2026-08-13')?.post.id).toBe('weekly');
         expect(weeklyMenuForDate(weekly, '2026-08-18')?.post.id).toBe('next-weekly');
         expect(weeklyMenuForDate(weekly, '2026-08-24')).toBeNull();
+    });
+});
+
+describe('Meals 페이지 상태 모델', () => {
+    const fixture = (patch: Partial<MealsPageLoadInput>): MealsPageLoadInput => ({
+        hasData: true,
+        isPending: false,
+        isStale: false,
+        isError: false,
+        manualRefreshError: false,
+        todayHasContent: true,
+        weeklyHasContent: true,
+        historyHasContent: true,
+        isOffline: false,
+        ...patch,
+    });
+
+    it('로딩은 데이터가 없고 pending일 때만 loading으로 분류한다', () => {
+        expect(
+            mealsPageLoadState(
+                fixture({
+                    hasData: false,
+                    isPending: true,
+                    isError: false,
+                }),
+            ).kind,
+        ).toBe('loading');
+    });
+
+    it('데이터가 없으면 오프라인을 로딩보다 우선하고 정상 응답의 빈값을 구분한다', () => {
+        expect(
+            mealsPageLoadState(
+                fixture({
+                    hasData: false,
+                    isPending: true,
+                    isOffline: true,
+                }),
+            ),
+        ).toMatchObject({kind: 'offline', reason: 'offline', canRetry: false});
+
+        expect(
+            mealsPageLoadState(
+                fixture({
+                    hasData: false,
+                    isPending: false,
+                }),
+            ),
+        ).toMatchObject({kind: 'empty', reason: null, hasFailure: false});
+    });
+
+    it('데이터 갱신 실패는 stale와 recovered를 구분한다', () => {
+        const stale = mealsPageLoadState(
+            fixture({
+                isError: true,
+                isStale: true,
+                previous: {
+                    kind: 'normal',
+                    hasFailure: false,
+                    reason: null,
+                    hasRecovered: false,
+                    canRetry: false,
+                    sections: {
+                        todayEmpty: false,
+                        weeklyEmpty: false,
+                        historyEmpty: false,
+                    },
+                },
+            }),
+        );
+
+        expect(stale.kind).toBe('stale');
+        expect(stale.reason).toBe('fetch-failed');
+        expect(stale.canRetry).toBe(true);
+
+        const aged = mealsPageLoadState(fixture({isStale: true}));
+        expect(aged.kind).toBe('stale');
+        expect(aged.canRetry).toBe(true);
+
+        const recovered = mealsPageLoadState(
+            fixture({
+                previous: {
+                    kind: 'stale',
+                    hasFailure: true,
+                    reason: 'fetch-failed',
+                    hasRecovered: false,
+                    canRetry: true,
+                    sections: {
+                        todayEmpty: false,
+                        weeklyEmpty: false,
+                        historyEmpty: false,
+                    },
+                },
+            }),
+        );
+
+        expect(recovered.kind).toBe('recovered');
+        expect(recovered.hasRecovered).toBe(true);
+        expect(recovered.canRetry).toBe(false);
+    });
+
+    it('장애 이력 없는 수동 새로고침 성공은 recovered로 오인하지 않는다', () => {
+        expect(mealsPageLoadState(fixture({recovered: false})).kind).toBe('normal');
+    });
+
+    it('오프라인/빈값/오류/재확보를 분명히 구분한다', () => {
+        const offline = mealsPageLoadState(
+            fixture({
+                isOffline: true,
+            }),
+        );
+        expect(offline.kind).toBe('offline');
+        expect(offline.reason).toBe('offline');
+        expect(offline.canRetry).toBe(false);
+
+        const empty = mealsPageLoadState(
+            fixture({
+                todayHasContent: false,
+                weeklyHasContent: false,
+                historyHasContent: false,
+            }),
+        );
+        expect(empty.kind).toBe('empty');
+        expect(empty.sections).toEqual({
+            todayEmpty: true,
+            weeklyEmpty: true,
+            historyEmpty: true,
+        });
+
+        const error = mealsPageLoadState(
+            fixture({
+                hasData: false,
+                isPending: false,
+                isError: true,
+                isOffline: false,
+            }),
+        );
+        expect(error.kind).toBe('error');
+        expect(error.canRetry).toBe(true);
+
+        const recovered = mealsPageLoadState(
+            fixture({
+                previous: {
+                    kind: 'error',
+                    hasFailure: true,
+                    reason: 'fetch-failed',
+                    hasRecovered: false,
+                    canRetry: true,
+                    sections: {
+                        todayEmpty: false,
+                        weeklyEmpty: false,
+                        historyEmpty: false,
+                    },
+                },
+            }),
+        );
+        expect(recovered.kind).toBe('recovered');
+        expect(recovered.reason).toBe(null);
+    });
+
+    it('섹션별 빈값 플래그는 UI 메시지 라우팅에 사용 가능하다', () => {
+        const mixed = mealsPageLoadState(
+            fixture({
+                todayHasContent: false,
+                weeklyHasContent: true,
+                historyHasContent: false,
+            }),
+        );
+
+        expect(mixed.kind).toBe('normal');
+        expect(mixed.sections).toEqual({
+            todayEmpty: true,
+            weeklyEmpty: false,
+            historyEmpty: true,
+        });
     });
 });

--- a/frontend/src/features/meals/lib/meal-view.ts
+++ b/frontend/src/features/meals/lib/meal-view.ts
@@ -3,6 +3,128 @@ import {mealPeriodLabel, mealServiceDate} from '@/domain/meals/today';
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
+export type MealsPageLoadKind =
+    | 'loading'
+    | 'normal'
+    | 'empty'
+    | 'stale'
+    | 'offline'
+    | 'error'
+    | 'recovered';
+
+export type MealsPageLoadReason = 'offline' | 'fetch-failed' | 'stale-data' | null;
+
+export interface MealsPageSectionState {
+    todayEmpty: boolean;
+    weeklyEmpty: boolean;
+    historyEmpty: boolean;
+}
+
+export interface MealsPageLoadInput {
+    hasData: boolean;
+    isPending: boolean;
+    isStale: boolean;
+    isError: boolean;
+    manualRefreshError: boolean;
+    todayHasContent: boolean;
+    weeklyHasContent: boolean;
+    historyHasContent: boolean;
+    isOffline: boolean;
+    recovered?: boolean;
+    previous?: MealsPageLoadState;
+}
+
+export interface MealsPageLoadState {
+    kind: MealsPageLoadKind;
+    hasFailure: boolean;
+    reason: MealsPageLoadReason;
+    hasRecovered: boolean;
+    canRetry: boolean;
+    sections: MealsPageSectionState;
+}
+
+function normalizeMealsPageReason({
+    isOffline,
+    isError,
+    manualRefreshError,
+    isStale,
+}: Pick<
+    MealsPageLoadInput,
+    'isOffline' | 'isError' | 'manualRefreshError' | 'isStale'
+>): MealsPageLoadReason {
+    if (isOffline) return 'offline';
+    if (isError || manualRefreshError) return 'fetch-failed';
+    if (isStale) return 'stale-data';
+    return null;
+}
+
+export function mealsPageLoadState(input: MealsPageLoadInput): MealsPageLoadState {
+    if (!input.hasData) {
+        const kind: MealsPageLoadKind = input.isOffline
+            ? 'offline'
+            : input.isError || input.manualRefreshError
+              ? 'error'
+              : input.isPending
+                ? 'loading'
+                : 'empty';
+
+        return {
+            kind,
+            hasFailure: kind === 'offline' || kind === 'error',
+            reason: kind === 'offline' ? 'offline' : kind === 'error' ? 'fetch-failed' : null,
+            hasRecovered: false,
+            canRetry: kind === 'error',
+            sections: {
+                todayEmpty: true,
+                weeklyEmpty: true,
+                historyEmpty: true,
+            },
+        };
+    }
+
+    const sections: MealsPageSectionState = {
+        todayEmpty: !input.todayHasContent,
+        weeklyEmpty: !input.weeklyHasContent,
+        historyEmpty: !input.historyHasContent,
+    };
+    const isSectionEmpty = sections.todayEmpty && sections.weeklyEmpty && sections.historyEmpty;
+    const reason = normalizeMealsPageReason(input);
+    const hasFailure = reason !== null;
+    const wasFailure =
+        input.previous?.kind === 'error' ||
+        input.previous?.kind === 'offline' ||
+        input.previous?.kind === 'stale';
+    const hasRecovered = reason === null && (input.recovered === true || wasFailure);
+
+    let kind: MealsPageLoadKind =
+        reason === 'offline' || reason === 'fetch-failed'
+            ? 'stale'
+            : reason === 'stale-data'
+              ? 'stale'
+              : 'normal';
+
+    if (reason === 'offline') {
+        kind = 'offline';
+    }
+
+    if (isSectionEmpty && kind === 'normal') {
+        kind = 'empty';
+    }
+
+    if (hasRecovered) {
+        kind = 'recovered';
+    }
+
+    return {
+        kind,
+        hasFailure,
+        reason,
+        hasRecovered,
+        canRetry: kind === 'stale',
+        sections,
+    };
+}
+
 export type TodayMealPeriod = '\uC911\uC2DD' | '\uC11D\uC2DD';
 
 export interface TodayMealSlot {

--- a/frontend/src/features/meals/pages/meals-page.test.tsx
+++ b/frontend/src/features/meals/pages/meals-page.test.tsx
@@ -31,4 +31,19 @@ describe('MealsPage information architecture', () => {
         expect(source).not.toContain('PersonalSurface');
         expect(historySource).toContain('setVisibleMonthKey(month)');
     });
+
+    it('page header 밖의 공통 local async boundary로 식단 실패를 격리한다', () => {
+        const pageSource = source.slice(source.indexOf('export function MealsPage()'));
+
+        expect(pageSource.indexOf('<PageHeader')).toBeLessThan(
+            pageSource.indexOf('<MealsFeatureBoundary'),
+        );
+        expect(source).toContain(
+            "import {AsyncBoundary} from '@/components/dashboard/async-boundary'",
+        );
+        expect(source).toContain('<AsyncBoundary');
+        expect(source).toContain('regionLabel="급식 데이터"');
+        expect(source).not.toContain('<QueryErrorResetBoundary>');
+        expect(source).not.toContain('isRefreshSuccess: manualRefresh.isSuccess');
+    });
 });

--- a/frontend/src/features/meals/pages/meals-page.tsx
+++ b/frontend/src/features/meals/pages/meals-page.tsx
@@ -1,28 +1,206 @@
-import {CalendarDays, CircleAlert, RefreshCw, Utensils} from 'lucide-react';
-import {useMemo} from 'react';
+import {CalendarDays, RefreshCw, Utensils} from 'lucide-react';
+import {type ReactNode, useMemo} from 'react';
 
+import {type DashboardMealPost, type DashboardMealsSnapshot} from '@/api/dashboard-api';
 import {useCampusManualRefresh, useSuspenseMealsQuery} from '@/app/use-dashboard-queries';
-import {EmptyState} from '@/components/dashboard/async-state';
+import {AsyncBoundary} from '@/components/dashboard/async-boundary';
+import {
+    AsyncState,
+    EmptyState,
+    LoadingState,
+    useOnlineStatus,
+} from '@/components/dashboard/async-state';
 import {PageHeader} from '@/components/dashboard/page-header';
-import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
 import {Button} from '@/components/ui/button';
 import {selectTodayMeals} from '@/domain/meals/today';
-import {relativeTimeLabel} from '@/lib/format';
+import {dateTimeLabel, relativeTimeLabel} from '@/lib/format';
 import {cn} from '@/lib/utils';
 
 import {MealHistorySection} from '../components/meal-history-section';
 import {TodayMealGrid} from '../components/today-meal-grid';
 import {WeeklyMealMenu} from '../components/weekly-meal-menu';
+import {
+    mealsPageLoadState,
+    type MealsPageLoadState,
+    type MealsPageSectionState,
+} from '../lib/meal-view';
+
+type MealsPageSections = MealsPageSectionState;
+
+export type MealsPageBoundaryResult = {
+    state: MealsPageLoadState;
+    meals: ReturnType<typeof useSuspenseMealsQuery>;
+    sections: MealsPageSections;
+    todayMeals: DashboardMealPost[];
+    weeklyMeal: NonNullable<DashboardMealsSnapshot['data']['currentWeeklyMenu']>['post'];
+    weeklyKey: string | null;
+    historyHasContent: boolean;
+    manualRefresh: ReturnType<typeof useCampusManualRefresh>;
+    isRefreshing: boolean;
+};
+
+type MealsPageBoundaryProps = {
+    children: (result: MealsPageBoundaryResult) => ReactNode;
+    manualRefresh: ReturnType<typeof useCampusManualRefresh>;
+};
+
+export interface MealsFeatureBoundaryProps {
+    children: ReactNode;
+    errorDescription?: string;
+    errorTitle?: string;
+    fallback?: ReactNode;
+    resetKeys?: unknown[];
+}
+
+export function MealsFeatureBoundary({
+    children,
+    errorDescription = '현재 페이지 헤더만 유지된 상태에서 새로고침할 수 있습니다.',
+    errorTitle = '급식 정보를 불러오지 못했습니다.',
+    fallback = <LoadingState label="급식 정보를 불러오는 중입니다." />,
+    resetKeys,
+}: MealsFeatureBoundaryProps) {
+    const isOnline = useOnlineStatus();
+
+    return (
+        <AsyncBoundary
+            errorDescription={errorDescription}
+            errorTitle={errorTitle}
+            fallback={
+                isOnline ? (
+                    fallback
+                ) : (
+                    <AsyncState
+                        type="offline"
+                        title="현재 오프라인 상태입니다."
+                        description="저장된 급식 정보가 없어 인터넷 연결 후 다시 확인해야 합니다."
+                        reason="네트워크 연결 끊김"
+                    />
+                )
+            }
+            regionLabel="급식 데이터"
+            renderError={({retry}) =>
+                isOnline ? (
+                    <AsyncState
+                        type="error"
+                        title={errorTitle}
+                        description={errorDescription}
+                        retry={retry}
+                        retryLabel="다시 시도"
+                    />
+                ) : (
+                    <AsyncState
+                        type="offline"
+                        title="현재 오프라인 상태입니다."
+                        description="인터넷 연결을 확인한 뒤 다시 시도해 주세요."
+                        reason="네트워크 연결 끊김"
+                    />
+                )
+            }
+            resetKeys={resetKeys}
+        >
+            {children}
+        </AsyncBoundary>
+    );
+}
+
+function messageForStatus(state: MealsPageLoadState) {
+    if (state.kind === 'offline') {
+        return {
+            title: '현재 오프라인 상태입니다.',
+            description:
+                '인터넷 연결이 없어 마지막 정상 식단을 표시합니다. 실시간 정보가 아닙니다.',
+            reason: '네트워크 연결 끊김',
+        };
+    }
+
+    if (state.kind === 'error') {
+        return {
+            title: '급식 정보를 불러오지 못했습니다.',
+            description: '네트워크 또는 서버 오류로 인해 데이터를 표시할 수 없습니다.',
+            reason: '급식 조회 실패',
+        };
+    }
+
+    if (state.kind === 'stale' || state.kind === 'recovered') {
+        const recovered = state.kind === 'recovered';
+        return {
+            title: recovered ? '급식 정보가 복구되었습니다.' : '급식 정보가 최신이 아닙니다.',
+            description: recovered
+                ? '최근 조회 실패가 해결되어 최신 식단으로 갱신했습니다.'
+                : '마지막 정상 식단을 표시합니다. 실시간 정보가 아닙니다.',
+            reason: recovered
+                ? '정상 조회 재개'
+                : state.reason === 'fetch-failed'
+                  ? '최신 식단 갱신 실패'
+                  : '급식 데이터 갱신 지연',
+        };
+    }
+
+    return {
+        title: '',
+        description: '',
+        reason: '',
+    };
+}
+
+function MealsPageStatusBanner({
+    state,
+    lastCheckedAt,
+    isRefreshing,
+    onRetry,
+}: {
+    state: MealsPageLoadState;
+    lastCheckedAt: string;
+    isRefreshing: boolean;
+    onRetry: () => void;
+}) {
+    if (state.kind === 'normal' || state.kind === 'loading') {
+        return null;
+    }
+
+    if (state.kind === 'empty') {
+        return (
+            <AsyncState
+                type="empty"
+                title="표시할 급식 정보가 없습니다."
+                description="새 식단이 등록되면 이 화면에 표시됩니다."
+                regionLabel="급식 데이터 상태"
+            />
+        );
+    }
+
+    const statusMessage = messageForStatus(state);
+
+    if (state.kind === 'error') {
+        return (
+            <AsyncState
+                type="error"
+                title={statusMessage.title}
+                description={statusMessage.description}
+                regionLabel="급식 데이터 상태"
+                retry={state.canRetry && !isRefreshing ? onRetry : undefined}
+            />
+        );
+    }
+
+    return (
+        <AsyncState
+            type={state.kind}
+            title={statusMessage.title}
+            description={statusMessage.description}
+            lastUpdatedAt={lastCheckedAt}
+            reason={statusMessage.reason}
+            regionLabel="급식 데이터 상태"
+            retry={state.canRetry && !isRefreshing ? onRetry : undefined}
+            retryLabel="새로고침"
+        />
+    );
+}
 
 export function MealsPage() {
-    const meals = useSuspenseMealsQuery();
     const manualRefresh = useCampusManualRefresh('meals');
-    const todayMeals = useMemo(() => selectTodayMeals(meals.data), [meals.data]);
-    const currentWeekly = meals.data.data.currentWeeklyMenu;
-    const weeklyMeal = currentWeekly?.status === 'AVAILABLE' ? currentWeekly.post : null;
-    const weeklyKey = currentWeekly?.targetWeekKey ?? null;
-    const refreshFailed = meals.isError || manualRefresh.isError;
-    const refreshing = meals.isFetching || manualRefresh.isPending;
+    const isOnline = useOnlineStatus();
+    const isRefreshing = manualRefresh.isPending;
 
     return (
         <div className="space-y-6">
@@ -30,53 +208,175 @@ export function MealsPage() {
                 title="급식"
                 actions={
                     <Button
-                        disabled={refreshing}
+                        disabled={isRefreshing || !isOnline}
                         variant="outline"
                         onClick={() => manualRefresh.mutate()}
                     >
-                        <RefreshCw className={cn(refreshing && 'animate-spin')} />
-                        {refreshing ? '새로고침 중' : '새로고침'}
+                        <RefreshCw className={cn(isRefreshing && 'animate-spin')} />
+                        {!isOnline ? '오프라인' : isRefreshing ? '새로고침 중' : '새로고침'}
                     </Button>
                 }
             />
 
-            {refreshFailed ? (
-                <Alert variant="destructive">
-                    <CircleAlert />
-                    <AlertTitle>최신 식단을 불러오지 못했습니다.</AlertTitle>
-                    <AlertDescription>마지막으로 확인한 게시 정보를 표시합니다.</AlertDescription>
-                </Alert>
-            ) : null}
+            <MealsFeatureBoundary
+                errorTitle="급식 정보를 불러오지 못했습니다."
+                errorDescription="현재 페이지 헤더만 유지된 상태에서 새로고침할 수 있습니다."
+            >
+                <MealsPageBoundary manualRefresh={manualRefresh}>
+                    {({
+                        state,
+                        meals,
+                        todayMeals,
+                        weeklyMeal,
+                        weeklyKey,
+                        historyHasContent,
+                        isRefreshing: featureRefreshing,
+                    }) => {
+                        const lastCheckedLabel = relativeTimeLabel(
+                            meals.data.lastCheckedAt ?? meals.data.asOf,
+                        );
+                        const lastCheckedAt = dateTimeLabel(
+                            meals.data.lastCheckedAt ?? meals.data.asOf,
+                        );
 
-            <section aria-labelledby="today-meals-title">
-                <div className="mb-3">
-                    <h2 className="flex items-center gap-2 font-semibold" id="today-meals-title">
-                        <Utensils className="size-4 text-primary" />
-                        오늘 식단
-                    </h2>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                        마지막 확인 {relativeTimeLabel(meals.data.lastCheckedAt ?? meals.data.asOf)}
-                    </p>
-                </div>
-                <TodayMealGrid meals={todayMeals} />
-            </section>
+                        return (
+                            <>
+                                <MealsPageStatusBanner
+                                    isRefreshing={featureRefreshing}
+                                    lastCheckedAt={lastCheckedAt}
+                                    state={state}
+                                    onRetry={() => {
+                                        manualRefresh.mutate();
+                                    }}
+                                />
 
-            <section aria-labelledby="weekly-meal-title">
-                <h2 className="mb-3 flex items-center gap-2 font-semibold" id="weekly-meal-title">
-                    <CalendarDays className="size-4 text-primary" />
-                    이번 주 급식표
-                </h2>
-                {weeklyMeal && weeklyKey ? (
-                    <WeeklyMealMenu meal={weeklyMeal} weekKey={weeklyKey} />
-                ) : (
-                    <EmptyState
-                        title="이번 주 급식표 없음"
-                        description="새 급식표가 확인되면 표시합니다."
-                    />
-                )}
-            </section>
+                                <section aria-labelledby="today-meals-title">
+                                    <div className="mb-3">
+                                        <h2
+                                            className="flex items-center gap-2 font-semibold"
+                                            id="today-meals-title"
+                                        >
+                                            <Utensils className="size-4 text-primary" />
+                                            오늘 식단
+                                        </h2>
+                                        <p className="mt-1 text-xs text-muted-foreground">
+                                            마지막 확인 {lastCheckedLabel}
+                                        </p>
+                                    </div>
+                                    <TodayMealGrid meals={todayMeals} />
+                                </section>
 
-            <MealHistorySection meals={meals.data} />
+                                <section aria-labelledby="weekly-meal-title">
+                                    <h2
+                                        className="mb-3 flex items-center gap-2 font-semibold"
+                                        id="weekly-meal-title"
+                                    >
+                                        <CalendarDays className="size-4 text-primary" />
+                                        이번 주 급식표
+                                    </h2>
+                                    {weeklyMeal && weeklyKey ? (
+                                        <WeeklyMealMenu meal={weeklyMeal} weekKey={weeklyKey} />
+                                    ) : (
+                                        <EmptyState
+                                            title={
+                                                state.sections.weeklyEmpty
+                                                    ? '이번 주 급식표가 없습니다.'
+                                                    : '이번 주 급식표를 가져오지 못했습니다.'
+                                            }
+                                            description={
+                                                state.kind === 'offline'
+                                                    ? '오프라인에서 확인할 수 있는 최근 급식표가 없습니다.'
+                                                    : state.kind === 'stale'
+                                                      ? '마지막 정상 데이터에도 이번 주 급식표가 없습니다.'
+                                                      : '새 급식표가 확인되면 표시됩니다.'
+                                            }
+                                        />
+                                    )}
+                                </section>
+
+                                {historyHasContent ? (
+                                    <MealHistorySection meals={meals.data} />
+                                ) : (
+                                    <section aria-labelledby="meal-history-empty-title">
+                                        <h2
+                                            className="mb-3 flex items-center gap-2 font-semibold"
+                                            id="meal-history-empty-title"
+                                        >
+                                            <CalendarDays className="size-4 text-primary" />
+                                            지난 급식 기록
+                                        </h2>
+                                        <EmptyState
+                                            title="지난 급식 기록이 없습니다."
+                                            description="아직 저장된 과거 급식 기록이 없습니다."
+                                        />
+                                    </section>
+                                )}
+                            </>
+                        );
+                    }}
+                </MealsPageBoundary>
+            </MealsFeatureBoundary>
         </div>
+    );
+}
+
+export function MealsPageBoundary({children, manualRefresh}: MealsPageBoundaryProps) {
+    const meals = useSuspenseMealsQuery();
+    const isOnline = useOnlineStatus();
+
+    const todayMeals = useMemo(() => selectTodayMeals(meals.data), [meals.data]);
+    const currentWeekly = meals.data.data.currentWeeklyMenu;
+    const weeklyMeal = currentWeekly?.status === 'AVAILABLE' ? currentWeekly.post : null;
+    const weeklyKey = currentWeekly?.targetWeekKey ?? null;
+    const sections = {
+        todayEmpty: todayMeals.length === 0,
+        weeklyEmpty: weeklyMeal === null,
+        historyEmpty:
+            meals.data.data.dailyMenus.length === 0 &&
+            meals.data.data.recentMenus.length === 0 &&
+            meals.data.data.weeklyMenus.length === 0,
+    };
+    const isOffline = !isOnline || meals.fetchStatus === 'paused';
+    const isRefreshing = meals.isFetching || manualRefresh.isPending;
+    const manualRefreshFailureIsCurrent =
+        manualRefresh.isError && manualRefresh.submittedAt >= meals.dataUpdatedAt;
+    const recoveredFromManualRefresh =
+        manualRefresh.isError &&
+        manualRefresh.submittedAt > 0 &&
+        meals.dataUpdatedAt > manualRefresh.submittedAt;
+    const recovered =
+        (recoveredFromManualRefresh ||
+            (meals.errorUpdatedAt > 0 && meals.dataUpdatedAt > meals.errorUpdatedAt)) &&
+        !meals.isError &&
+        !meals.isStale &&
+        !manualRefreshFailureIsCurrent;
+
+    const state = mealsPageLoadState({
+        hasData: Boolean(meals.data),
+        isPending: meals.isPending,
+        isStale: meals.isStale,
+        isError: meals.isError,
+        manualRefreshError: manualRefreshFailureIsCurrent,
+        todayHasContent: todayMeals.length > 0,
+        weeklyHasContent: weeklyMeal !== null,
+        historyHasContent: !sections.historyEmpty,
+        isOffline,
+        recovered,
+    });
+
+    return (
+        <>
+            {children({
+                state,
+                meals,
+                sections,
+                todayMeals,
+                weeklyMeal,
+                weeklyKey,
+                historyHasContent: !sections.historyEmpty,
+                manualRefresh,
+                isRefreshing,
+            })}
+        </>
     );
 }


### PR DESCRIPTION
# 요약

생활 정보의 loading/empty/stale/offline/error/recovered 상태와 모바일 탐색을 표준화합니다.

- 기능별 오류 격리와 마지막 정상 시각
- stale 세탁 상태의 실시간 아님 표시와 액션 제한
- 세탁 필터·문제 우선·상세 접기·표 스크롤 힌트
- 식단 텍스트 우선 모바일 카드

# 스택

6/9, base: `codex/issue-69-05-home-install`

# 검증

- 독립 worktree 병렬 작업: 성공
- `npm run check`: 113개 파일, 646개 테스트 통과
- `npm run build:web`: PWA 산출물 검증 통과

Refs #69
