### PR TITLE
[stack 7/9] feat(platform): PWA·PC 수명주기 계약 추가

### DIFF
--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -2,6 +2,9 @@ use std::{fs, path::Path};
 
 const APP_COMMANDS: &[&str] = &[
     "report_checker_event",
+    "get_desktop_lifecycle_status",
+    "acknowledge_and_hide_to_tray",
+    "quit_desktop_app",
     "bootstrap_desktop_http_session",
     "get_desktop_settings",
     "check_desktop_update",

--- a/desktop/capabilities/dashboard.json
+++ b/desktop/capabilities/dashboard.json
@@ -9,10 +9,21 @@
       "identifier": "opener:allow-open-url",
       "allow": [
         { "url": "https://github.com/YangSiJun528/jungle-bell" },
+        {
+          "url": "https://github.com/YangSiJun528/jungle-bell#%EC%84%A4%EC%B9%98"
+        },
         { "url": "https://github.com/YangSiJun528/jungle-bell/issues/new/choose" },
-        { "url": "https://github.com/YangSiJun528/jungle-bell/releases/latest" }
+        { "url": "https://github.com/YangSiJun528/jungle-bell/releases/latest" },
+        { "url": "https://jungle-lms.krafton.com/check-in" },
+        { "url": "https://pf.kakao.com/_xhzNjn/*" },
+        {
+          "url": "https://jungle-bell.sijun-yang.com/api/public/assets/*"
+        }
       ]
     },
+    "allow-get-desktop-lifecycle-status",
+    "allow-acknowledge-and-hide-to-tray",
+    "allow-quit-desktop-app",
     "allow-bootstrap-desktop-http-session",
     "allow-get-desktop-settings",
     "allow-check-desktop-update",

--- a/desktop/src/commands.rs
+++ b/desktop/src/commands.rs
@@ -21,6 +21,34 @@ use crate::tray;
 
 const LMS_SESSION_STATE_UPDATED_EVENT: &str = "lms-session-state-updated";
 
+// ── 데스크톱 창 수명주기 경계 ──────────────────────────
+
+#[tauri::command]
+pub(crate) fn get_desktop_lifecycle_status(
+    window: tauri::WebviewWindow,
+    lifecycle: tauri::State<'_, Arc<crate::config::DesktopLifecycleStateStore>>,
+) -> Result<crate::config::DesktopLifecycleStatus, String> {
+    remote_sync::ensure_dashboard_window(&window)?;
+    lifecycle.status()
+}
+
+#[tauri::command]
+pub(crate) fn acknowledge_and_hide_to_tray(
+    window: tauri::WebviewWindow,
+    lifecycle: tauri::State<'_, Arc<crate::config::DesktopLifecycleStateStore>>,
+) -> Result<crate::config::DesktopLifecycleStatus, String> {
+    remote_sync::ensure_dashboard_window(&window)?;
+    tray::acknowledge_and_hide_to_tray(&window, lifecycle.inner())?;
+    lifecycle.status()
+}
+
+#[tauri::command]
+pub(crate) fn quit_desktop_app(window: tauri::WebviewWindow, app: tauri::AppHandle) -> Result<(), String> {
+    remote_sync::ensure_dashboard_window(&window)?;
+    tray::quit_app(&app);
+    Ok(())
+}
+
 // ── 연결 서비스 대시보드 경계 ───────────────────────────
 
 #[tauri::command]
@@ -567,6 +595,23 @@ mod tests {
         system_notification_settings_url, validate_js_log_payload, CheckerEventInput, CheckerEventResponse,
         DesktopSettings, DesktopSettingsInput,
     };
+
+    #[test]
+    fn desktop_lifecycle_status는_close동작과_명시적_종료_가능성을_고정한다() {
+        let value = serde_json::to_value(crate::config::DesktopLifecycleStatus::new(
+            crate::config::CloseToTrayNotice::Pending,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "closeBehavior": "hideToTray",
+                "closeToTrayNotice": "pending",
+                "explicitQuitAvailable": true,
+            })
+        );
+    }
 
     #[test]
     fn 운영체제별_알림_설정_url은_고정된_대상만_허용한다() {

--- a/desktop/src/config.rs
+++ b/desktop/src/config.rs
@@ -2,11 +2,155 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
 
 const CURRENT_CONFIG_FILE_NAME: &str = "desktop-settings.json";
 const CONFIG_SCHEMA: &str = "jungle-bell.desktop-settings";
 const CONFIG_SCHEMA_VERSION: u32 = 6;
 const MIN_SUPPORTED_CONFIG_SCHEMA_VERSION: u32 = 3;
+const DESKTOP_LIFECYCLE_FILE_NAME: &str = "desktop-lifecycle.json";
+const DESKTOP_LIFECYCLE_SCHEMA: &str = "jungle-bell.desktop-lifecycle";
+const DESKTOP_LIFECYCLE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum CloseToTrayNotice {
+    #[default]
+    Unseen,
+    Pending,
+    Acknowledged,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DesktopLifecycleDocument {
+    schema: String,
+    schema_version: u32,
+    close_to_tray_notice: CloseToTrayNotice,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopLifecycleStatus {
+    close_behavior: &'static str,
+    close_to_tray_notice: CloseToTrayNotice,
+    explicit_quit_available: bool,
+}
+
+impl DesktopLifecycleStatus {
+    pub(crate) fn new(close_to_tray_notice: CloseToTrayNotice) -> Self {
+        Self {
+            close_behavior: "hideToTray",
+            close_to_tray_notice,
+            explicit_quit_available: true,
+        }
+    }
+}
+
+/// 창 닫기 동작을 설명하는 최초 1회 안내 상태를 별도 문서에 보관한다.
+///
+/// 사용자 설정 DTO와 독립시켜 병렬 설정 변경 및 이전 설정 스키마와 충돌하지
+/// 않는다. 전이는 파일 저장에 성공한 뒤 메모리에 반영한다.
+pub(crate) struct DesktopLifecycleStateStore {
+    path: Option<PathBuf>,
+    close_to_tray_notice: StdMutex<CloseToTrayNotice>,
+}
+
+impl DesktopLifecycleStateStore {
+    pub(crate) fn load() -> Self {
+        Self::load_from(desktop_lifecycle_path())
+    }
+
+    pub(crate) fn load_from(path: Option<PathBuf>) -> Self {
+        let state = path
+            .as_deref()
+            .and_then(|path| match fs::read_to_string(path) {
+                Ok(data) => match parse_desktop_lifecycle_document(&data) {
+                    Ok(state) => Some(state),
+                    Err(error) => {
+                        log::warn!("[lifecycle] 상태 파일({}) 검증 실패: {error}", path.display());
+                        None
+                    }
+                },
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => {
+                    log::warn!("[lifecycle] 상태 파일({}) 읽기 실패: {error}", path.display());
+                    None
+                }
+            })
+            .unwrap_or_default();
+        Self {
+            path,
+            close_to_tray_notice: StdMutex::new(state),
+        }
+    }
+
+    fn lock(&self) -> Result<StdMutexGuard<'_, CloseToTrayNotice>, String> {
+        self.close_to_tray_notice
+            .lock()
+            .map_err(|_| "데스크톱 수명주기 상태 잠금이 손상되었습니다.".to_owned())
+    }
+
+    pub(crate) fn close_to_tray_notice(&self) -> Result<CloseToTrayNotice, String> {
+        Ok(*self.lock()?)
+    }
+
+    pub(crate) fn status(&self) -> Result<DesktopLifecycleStatus, String> {
+        Ok(DesktopLifecycleStatus::new(self.close_to_tray_notice()?))
+    }
+
+    pub(crate) fn record_close_to_tray(&self) -> Result<bool, String> {
+        let mut state = self.lock()?;
+        if *state != CloseToTrayNotice::Unseen {
+            return Ok(false);
+        }
+        self.persist(CloseToTrayNotice::Pending)?;
+        *state = CloseToTrayNotice::Pending;
+        Ok(true)
+    }
+
+    pub(crate) fn acknowledge_close_to_tray_notice(&self) -> Result<bool, String> {
+        let mut state = self.lock()?;
+        if *state == CloseToTrayNotice::Acknowledged {
+            return Ok(false);
+        }
+        self.persist(CloseToTrayNotice::Acknowledged)?;
+        *state = CloseToTrayNotice::Acknowledged;
+        Ok(true)
+    }
+
+    fn persist(&self, close_to_tray_notice: CloseToTrayNotice) -> Result<(), String> {
+        let path = self
+            .path
+            .as_deref()
+            .ok_or_else(|| "운영체제 설정 디렉토리를 확인할 수 없습니다.".to_owned())?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| "데스크톱 수명주기 상태 파일 상위 디렉토리가 없습니다.".to_owned())?;
+        fs::create_dir_all(parent).map_err(|error| format!("데스크톱 수명주기 상태 디렉토리 생성 실패: {error}"))?;
+        let data = serde_json::to_vec_pretty(&DesktopLifecycleDocument {
+            schema: DESKTOP_LIFECYCLE_SCHEMA.to_owned(),
+            schema_version: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+            close_to_tray_notice,
+        })
+        .map_err(|error| format!("데스크톱 수명주기 상태 직렬화 실패: {error}"))?;
+        write_file_atomically(path, &data)
+            .map_err(|error| format!("데스크톱 수명주기 상태 파일({}) 저장 실패: {error}", path.display()))
+    }
+}
+
+fn desktop_lifecycle_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|path| path.join("jungle-bell").join(DESKTOP_LIFECYCLE_FILE_NAME))
+}
+
+fn parse_desktop_lifecycle_document(data: &str) -> Result<CloseToTrayNotice, String> {
+    let document: DesktopLifecycleDocument =
+        serde_json::from_str(data).map_err(|error| format!("상태 파싱 실패: {error}"))?;
+    if document.schema != DESKTOP_LIFECYCLE_SCHEMA || document.schema_version != DESKTOP_LIFECYCLE_SCHEMA_VERSION {
+        return Err("지원하지 않는 데스크톱 수명주기 스키마입니다.".to_owned());
+    }
+    Ok(document.close_to_tray_notice)
+}
 
 pub const MORNING_START_HOUR: u32 = 4;
 pub const MORNING_START_MINUTE: u32 = 0;
@@ -386,6 +530,67 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ))
+    }
+
+    #[test]
+    fn close_to_tray_안내는_첫_close에_pending이_되고_확인후_영구_종료된다() {
+        let path = temporary_path("desktop-lifecycle");
+        let store = DesktopLifecycleStateStore::load_from(Some(path.clone()));
+
+        assert_eq!(store.close_to_tray_notice().unwrap(), CloseToTrayNotice::Unseen);
+        assert!(store.record_close_to_tray().unwrap());
+        assert!(!store.record_close_to_tray().unwrap());
+        assert_eq!(store.close_to_tray_notice().unwrap(), CloseToTrayNotice::Pending);
+        assert_eq!(
+            DesktopLifecycleStateStore::load_from(Some(path.clone()))
+                .close_to_tray_notice()
+                .unwrap(),
+            CloseToTrayNotice::Pending,
+        );
+
+        assert!(store.acknowledge_close_to_tray_notice().unwrap());
+        assert!(!store.acknowledge_close_to_tray_notice().unwrap());
+        assert_eq!(
+            DesktopLifecycleStateStore::load_from(Some(path.clone()))
+                .close_to_tray_notice()
+                .unwrap(),
+            CloseToTrayNotice::Acknowledged,
+        );
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn 잘못된_lifecycle_문서는_안내를_보지_않은_상태로_fail_closed한다() {
+        let path = temporary_path("desktop-lifecycle-invalid");
+        fs::write(
+            &path,
+            serde_json::json!({
+                "schema": "jungle-bell.desktop-lifecycle",
+                "schemaVersion": 1,
+                "closeToTrayNotice": "legacy-value",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let store = DesktopLifecycleStateStore::load_from(Some(path.clone()));
+
+        assert_eq!(store.close_to_tray_notice().unwrap(), CloseToTrayNotice::Unseen);
+        assert!(store.record_close_to_tray().unwrap());
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn lifecycle_저장_실패는_메모리_상태를_소비하지_않는다() {
+        let root = temporary_path("desktop-lifecycle-write-failure");
+        fs::create_dir_all(&root).unwrap();
+        let blocked_parent = root.join("not-a-directory");
+        fs::write(&blocked_parent, b"file").unwrap();
+        let store = DesktopLifecycleStateStore::load_from(Some(blocked_parent.join("desktop-lifecycle.json")));
+
+        assert!(store.record_close_to_tray().is_err());
+        assert_eq!(store.close_to_tray_notice().unwrap(), CloseToTrayNotice::Unseen);
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
     let notification_inbox_service = Arc::new(NotificationInboxService::load());
     let notification_service = Arc::new(NotificationService::new(notification_inbox_service.clone()));
     let settings_service = Arc::new(DesktopSettingsService::new(shared_state.clone()));
+    let lifecycle_state = Arc::new(config::DesktopLifecycleStateStore::load());
 
     tauri::Builder::default()
         // single-instance 플러그인: 공식 문서 권장대로 가장 먼저 등록한다.
@@ -219,9 +220,13 @@ pub fn run() {
         .manage(notification_inbox_service.clone())
         .manage(notification_service.clone())
         .manage(settings_service.clone())
+        .manage(lifecycle_state)
         // JS에서 `window.__TAURI__.core.invoke()`로 호출할 수 있는 Tauri 커맨드 등록.
         .invoke_handler(tauri::generate_handler![
             commands::report_checker_event,
+            commands::get_desktop_lifecycle_status,
+            commands::acknowledge_and_hide_to_tray,
+            commands::quit_desktop_app,
             commands::bootstrap_desktop_http_session,
             commands::get_desktop_settings,
             commands::check_desktop_update,
@@ -336,10 +341,12 @@ mod tests {
             .filter_map(|line| line.trim().strip_prefix('"')?.strip_suffix("\","))
             .collect::<std::collections::BTreeSet<_>>();
         let expected = [
+            "acknowledge_and_hide_to_tray",
             "activate_notification",
             "bootstrap_desktop_http_session",
             "check_desktop_update",
             "get_connected_service_status",
+            "get_desktop_lifecycle_status",
             "get_desktop_settings",
             "get_notification_inbox_snapshot",
             "mark_all_notifications_read",
@@ -352,6 +359,7 @@ mod tests {
             "report_checker_event",
             "reset_desktop_identity",
             "send_test_notification",
+            "quit_desktop_app",
             "update_desktop_settings",
         ]
         .into_iter()

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -18,7 +18,7 @@ use tauri::{
     image::Image,
     menu::MenuBuilder,
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Manager, WebviewWindow,
+    Emitter, Manager, WebviewWindow,
 };
 
 const STATUS_COURSE_UPCOMING: &str = "코스 시작 전";
@@ -79,6 +79,7 @@ const ICON_COMPLETE_DARK: &[u8] = include_bytes!("../icons/tray-complete-dark-wi
 
 const TRAY_MENU_OPEN_ID: &str = "open-dashboard";
 const TRAY_MENU_QUIT_ID: &str = "quit";
+const DESKTOP_CLOSE_TO_TRAY_EVENT: &str = "desktop-close-to-tray";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DashboardRoute {
@@ -105,6 +106,12 @@ impl DashboardRoute {
 enum TrayMenuAction {
     OpenDashboard,
     Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DashboardCloseOutcome {
+    KeptVisible,
+    Hidden,
 }
 
 fn tray_menu_action(id: &str) -> Option<TrayMenuAction> {
@@ -526,6 +533,50 @@ fn sync_foreground_app_visibility_soon(app: tauri::AppHandle) {
     });
 }
 
+fn handle_dashboard_close(
+    lifecycle: &crate::config::DesktopLifecycleStateStore,
+    notify: impl FnOnce(crate::config::DesktopLifecycleStatus) -> Result<(), String>,
+    hide: impl FnOnce() -> Result<(), String>,
+) -> Result<DashboardCloseOutcome, String> {
+    match lifecycle.close_to_tray_notice()? {
+        crate::config::CloseToTrayNotice::Acknowledged => {
+            hide()?;
+            Ok(DashboardCloseOutcome::Hidden)
+        }
+        crate::config::CloseToTrayNotice::Unseen => {
+            lifecycle.record_close_to_tray()?;
+            notify(lifecycle.status()?)?;
+            Ok(DashboardCloseOutcome::KeptVisible)
+        }
+        crate::config::CloseToTrayNotice::Pending => Ok(DashboardCloseOutcome::KeptVisible),
+    }
+}
+
+fn acknowledge_and_hide(
+    lifecycle: &crate::config::DesktopLifecycleStateStore,
+    hide: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    lifecycle.acknowledge_close_to_tray_notice()?;
+    hide()
+}
+
+fn hide_dashboard_window(window: &WebviewWindow<tauri::Wry>) -> Result<(), String> {
+    window.hide().map_err(|error| format!("창 숨김 실패: {error}"))?;
+    sync_foreground_app_visibility_soon(window.app_handle().clone());
+    Ok(())
+}
+
+pub(crate) fn acknowledge_and_hide_to_tray(
+    window: &WebviewWindow<tauri::Wry>,
+    lifecycle: &crate::config::DesktopLifecycleStateStore,
+) -> Result<(), String> {
+    acknowledge_and_hide(lifecycle, || hide_dashboard_window(window))
+}
+
+pub(crate) fn quit_app(app: &tauri::AppHandle) {
+    app.exit(0);
+}
+
 fn dashboard_app_url(route: DashboardRoute) -> String {
     format!("index.html#/{}", route.as_str())
 }
@@ -552,7 +603,6 @@ fn build_dashboard_window(app: &tauri::AppHandle, route: DashboardRoute) {
         tauri::WebviewUrl::App(dashboard_app_url(route).into()),
     )
     .title("Jungle Bell")
-    .theme(Some(tauri::Theme::Light))
     .inner_size(DASHBOARD_WINDOW_WIDTH, DASHBOARD_WINDOW_HEIGHT)
     .min_inner_size(DASHBOARD_WINDOW_MIN_WIDTH, DASHBOARD_WINDOW_MIN_HEIGHT)
     .resizable(true)
@@ -569,10 +619,22 @@ fn build_dashboard_window(app: &tauri::AppHandle, route: DashboardRoute) {
             window.on_window_event(move |event| match event {
                 tauri::WindowEvent::CloseRequested { api, .. } => {
                     api.prevent_close();
-                    if let Err(error) = window_for_event.hide() {
-                        log::warn!("[dashboard] hide on close failed: {error}");
+                    let Some(lifecycle) = app_handle.try_state::<Arc<crate::config::DesktopLifecycleStateStore>>()
+                    else {
+                        log::error!("[dashboard] lifecycle state is unavailable; keeping window visible");
+                        return;
+                    };
+                    if let Err(error) = handle_dashboard_close(
+                        lifecycle.inner(),
+                        |status| {
+                            window_for_event
+                                .emit(DESKTOP_CLOSE_TO_TRAY_EVENT, status)
+                                .map_err(|error| format!("close-to-tray 안내 전송 실패: {error}"))
+                        },
+                        || hide_dashboard_window(&window_for_event),
+                    ) {
+                        log::warn!("[dashboard] close-to-tray 처리 실패: {error}");
                     }
-                    sync_foreground_app_visibility_soon(app_handle.clone());
                 }
                 tauri::WindowEvent::Destroyed => {
                     sync_foreground_app_visibility_soon(app_handle.clone());
@@ -644,7 +706,7 @@ pub fn setup_tray(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Erro
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match tray_menu_action(event.id().as_ref()) {
             Some(TrayMenuAction::OpenDashboard) => open_dashboard_window(app),
-            Some(TrayMenuAction::Quit) => app.exit(0),
+            Some(TrayMenuAction::Quit) => quit_app(app),
             None => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -695,6 +757,8 @@ pub fn update_tray(app: &tauri::AppHandle, snapshot: &TraySnapshot) -> Result<()
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use super::*;
 
     #[cfg(target_os = "macos")]
@@ -976,12 +1040,86 @@ mod tests {
     }
 
     #[test]
-    fn 대시보드는_닫을때_숨기고_기존_창을_재사용한다() {
+    fn 대시보드는_close정책을_적용하고_기존_창을_재사용한다() {
         let source = include_str!("tray.rs");
+        let dashboard_builder = source
+            .split("fn build_dashboard_window")
+            .nth(1)
+            .unwrap()
+            .split("pub fn open_dashboard_window")
+            .next()
+            .unwrap();
         assert!(source.contains("tauri::WindowEvent::CloseRequested { api, .. }"));
         assert!(source.contains("api.prevent_close()"));
-        assert!(source.contains("window_for_event.hide()"));
+        assert!(source.contains("record_close_to_tray"));
+        assert!(source.contains("desktop-close-to-tray"));
+        assert!(source.contains("hide_dashboard_window"));
         assert!(source.contains("if let Some(window) = app.get_webview_window(\"dashboard\")"));
+        assert!(!dashboard_builder.contains(".theme("));
+    }
+
+    #[test]
+    fn 최초_close는_창을_유지하고_ack후_숨긴뒤_후속_close는_즉시_숨긴다() {
+        let path = std::env::temp_dir().join(format!(
+            "jungle-bell-tray-lifecycle-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let lifecycle = crate::config::DesktopLifecycleStateStore::load_from(Some(path.clone()));
+        let notified = Cell::new(false);
+        let hidden = Cell::new(false);
+
+        let first = handle_dashboard_close(
+            &lifecycle,
+            |_| {
+                notified.set(true);
+                Ok(())
+            },
+            || {
+                hidden.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(first, DashboardCloseOutcome::KeptVisible);
+        assert!(notified.get());
+        assert!(!hidden.get());
+        assert_eq!(
+            lifecycle.close_to_tray_notice().unwrap(),
+            crate::config::CloseToTrayNotice::Pending
+        );
+
+        acknowledge_and_hide(&lifecycle, || {
+            hidden.set(true);
+            Ok(())
+        })
+        .unwrap();
+        assert!(hidden.replace(false));
+        assert_eq!(
+            lifecycle.close_to_tray_notice().unwrap(),
+            crate::config::CloseToTrayNotice::Acknowledged
+        );
+
+        notified.set(false);
+        let subsequent = handle_dashboard_close(
+            &lifecycle,
+            |_| {
+                notified.set(true);
+                Ok(())
+            },
+            || {
+                hidden.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(subsequent, DashboardCloseOutcome::Hidden);
+        assert!(!notified.get());
+        assert!(hidden.get());
+        std::fs::remove_file(path).unwrap();
     }
 
     // --- TrayViewModel ---

--- a/frontend/src/components/ui/external-link-policy.ts
+++ b/frontend/src/components/ui/external-link-policy.ts
@@ -1,0 +1,56 @@
+const PROJECT_PATH = '/YangSiJun528/jungle-bell';
+const INSTALL_GUIDE_FRAGMENT = '#%EC%84%A4%EC%B9%98';
+const MEAL_ASSET_PATH = /^\/api\/public\/assets\/[a-f0-9]{64}\.(?:avif|gif|jpe?g|png|webp)$/u;
+const MEAL_POST_PATH = /^\/_xhzNjn\/(?:posts|[1-9][0-9]*)$/u;
+
+function containsControlCharacter(value: string): boolean {
+    for (let index = 0; index < value.length; index += 1) {
+        const code = value.charCodeAt(index);
+        if (code <= 31 || code === 127) return true;
+    }
+    return false;
+}
+
+export function normalizeExternalUrl(value: string): string {
+    if (
+        value.length === 0 ||
+        value.length > 2_048 ||
+        value.trim() !== value ||
+        containsControlCharacter(value)
+    ) {
+        throw new Error('EXTERNAL_URL_NOT_ALLOWED');
+    }
+
+    let url: URL;
+    try {
+        url = new URL(value);
+    } catch {
+        throw new Error('EXTERNAL_URL_NOT_ALLOWED');
+    }
+    if (
+        url.protocol !== 'https:' ||
+        url.username !== '' ||
+        url.password !== '' ||
+        url.port !== '' ||
+        url.search !== ''
+    ) {
+        throw new Error('EXTERNAL_URL_NOT_ALLOWED');
+    }
+
+    const allowed =
+        (url.hostname === 'github.com' &&
+            ((url.pathname === PROJECT_PATH &&
+                (url.hash === '' || url.hash === INSTALL_GUIDE_FRAGMENT)) ||
+                ((url.pathname === `${PROJECT_PATH}/issues/new/choose` ||
+                    url.pathname === `${PROJECT_PATH}/releases/latest`) &&
+                    url.hash === ''))) ||
+        (url.hostname === 'jungle-lms.krafton.com' &&
+            url.pathname === '/check-in' &&
+            url.hash === '') ||
+        (url.hostname === 'pf.kakao.com' && MEAL_POST_PATH.test(url.pathname) && url.hash === '') ||
+        (url.hostname === 'jungle-bell.sijun-yang.com' &&
+            MEAL_ASSET_PATH.test(url.pathname) &&
+            url.hash === '');
+    if (!allowed) throw new Error('EXTERNAL_URL_NOT_ALLOWED');
+    return url.toString();
+}

--- a/frontend/src/components/ui/external-link.test.tsx
+++ b/frontend/src/components/ui/external-link.test.tsx
@@ -1,0 +1,50 @@
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, it, vi} from 'vitest';
+
+import {ExternalLink} from './external-link';
+
+const PROJECT_URL = 'https://github.com/YangSiJun528/jungle-bell';
+
+describe('ExternalLink', () => {
+    it('새 창 링크의 보안 속성과 호출자가 제공한 접근 가능한 이름을 고정한다', () => {
+        const markup = renderToStaticMarkup(
+            <ExternalLink href={PROJECT_URL} aria-label="Jungle Bell GitHub 열기">
+                GitHub
+            </ExternalLink>,
+        );
+
+        expect(markup).toContain(`href="${PROJECT_URL}"`);
+        expect(markup).toContain('target="_blank"');
+        expect(markup).toContain('rel="noopener noreferrer"');
+        expect(markup).toContain('aria-label="Jungle Bell GitHub 열기"');
+    });
+
+    it('Tauri opener를 주입하면 브라우저 탐색을 막고 실패를 콜백으로 반환한다', async () => {
+        const error = new Error('SYSTEM_BROWSER_OPEN_FAILED');
+        const openExternally = vi.fn<(url: string) => Promise<void>>(async () => {
+            throw error;
+        });
+        const onOpenError = vi.fn<(error: unknown) => void>();
+        const element = ExternalLink({
+            href: PROJECT_URL,
+            openExternally,
+            onOpenError,
+            children: 'GitHub',
+        });
+        const event = new Event('click', {cancelable: true});
+        const handler = element.props.onClick;
+        if (!handler) throw new Error('onClick handler is required');
+
+        await Reflect.apply(handler, undefined, [event]);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(openExternally).toHaveBeenCalledWith(PROJECT_URL);
+        expect(onOpenError).toHaveBeenCalledWith(error);
+    });
+
+    it('허용 목록 밖 URL은 anchor를 만들기 전에 거부한다', () => {
+        expect(() => ExternalLink({href: 'javascript:alert(1)', children: 'bad'})).toThrow(
+            'EXTERNAL_URL_NOT_ALLOWED',
+        );
+    });
+});

--- a/frontend/src/components/ui/external-link.tsx
+++ b/frontend/src/components/ui/external-link.tsx
@@ -1,0 +1,44 @@
+import type {ComponentProps, MouseEventHandler, ReactElement} from 'react';
+
+import {normalizeExternalUrl} from './external-link-policy';
+
+export type ExternalUrlOpener = (url: string) => Promise<void>;
+
+export interface ExternalLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target' | 'rel'> {
+    href: string;
+    openExternally?: ExternalUrlOpener;
+    onOpenError?: (error: unknown) => void;
+}
+
+export function ExternalLink({
+    href,
+    openExternally,
+    onOpenError,
+    onClick,
+    children,
+    ...props
+}: ExternalLinkProps): ReactElement<ComponentProps<'a'>> {
+    const safeHref = normalizeExternalUrl(href);
+    const handleClick: MouseEventHandler<HTMLAnchorElement> = async (event) => {
+        onClick?.(event);
+        if (event.defaultPrevented || !openExternally) return;
+        event.preventDefault();
+        try {
+            await openExternally(safeHref);
+        } catch (error) {
+            onOpenError?.(error);
+        }
+    };
+
+    return (
+        <a
+            {...props}
+            href={safeHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={handleClick}
+        >
+            {children}
+        </a>
+    );
+}

--- a/frontend/src/platform/pwa/service-worker/sw.js
+++ b/frontend/src/platform/pwa/service-worker/sw.js
@@ -7,6 +7,7 @@ const PUBLIC_DATA_CACHE = 'jungle-bell-public-data-v1';
 const PUBLIC_IMAGE_CACHE = 'jungle-bell-public-images-v1';
 const RUNTIME_ASSET_CACHE = 'jungle-bell-runtime-assets-v1';
 const LEGACY_CACHE_PREFIX = 'jungle-bell-dashboard-';
+const ACTIVATE_UPDATE_MESSAGE = 'JUNGLE_BELL_ACTIVATE_UPDATE';
 const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
 
@@ -90,6 +91,21 @@ registerRoute(
 // dashboard and lazy chunk remains available immediately after installation.
 precacheAndRoute(self.__WB_MANIFEST);
 cleanupOutdatedCaches();
+
+// A newly installed worker remains waiting until the visible client has saved
+// any user input and explicitly completes the update handshake.
+self.addEventListener('message', (event) => {
+    const message = event.data;
+    if (
+        !message ||
+        typeof message !== 'object' ||
+        Object.keys(message).length !== 1 ||
+        message.type !== ACTIVATE_UPDATE_MESSAGE
+    ) {
+        return;
+    }
+    event.waitUntil(self.skipWaiting());
+});
 
 self.addEventListener('activate', (event) => {
     event.waitUntil(Promise.all([deleteLegacyCaches(), self.clients.claim()]));

--- a/frontend/src/platform/pwa/update-lifecycle.test.ts
+++ b/frontend/src/platform/pwa/update-lifecycle.test.ts
@@ -1,0 +1,145 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import {
+    PWA_ACTIVATE_UPDATE_MESSAGE,
+    createPwaUpdateLifecycle,
+    type PwaUpdateSnapshot,
+} from './update-lifecycle';
+
+class FakeServiceWorker extends EventTarget {
+    state: ServiceWorkerState = 'installing';
+    postMessage = vi.fn<ServiceWorker['postMessage']>();
+
+    transitionTo(state: ServiceWorkerState): void {
+        this.state = state;
+        this.dispatchEvent(new Event('statechange'));
+    }
+}
+
+interface MutableRegistration {
+    installing: ServiceWorker | null;
+    waiting: ServiceWorker | null;
+}
+
+function serviceWorkerEnvironment(options: {controlled?: boolean; waiting?: boolean} = {}) {
+    const container = Object.assign(new EventTarget(), {
+        controller: options.controlled === false ? null : ({} as ServiceWorker),
+    }) as unknown as ServiceWorkerContainer;
+    const worker = new FakeServiceWorker();
+    const registration = Object.assign(new EventTarget(), {
+        installing: null,
+        waiting: options.waiting ? worker : null,
+    }) as unknown as ServiceWorkerRegistration & MutableRegistration;
+    const reloadPage = vi.fn<() => void>();
+    const lifecycle = createPwaUpdateLifecycle({
+        serviceWorker: container,
+        reloadPage,
+        activationTimeoutMs: 50,
+    });
+    return {container, lifecycle, registration, reloadPage, worker};
+}
+
+describe('PwaUpdateLifecycle', () => {
+    it('등록 시 이미 waiting인 업데이트를 즉시 ready로 노출한다', () => {
+        const browser = serviceWorkerEnvironment({waiting: true});
+
+        browser.lifecycle.observeRegistration(browser.registration);
+
+        expect(browser.lifecycle.getSnapshot()).toEqual({status: 'ready', error: null});
+    });
+
+    it('updatefound의 installing worker가 설치되면 ready 상태를 발행한다', () => {
+        const browser = serviceWorkerEnvironment();
+        const listener = vi.fn<(snapshot: PwaUpdateSnapshot) => void>();
+        browser.lifecycle.subscribe(listener);
+        browser.lifecycle.observeRegistration(browser.registration);
+
+        browser.registration.installing = browser.worker as unknown as ServiceWorker;
+        browser.registration.dispatchEvent(new Event('updatefound'));
+        expect(browser.lifecycle.getSnapshot()).toEqual({status: 'installing', error: null});
+
+        browser.registration.waiting = browser.worker as unknown as ServiceWorker;
+        browser.worker.transitionTo('installed');
+
+        expect(browser.lifecycle.getSnapshot()).toEqual({status: 'ready', error: null});
+        expect(listener).toHaveBeenLastCalledWith({status: 'ready', error: null});
+    });
+
+    it('첫 설치처럼 기존 controller가 없으면 업데이트 ready로 오인하지 않는다', () => {
+        const browser = serviceWorkerEnvironment({controlled: false});
+        browser.lifecycle.observeRegistration(browser.registration);
+
+        browser.registration.installing = browser.worker as unknown as ServiceWorker;
+        browser.registration.dispatchEvent(new Event('updatefound'));
+        browser.worker.transitionTo('installed');
+
+        expect(browser.lifecycle.getSnapshot()).toEqual({status: 'idle', error: null});
+    });
+
+    it('입력 보존 handshake가 끝난 뒤에만 새 worker를 활성화하고 controller 교체 후 reload한다', async () => {
+        const browser = serviceWorkerEnvironment({waiting: true});
+        browser.lifecycle.observeRegistration(browser.registration);
+        let finishPreparing: (() => void) | undefined;
+        const preservedDrafts: string[] = [];
+        const prepareForReload = vi.fn<() => Promise<true>>(
+            () =>
+                new Promise<true>((resolve) => {
+                    finishPreparing = () => {
+                        preservedDrafts.push('세탁 메모 초안');
+                        resolve(true);
+                    };
+                }),
+        );
+
+        const activation = browser.lifecycle.activateWhenSafe(prepareForReload);
+
+        expect(browser.worker.postMessage).not.toHaveBeenCalled();
+        finishPreparing?.();
+        await vi.waitFor(() => expect(browser.worker.postMessage).toHaveBeenCalledOnce());
+        expect(preservedDrafts).toEqual(['세탁 메모 초안']);
+        expect(browser.worker.postMessage).toHaveBeenCalledWith(
+            {type: PWA_ACTIVATE_UPDATE_MESSAGE},
+            [],
+        );
+        expect(browser.reloadPage).not.toHaveBeenCalled();
+
+        browser.container.dispatchEvent(new Event('controllerchange'));
+
+        await expect(activation).resolves.toBe('reloading');
+        expect(browser.reloadPage).toHaveBeenCalledOnce();
+    });
+
+    it('입력 보존을 취소하면 waiting worker와 현재 문서를 그대로 둔다', async () => {
+        const browser = serviceWorkerEnvironment({waiting: true});
+        browser.lifecycle.observeRegistration(browser.registration);
+
+        await expect(browser.lifecycle.activateWhenSafe(async () => false)).resolves.toBe(
+            'cancelled',
+        );
+
+        expect(browser.worker.postMessage).not.toHaveBeenCalled();
+        expect(browser.reloadPage).not.toHaveBeenCalled();
+        expect(browser.lifecycle.getSnapshot().status).toBe('ready');
+    });
+
+    it('controller 교체가 확인되지 않으면 reload하지 않고 실패 상태를 노출한다', async () => {
+        vi.useFakeTimers();
+        const browser = serviceWorkerEnvironment({waiting: true});
+        browser.lifecycle.observeRegistration(browser.registration);
+
+        const failure = browser.lifecycle
+            .activateWhenSafe(async () => true)
+            .catch((error: unknown) => error);
+        await vi.runAllTimersAsync();
+
+        await expect(failure).resolves.toMatchObject({
+            message: 'PWA_UPDATE_ACTIVATION_TIMEOUT',
+        });
+        expect(browser.reloadPage).not.toHaveBeenCalled();
+        expect(browser.lifecycle.getSnapshot()).toEqual({
+            status: 'failed',
+            error: 'PWA_UPDATE_ACTIVATION_TIMEOUT',
+        });
+        vi.useRealTimers();
+    });
+});

--- a/frontend/src/platform/pwa/update-lifecycle.ts
+++ b/frontend/src/platform/pwa/update-lifecycle.ts
@@ -1,0 +1,150 @@
+export const PWA_ACTIVATE_UPDATE_MESSAGE = 'JUNGLE_BELL_ACTIVATE_UPDATE';
+
+export type PwaUpdateStatus = 'idle' | 'installing' | 'ready' | 'activating' | 'failed';
+
+export interface PwaUpdateSnapshot {
+    readonly status: PwaUpdateStatus;
+    readonly error: string | null;
+}
+
+export type PrepareForPwaReload = () => boolean | Promise<boolean>;
+
+export interface PwaUpdateLifecycle {
+    getSnapshot(): PwaUpdateSnapshot;
+    subscribe(listener: (snapshot: PwaUpdateSnapshot) => void): () => void;
+    observeRegistration(registration: ServiceWorkerRegistration): void;
+    activateWhenSafe(prepareForReload: PrepareForPwaReload): Promise<'cancelled' | 'reloading'>;
+}
+
+interface PwaUpdateLifecycleOptions {
+    serviceWorker: ServiceWorkerContainer;
+    reloadPage: () => void;
+    activationTimeoutMs?: number;
+}
+
+const IDLE_SNAPSHOT: PwaUpdateSnapshot = Object.freeze({status: 'idle', error: null});
+
+export function createPwaUpdateLifecycle(options: PwaUpdateLifecycleOptions): PwaUpdateLifecycle {
+    const activationTimeoutMs = options.activationTimeoutMs ?? 10_000;
+    const listeners = new Set<(snapshot: PwaUpdateSnapshot) => void>();
+    const observedRegistrations = new WeakSet<ServiceWorkerRegistration>();
+    const observedWorkers = new WeakSet<ServiceWorker>();
+    let snapshot = IDLE_SNAPSHOT;
+    let waitingWorker: ServiceWorker | null = null;
+
+    const publish = (status: PwaUpdateStatus, error: string | null = null): void => {
+        if (snapshot.status === status && snapshot.error === error) return;
+        snapshot = Object.freeze({status, error});
+        for (const listener of listeners) listener(snapshot);
+    };
+
+    const markReady = (worker: ServiceWorker): void => {
+        waitingWorker = worker;
+        publish('ready');
+    };
+
+    const observeInstallingWorker = (
+        registration: ServiceWorkerRegistration,
+        worker: ServiceWorker,
+    ): void => {
+        if (observedWorkers.has(worker)) return;
+        observedWorkers.add(worker);
+        publish('installing');
+
+        const syncWorkerState = (): void => {
+            if (worker.state === 'installed') {
+                if (options.serviceWorker.controller) {
+                    markReady(registration.waiting ?? worker);
+                } else {
+                    waitingWorker = null;
+                    publish('idle');
+                }
+            } else if (worker.state === 'redundant') {
+                waitingWorker = null;
+                publish('failed', 'PWA_UPDATE_INSTALL_FAILED');
+            }
+        };
+        worker.addEventListener('statechange', syncWorkerState);
+        syncWorkerState();
+    };
+
+    const observeRegistration = (registration: ServiceWorkerRegistration): void => {
+        if (registration.waiting && options.serviceWorker.controller) {
+            markReady(registration.waiting);
+        }
+        if (observedRegistrations.has(registration)) return;
+        observedRegistrations.add(registration);
+
+        if (registration.installing) {
+            observeInstallingWorker(registration, registration.installing);
+        }
+        registration.addEventListener('updatefound', () => {
+            const worker = registration.installing;
+            if (worker) observeInstallingWorker(registration, worker);
+        });
+    };
+
+    const waitForControllerChange = (worker: ServiceWorker): Promise<void> =>
+        new Promise<void>((resolve, reject) => {
+            let settled = false;
+            const finish = (callback: () => void): void => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeout);
+                options.serviceWorker.removeEventListener('controllerchange', handleChange);
+                callback();
+            };
+            const handleChange = (): void => finish(resolve);
+            const timeout = setTimeout(
+                () => finish(() => reject(new Error('PWA_UPDATE_ACTIVATION_TIMEOUT'))),
+                activationTimeoutMs,
+            );
+            options.serviceWorker.addEventListener('controllerchange', handleChange);
+            try {
+                worker.postMessage({type: PWA_ACTIVATE_UPDATE_MESSAGE}, []);
+            } catch {
+                finish(() => reject(new Error('PWA_UPDATE_ACTIVATION_FAILED')));
+            }
+        });
+
+    return {
+        getSnapshot: () => snapshot,
+        subscribe(listener) {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+        observeRegistration,
+        async activateWhenSafe(prepareForReload) {
+            if (snapshot.status !== 'ready' || !waitingWorker) {
+                throw new Error('PWA_UPDATE_NOT_READY');
+            }
+            const worker = waitingWorker;
+            publish('activating');
+
+            let prepared: boolean;
+            try {
+                prepared = await prepareForReload();
+            } catch (error) {
+                publish('ready');
+                throw error;
+            }
+            if (!prepared) {
+                publish('ready');
+                return 'cancelled';
+            }
+
+            try {
+                await waitForControllerChange(worker);
+                options.reloadPage();
+                return 'reloading';
+            } catch (error) {
+                const code =
+                    error instanceof Error && error.message.startsWith('PWA_UPDATE_')
+                        ? error.message
+                        : 'PWA_UPDATE_ACTIVATION_FAILED';
+                publish('failed', code);
+                throw new Error(code, {cause: error});
+            }
+        },
+    };
+}

--- a/frontend/src/platform/tauri/adapter.ts
+++ b/frontend/src/platform/tauri/adapter.ts
@@ -9,15 +9,24 @@ import {unavailablePwaAdapter, unavailableUsagePrivacyAdapter} from '@/platform/
 import {createDesktopHttpSessionManager} from './desktop-http-session';
 import {createDashboardDesktopSettingsApi} from './desktop-settings';
 import {createTauriEventAdapter} from './event-adapter';
+import {createTauriExternalLinkAdapter, type TauriExternalLinkAdapter} from './external-links';
+import {createTauriLifecycleAdapter, type TauriLifecycleAdapter} from './lifecycle';
 import {createNativeBridge} from './native-bridge';
+
+export interface TauriPlatformAdapter extends PlatformAdapter {
+    externalLinks: TauriExternalLinkAdapter;
+    lifecycle: TauriLifecycleAdapter;
+}
 
 export function createTauriPlatformAdapter(
     options: {
         nativeBridge?: NativeBridge;
         events?: PlatformEventAdapter;
+        externalLinks?: TauriExternalLinkAdapter;
+        lifecycle?: TauriLifecycleAdapter;
         pwa?: PwaCapabilityAdapter;
     } = {},
-): PlatformAdapter {
+): TauriPlatformAdapter {
     const native = options.nativeBridge ?? createNativeBridge();
     return {
         kind: 'desktop',
@@ -38,6 +47,8 @@ export function createTauriPlatformAdapter(
         native,
         desktopSettings: createDashboardDesktopSettingsApi(native),
         events: options.events ?? createTauriEventAdapter(),
+        externalLinks: options.externalLinks ?? createTauriExternalLinkAdapter(),
+        lifecycle: options.lifecycle ?? createTauriLifecycleAdapter(),
         pwa: options.pwa ?? unavailablePwaAdapter(),
         usagePrivacy: unavailableUsagePrivacyAdapter(),
     };

--- a/frontend/src/platform/tauri/external-links.test.ts
+++ b/frontend/src/platform/tauri/external-links.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import type {NativeInvoke} from '@/platform/contracts';
+
+import {createTauriExternalLinkAdapter, normalizeExternalUrl} from './external-links';
+
+describe('TauriExternalLinkAdapter', () => {
+    it.each([
+        'https://github.com/YangSiJun528/jungle-bell',
+        'https://github.com/YangSiJun528/jungle-bell#%EC%84%A4%EC%B9%98',
+        'https://github.com/YangSiJun528/jungle-bell/issues/new/choose',
+        'https://github.com/YangSiJun528/jungle-bell/releases/latest',
+        'https://jungle-lms.krafton.com/check-in',
+        'https://pf.kakao.com/_xhzNjn/posts',
+        'https://pf.kakao.com/_xhzNjn/114222378',
+        `https://jungle-bell.sijun-yang.com/api/public/assets/${'a'.repeat(64)}.webp`,
+    ])('허용된 HTTPS 목적지만 정규화한다: %s', (url) => {
+        expect(normalizeExternalUrl(url)).toBe(url);
+    });
+
+    it.each([
+        'http://github.com/YangSiJun528/jungle-bell',
+        'javascript:alert(1)',
+        'https://evil.example/YangSiJun528/jungle-bell',
+        'https://github.com.evil.example/YangSiJun528/jungle-bell',
+        'https://user:pass@github.com/YangSiJun528/jungle-bell',
+        'https://github.com:444/YangSiJun528/jungle-bell',
+        'https://github.com/YangSiJun528/jungle-bell/issues/69',
+        'https://jungle-lms.krafton.com/check-in?next=https://evil.example',
+        'https://pf.kakao.com/_xhzNjn/0',
+        `https://jungle-bell.sijun-yang.com/api/public/assets/${'a'.repeat(63)}.png`,
+    ])('허용 목록 밖 URL을 거부한다: %s', (url) => {
+        expect(() => normalizeExternalUrl(url)).toThrow('EXTERNAL_URL_NOT_ALLOWED');
+    });
+
+    it('검증한 URL만 opener 플러그인에 넘기고 native 실패를 호출자에게 전달한다', async () => {
+        const nativeError = new Error('SYSTEM_BROWSER_OPEN_FAILED');
+        const invoke = vi.fn<NativeInvoke>(async () => {
+            throw nativeError;
+        });
+        const adapter = createTauriExternalLinkAdapter(invoke);
+
+        await expect(adapter.open('https://github.com/YangSiJun528/jungle-bell')).rejects.toBe(
+            nativeError,
+        );
+        expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
+            url: 'https://github.com/YangSiJun528/jungle-bell',
+        });
+    });
+
+    it('검증 실패 시 native 호출을 시작하지 않는다', async () => {
+        const invoke = vi.fn<NativeInvoke>();
+        const adapter = createTauriExternalLinkAdapter(invoke);
+
+        await expect(adapter.open('file:///etc/passwd')).rejects.toThrow(
+            'EXTERNAL_URL_NOT_ALLOWED',
+        );
+        expect(invoke).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/platform/tauri/external-links.ts
+++ b/frontend/src/platform/tauri/external-links.ts
@@ -1,0 +1,21 @@
+import {invoke as tauriInvoke} from '@tauri-apps/api/core';
+
+import {normalizeExternalUrl} from '@/components/ui/external-link-policy';
+import type {NativeInvoke} from '@/platform/contracts';
+
+export {normalizeExternalUrl} from '@/components/ui/external-link-policy';
+
+export interface TauriExternalLinkAdapter {
+    open(url: string): Promise<void>;
+}
+
+export function createTauriExternalLinkAdapter(
+    invokeCommand: NativeInvoke = (command, args) => tauriInvoke(command, args),
+): TauriExternalLinkAdapter {
+    return {
+        async open(value) {
+            const url = normalizeExternalUrl(value);
+            await invokeCommand('plugin:opener|open_url', {url});
+        },
+    };
+}

--- a/frontend/src/platform/tauri/lifecycle.test.ts
+++ b/frontend/src/platform/tauri/lifecycle.test.ts
@@ -1,0 +1,71 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import type {NativeInvoke} from '@/platform/contracts';
+
+import {createTauriLifecycleAdapter, type DesktopLifecycleStatus} from './lifecycle';
+
+const listen = vi.hoisted(() =>
+    vi.fn<(event: string, handler: (event: {payload: unknown}) => void) => Promise<() => void>>(
+        async () => () => undefined,
+    ),
+);
+
+vi.mock('@tauri-apps/api/event', () => ({listen}));
+
+const pendingStatus = {
+    closeBehavior: 'hideToTray',
+    closeToTrayNotice: 'pending',
+    explicitQuitAvailable: true,
+} as const;
+
+beforeEach(() => listen.mockClear());
+
+describe('TauriLifecycleAdapter', () => {
+    it('수명주기 상태 조회·안내 확인·완전 종료를 좁은 command로 매핑한다', async () => {
+        const invoke = vi.fn<NativeInvoke>(async (command) => {
+            if (command === 'get_desktop_lifecycle_status') return pendingStatus;
+            if (command === 'acknowledge_and_hide_to_tray') {
+                return {...pendingStatus, closeToTrayNotice: 'acknowledged'};
+            }
+            return null;
+        });
+        const adapter = createTauriLifecycleAdapter(invoke);
+
+        await expect(adapter.getStatus()).resolves.toEqual(pendingStatus);
+        await expect(adapter.acknowledgeAndHideToTray()).resolves.toEqual({
+            ...pendingStatus,
+            closeToTrayNotice: 'acknowledged',
+        });
+        await expect(adapter.quit()).resolves.toBeUndefined();
+        expect(invoke.mock.calls).toEqual([
+            ['get_desktop_lifecycle_status'],
+            ['acknowledge_and_hide_to_tray'],
+            ['quit_desktop_app'],
+        ]);
+    });
+
+    it.each([
+        {...pendingStatus, legacy: true},
+        {...pendingStatus, closeBehavior: 'close'},
+        {...pendingStatus, closeToTrayNotice: 'shown'},
+        {...pendingStatus, explicitQuitAvailable: false},
+    ])('backend의 느슨하거나 잘못된 DTO를 거부한다: %#', async (value) => {
+        const adapter = createTauriLifecycleAdapter(async () => value);
+        await expect(adapter.getStatus()).rejects.toThrow('API_RESPONSE_INVALID');
+    });
+
+    it('최초 close-to-tray 이벤트 payload를 검증해 전달한다', async () => {
+        const listener = vi.fn<(status: DesktopLifecycleStatus) => void>();
+        const adapter = createTauriLifecycleAdapter(async () => pendingStatus);
+
+        const unlisten = await adapter.subscribeCloseToTrayNotice(listener);
+
+        expect(unlisten).toEqual(expect.any(Function));
+        expect(listen).toHaveBeenCalledWith('desktop-close-to-tray', expect.any(Function));
+        const eventHandler = listen.mock.calls[0]?.[1];
+        eventHandler?.({payload: pendingStatus});
+        eventHandler?.({payload: {...pendingStatus, extra: true}});
+        expect(listener).toHaveBeenCalledOnce();
+        expect(listener).toHaveBeenCalledWith(pendingStatus);
+    });
+});

--- a/frontend/src/platform/tauri/lifecycle.ts
+++ b/frontend/src/platform/tauri/lifecycle.ts
@@ -1,0 +1,70 @@
+import {invoke as tauriInvoke} from '@tauri-apps/api/core';
+import {listen} from '@tauri-apps/api/event';
+
+import {hasOwn, isRecord} from '@/lib/object';
+import type {NativeInvoke} from '@/platform/contracts';
+
+export type CloseToTrayNotice = 'unseen' | 'pending' | 'acknowledged';
+
+export interface DesktopLifecycleStatus {
+    readonly closeBehavior: 'hideToTray';
+    readonly closeToTrayNotice: CloseToTrayNotice;
+    readonly explicitQuitAvailable: true;
+}
+
+export interface TauriLifecycleAdapter {
+    getStatus(): Promise<DesktopLifecycleStatus>;
+    acknowledgeAndHideToTray(): Promise<DesktopLifecycleStatus>;
+    quit(): Promise<void>;
+    subscribeCloseToTrayNotice(
+        listener: (status: DesktopLifecycleStatus) => void,
+    ): Promise<() => void>;
+}
+
+function isCloseToTrayNotice(value: unknown): value is CloseToTrayNotice {
+    return value === 'unseen' || value === 'pending' || value === 'acknowledged';
+}
+
+export function createTauriLifecycleAdapter(
+    invokeCommand: NativeInvoke = (command, args) => tauriInvoke(command, args),
+): TauriLifecycleAdapter {
+    return {
+        async getStatus() {
+            return parseDesktopLifecycleStatus(await invokeCommand('get_desktop_lifecycle_status'));
+        },
+        async acknowledgeAndHideToTray() {
+            return parseDesktopLifecycleStatus(await invokeCommand('acknowledge_and_hide_to_tray'));
+        },
+        async quit() {
+            await invokeCommand('quit_desktop_app');
+        },
+        subscribeCloseToTrayNotice: (listener) =>
+            listen<unknown>('desktop-close-to-tray', ({payload}) => {
+                try {
+                    listener(parseDesktopLifecycleStatus(payload));
+                } catch {
+                    // Native event payloads are an untrusted IPC boundary.
+                }
+            }),
+    };
+}
+
+function parseDesktopLifecycleStatus(value: unknown): DesktopLifecycleStatus {
+    if (
+        !isRecord(value) ||
+        Object.keys(value).length !== 3 ||
+        !hasOwn(value, 'closeBehavior') ||
+        value.closeBehavior !== 'hideToTray' ||
+        !hasOwn(value, 'closeToTrayNotice') ||
+        !isCloseToTrayNotice(value.closeToTrayNotice) ||
+        !hasOwn(value, 'explicitQuitAvailable') ||
+        value.explicitQuitAvailable !== true
+    ) {
+        throw new Error('API_RESPONSE_INVALID');
+    }
+    return {
+        closeBehavior: value.closeBehavior,
+        closeToTrayNotice: value.closeToTrayNotice,
+        explicitQuitAvailable: value.explicitQuitAvailable,
+    };
+}

--- a/frontend/src/tests/contracts/dashboard-pwa.test.ts
+++ b/frontend/src/tests/contracts/dashboard-pwa.test.ts
@@ -11,6 +11,10 @@ const manifest = JSON.parse(
 const dashboardApi = readFileSync(new URL('./api/dashboard-api.ts', srcRoot), 'utf8');
 const worker = readFileSync(new URL('./platform/pwa/service-worker/sw.js', srcRoot), 'utf8');
 const pwaAdapter = readFileSync(new URL('./platform/pwa/adapter.ts', srcRoot), 'utf8');
+const pwaUpdateLifecycle = readFileSync(
+    new URL('./platform/pwa/update-lifecycle.ts', srcRoot),
+    'utf8',
+);
 const headers = readFileSync(new URL('./platform/pwa/public/_headers', srcRoot), 'utf8');
 const webIcon = readFileSync(new URL('./platform/pwa/public/icons/icon.svg', srcRoot), 'utf8');
 const vite = readFileSync(new URL('../vite.config.ts', srcRoot), 'utf8');
@@ -69,8 +73,14 @@ test('공개 상태·세탁·급식 API는 과거 급식 페이지까지 network
     assert.match(worker, /maxAgeSeconds:\s*SEVEN_DAYS_SECONDS/);
 });
 
-test('새 service worker는 기존 React client가 닫힐 때까지 waiting 상태를 유지한다', () => {
-    assert.doesNotMatch(worker, /\bskipWaiting\s*\(/);
+test('새 service worker는 입력 보존 handshake 전까지 waiting 상태를 유지한다', () => {
+    assert.match(worker, /JUNGLE_BELL_ACTIVATE_UPDATE/);
+    assert.match(worker, /self\.addEventListener\(['"]message['"]/);
+    assert.match(worker, /self\.skipWaiting\(\)/);
+    assert.match(pwaUpdateLifecycle, /prepareForReload/);
+    assert.match(pwaUpdateLifecycle, /controllerchange/);
+    assert.match(pwaUpdateLifecycle, /JUNGLE_BELL_ACTIVATE_UPDATE/);
+    assert.doesNotMatch(worker, /self\.addEventListener\(['"]install['"][\s\S]*skipWaiting/);
     assert.doesNotMatch(pwaAdapter, /SKIP_WAITING|registration\.waiting\.postMessage/);
     assert.match(worker, /cleanupOutdatedCaches\(\)/);
     assert.match(worker, /LEGACY_CACHE_PREFIX\s*=\s*['"]jungle-bell-dashboard-['"]/);

--- a/frontend/src/tests/contracts/desktop-external-links.test.ts
+++ b/frontend/src/tests/contracts/desktop-external-links.test.ts
@@ -16,7 +16,7 @@ const dashboardCapability = JSON.parse(
 ) as {permissions: CapabilityPermission[]};
 const desktopAppSource = readFileSync(new URL('desktop/src/lib.rs', repoRoot), 'utf8');
 
-test('Tauri 대시보드는 프로젝트 링크만 시스템 브라우저로 열 수 있다', () => {
+test('Tauri 대시보드는 검증된 프로젝트·LMS·급식 링크만 시스템 브라우저로 열 수 있다', () => {
     assert.match(desktopAppSource, /\.plugin\(tauri_plugin_opener::init\(\)\)/u);
     assert.equal(dashboardCapability.permissions.includes('opener:default'), false);
     assert.deepEqual(
@@ -28,8 +28,16 @@ test('Tauri 대시보드는 프로젝트 링크만 시스템 브라우저로 열
             identifier: 'opener:allow-open-url',
             allow: [
                 {url: 'https://github.com/YangSiJun528/jungle-bell'},
+                {
+                    url: 'https://github.com/YangSiJun528/jungle-bell#%EC%84%A4%EC%B9%98',
+                },
                 {url: 'https://github.com/YangSiJun528/jungle-bell/issues/new/choose'},
                 {url: 'https://github.com/YangSiJun528/jungle-bell/releases/latest'},
+                {url: 'https://jungle-lms.krafton.com/check-in'},
+                {url: 'https://pf.kakao.com/_xhzNjn/*'},
+                {
+                    url: 'https://jungle-bell.sijun-yang.com/api/public/assets/*',
+                },
             ],
         },
     );


### PR DESCRIPTION
# 요약

PWA 업데이트와 Tauri 외부 링크·close-to-tray 수명주기의 안전한 계약을 추가합니다.

- service worker waiting/activate/controllerchange handshake
- HTTPS allowlist 기반 system browser opener
- 최초 X 안내 상태와 명시적 종료 명령
- 시스템 테마 사용

# 스택

7/9, base: `codex/issue-69-06-data-feedback`

# 검증

- 독립 worktree 병렬 작업: 성공
- `npm run check`: 117개 파일, 681개 테스트 통과
- `npm run build:web`: PWA 산출물 검증 통과
- `npm run verify:desktop`: Rust 단위 241개·통합 2개 통과

Refs #69
