### PR TITLE
[stack 8/9] feat(ui): 앱 상태·푸시·페어링 수명주기 구현

### DIFF
--- a/frontend/src/api/dashboard-api.test.ts
+++ b/frontend/src/api/dashboard-api.test.ts
@@ -1261,6 +1261,94 @@ test('테스트 알림은 PC에서는 OS 알림 IPC, 모바일에서는 인증�
     );
 });
 
+const pushSubscription = {
+    endpoint: 'https://push.example.com/subscriptions/device-1',
+    keys: {
+        p256dh: 'public-key',
+        auth: 'auth-secret',
+    },
+};
+
+test('푸시 구독은 서버가 반환한 ID를 검증해 반환하고 같은 ID로 해제한다', async () => {
+    const requests: Array<{url: string; init?: RequestInit}> = [];
+    const subscriptionId = `jbps_${'a'.repeat(64)}`;
+    const api = createDashboardApi({
+        platformApiBaseUrl: 'https://platform.example.com',
+        fetcher: async (input, init) => {
+            requests.push({url: String(input), init});
+            return init?.method === 'PUT'
+                ? jsonResponse({subscriptionId})
+                : new Response(null, {status: 204});
+        },
+        invokeCommand: async () => undefined,
+    });
+
+    assert.equal(await api.registerPushSubscription(pushSubscription), subscriptionId);
+    await api.unregisterPushSubscription(subscriptionId);
+
+    assert.deepEqual(
+        requests.map(({url, init}) => ({
+            url,
+            method: init?.method,
+            body: init?.body,
+            credentials: init?.credentials,
+            cache: init?.cache,
+        })),
+        [
+            {
+                url: 'https://platform.example.com/api/me/push/subscriptions',
+                method: 'PUT',
+                body: JSON.stringify(pushSubscription),
+                credentials: 'include',
+                cache: 'no-store',
+            },
+            {
+                url: `https://platform.example.com/api/me/push/subscriptions/${subscriptionId}`,
+                method: 'DELETE',
+                body: undefined,
+                credentials: 'include',
+                cache: 'no-store',
+            },
+        ],
+    );
+});
+
+test('푸시 구독 등록은 정규 ID만 반환하고 추가 필드를 거부한다', async () => {
+    for (const response of [
+        {},
+        {subscriptionId: 'jbps_short'},
+        {subscriptionId: `jbps_${'A'.repeat(64)}`},
+        {subscriptionId: `jbps_${'a'.repeat(64)}`, legacy: true},
+    ]) {
+        const api = createDashboardApi({fetcher: async () => jsonResponse(response)});
+        await assert.rejects(
+            api.registerPushSubscription(pushSubscription),
+            /API_RESPONSE_INVALID/u,
+        );
+    }
+});
+
+test('푸시 구독 해제는 정규 ID와 204 응답만 허용한다', async () => {
+    let fetchCount = 0;
+    const invalidInputApi = createDashboardApi({
+        fetcher: async () => {
+            fetchCount += 1;
+            return new Response(null, {status: 204});
+        },
+    });
+    await assert.rejects(
+        invalidInputApi.unregisterPushSubscription('../subscription'),
+        /API_CLIENT_INVALID_ARGUMENT/u,
+    );
+    assert.equal(fetchCount, 0);
+
+    const nonCanonicalResponseApi = createDashboardApi({fetcher: async () => jsonResponse({})});
+    await assert.rejects(
+        nonCanonicalResponseApi.unregisterPushSubscription(`jbps_${'a'.repeat(64)}`),
+        /API_RESPONSE_INVALID/u,
+    );
+});
+
 const mealPreferences = {
     enabled: true,
     lunch: true,

--- a/frontend/src/api/dashboard-api.ts
+++ b/frontend/src/api/dashboard-api.ts
@@ -30,6 +30,7 @@ import {
     parseDesktopTestNotificationResult,
     parseNotificationInboxSnapshot,
     pushPublicKeyResultSchema,
+    pushSubscriptionIdSchema,
     pushSubscriptionInputSchema,
     pushSubscriptionResultSchema,
     qrPairingClaimInputSchema,
@@ -150,7 +151,8 @@ export interface DashboardApi extends DashboardPersonalApi, DesktopSettingsAdapt
     sendDesktopTestNotification(): Promise<DesktopTestNotificationResult>;
     sendMobileTestNotification(): Promise<number>;
     getPushPublicKey(): Promise<string>;
-    registerPushSubscription(subscription: PushSubscriptionJSON): Promise<void>;
+    registerPushSubscription(subscription: PushSubscriptionJSON): Promise<string>;
+    unregisterPushSubscription(subscriptionId: string): Promise<void>;
 }
 
 const historyMonthSchema = z.string().regex(/^\d{4}-(?:0[1-9]|1[0-2])$/u);
@@ -428,10 +430,20 @@ export function createDashboardApi(options: DashboardApiOptions = {}): Dashboard
                 endpoint: subscription.endpoint,
                 keys: subscription.keys,
             });
-            await accountValue(pushSubscriptionResultSchema, '/api/me/push/subscriptions', {
-                method: 'PUT',
-                body: JSON.stringify(body),
-            });
+            return (
+                await accountValue(pushSubscriptionResultSchema, '/api/me/push/subscriptions', {
+                    method: 'PUT',
+                    body: JSON.stringify(body),
+                })
+            ).subscriptionId;
+        },
+
+        async unregisterPushSubscription(subscriptionId) {
+            const validatedSubscriptionId = parseInput(pushSubscriptionIdSchema, subscriptionId);
+            await accountNoContent(
+                `/api/me/push/subscriptions/${encodeURIComponent(validatedSubscriptionId)}`,
+                {method: 'DELETE'},
+            );
         },
     };
 }

--- a/frontend/src/api/push-subscription-lifecycle.test.ts
+++ b/frontend/src/api/push-subscription-lifecycle.test.ts
@@ -1,0 +1,542 @@
+import assert from 'node:assert/strict';
+
+import {describe, test, vi} from 'vitest';
+
+import {
+    PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY,
+    cleanupPushSubscription,
+    clearPushSubscriptionMetadata,
+    fingerprintPushSubscriptionEndpoint,
+    matchesPushSubscriptionEndpoint,
+    readPushSubscriptionMetadata,
+    reconcilePushSubscriptionState,
+    writePushSubscriptionMetadata,
+    type PushSubscriptionLifecycleStorage,
+    type PushSubscriptionMetadata,
+} from './push-subscription-lifecycle';
+
+const subscriptionId = `jbps_${'a'.repeat(64)}`;
+const endpoint = 'https://push.example.com/subscriptions/private-token';
+
+class MemoryStorage implements PushSubscriptionLifecycleStorage {
+    readonly values = new Map<string, string>();
+
+    getItem(key: string): string | null {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string): void {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string): void {
+        this.values.delete(key);
+    }
+}
+
+async function registeredMetadata(
+    overrides: Partial<PushSubscriptionMetadata> = {},
+): Promise<PushSubscriptionMetadata> {
+    return {
+        version: 1,
+        subscriptionId,
+        endpointFingerprint: await fingerprintPushSubscriptionEndpoint(endpoint),
+        cleanupPhase: 'registered',
+        ...overrides,
+    };
+}
+
+async function storeRegistered(storage: MemoryStorage): Promise<PushSubscriptionMetadata> {
+    const metadata = await registeredMetadata();
+    assert.deepEqual(writePushSubscriptionMetadata(storage, metadata), {status: 'written'});
+    return metadata;
+}
+
+function localSubscription(localEndpoint = endpoint): PushSubscriptionJSON {
+    return {
+        endpoint: localEndpoint,
+        expirationTime: null,
+        keys: {auth: 'auth-key', p256dh: 'p256dh-key'},
+    };
+}
+
+function unregisterServerMock() {
+    return vi.fn<(subscriptionId: string) => Promise<void>>(async () => undefined);
+}
+
+function unsubscribeLocalMock() {
+    return vi.fn<(subscription: PushSubscriptionJSON) => Promise<boolean>>(async () => true);
+}
+
+describe('push subscription metadata', () => {
+    test('restores strict versioned metadata without persisting the endpoint', async () => {
+        const storage = new MemoryStorage();
+        const metadata = await registeredMetadata();
+
+        assert.deepEqual(writePushSubscriptionMetadata(storage, metadata), {status: 'written'});
+        assert.deepEqual(readPushSubscriptionMetadata(storage), {status: 'found', metadata});
+
+        const serialized = storage.getItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY);
+        assert.ok(serialized);
+        assert.equal(serialized.includes(endpoint), false);
+        assert.deepEqual(Object.keys(JSON.parse(serialized)).sort(), [
+            'cleanupPhase',
+            'endpointFingerprint',
+            'subscriptionId',
+            'version',
+        ]);
+    });
+
+    test('matches a restored record only to the same endpoint', async () => {
+        const metadata = await registeredMetadata();
+
+        await assert.doesNotReject(async () => {
+            assert.equal(
+                await matchesPushSubscriptionEndpoint(localSubscription(), metadata),
+                true,
+            );
+            assert.equal(
+                await matchesPushSubscriptionEndpoint(
+                    localSubscription('https://push.example.com/subscriptions/other-token'),
+                    metadata,
+                ),
+                false,
+            );
+        });
+        assert.match(metadata.endpointFingerprint, /^sha256:[0-9a-f]{64}$/u);
+    });
+
+    test('reconciles restart state without treating absence as verified cleanup', async () => {
+        const metadata = await registeredMetadata();
+
+        assert.deepEqual(
+            await reconcilePushSubscriptionState({status: 'found', metadata}, localSubscription()),
+            {status: 'matched-registered', metadata},
+        );
+        assert.deepEqual(
+            await reconcilePushSubscriptionState(
+                {
+                    status: 'found',
+                    metadata: {...metadata, cleanupPhase: 'server-removed'},
+                },
+                localSubscription(),
+            ),
+            {
+                status: 'matched-server-removed',
+                metadata: {...metadata, cleanupPhase: 'server-removed'},
+            },
+        );
+        assert.deepEqual(
+            await reconcilePushSubscriptionState({status: 'missing'}, localSubscription()),
+            {status: 'local-only'},
+        );
+        assert.deepEqual(await reconcilePushSubscriptionState({status: 'found', metadata}, null), {
+            status: 'record-only',
+            metadata,
+        });
+        assert.deepEqual(
+            await reconcilePushSubscriptionState(
+                {status: 'found', metadata},
+                localSubscription('https://push.example.com/subscriptions/replaced'),
+            ),
+            {status: 'mismatch', metadata},
+        );
+        assert.deepEqual(await reconcilePushSubscriptionState({status: 'missing'}, null), {
+            status: 'none',
+            verification: 'not-verified',
+        });
+    });
+
+    test('does not accept corrupt, unsupported-version, noncanonical, or expanded records', async () => {
+        const storage = new MemoryStorage();
+        const valid = await registeredMetadata();
+
+        storage.setItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY, '{not json');
+        assert.equal(readPushSubscriptionMetadata(storage).status, 'invalid');
+        assert.deepEqual(readPushSubscriptionMetadata(storage), {
+            status: 'invalid',
+            error: {code: 'metadata-corrupt'},
+        });
+
+        storage.setItem(
+            PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY,
+            JSON.stringify({...valid, version: 2}),
+        );
+        assert.deepEqual(readPushSubscriptionMetadata(storage), {
+            status: 'invalid',
+            error: {code: 'metadata-version-unsupported', version: 2},
+        });
+
+        for (const invalid of [
+            {...valid, subscriptionId: 'jbps_short'},
+            {...valid, endpointFingerprint: endpoint},
+            {...valid, endpoint: 'must-not-be-stored'},
+        ]) {
+            storage.setItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY, JSON.stringify(invalid));
+            assert.deepEqual(readPushSubscriptionMetadata(storage), {
+                status: 'invalid',
+                error: {code: 'metadata-corrupt'},
+            });
+        }
+    });
+
+    test('safe storage helpers report storage failures instead of claiming success', async () => {
+        const failure = new Error('STORAGE_DISABLED');
+        const unreadable: PushSubscriptionLifecycleStorage = {
+            getItem: () => {
+                throw failure;
+            },
+            setItem: () => {
+                throw failure;
+            },
+            removeItem: () => {
+                throw failure;
+            },
+        };
+
+        assert.deepEqual(readPushSubscriptionMetadata(unreadable), {
+            status: 'failed',
+            error: {code: 'storage-read-failed', cause: failure},
+        });
+        assert.deepEqual(writePushSubscriptionMetadata(unreadable, await registeredMetadata()), {
+            status: 'failed',
+            error: {code: 'storage-write-failed', cause: failure},
+        });
+        assert.deepEqual(clearPushSubscriptionMetadata(unreadable), {
+            status: 'failed',
+            error: {code: 'storage-clear-failed', cause: failure},
+        });
+    });
+});
+
+describe('push subscription cleanup', () => {
+    test('unregisters the server before unsubscribing locally and durably records the boundary', async () => {
+        const events: string[] = [];
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const originalSetItem = storage.setItem.bind(storage);
+        const originalRemoveItem = storage.removeItem.bind(storage);
+        storage.setItem = (key, value) => {
+            events.push(`write:${JSON.parse(value).cleanupPhase}`);
+            originalSetItem(key, value);
+        };
+        storage.removeItem = (key) => {
+            events.push('clear');
+            originalRemoveItem(key);
+        };
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => {
+                events.push('get-local');
+                return localSubscription();
+            },
+            unregisterServer: async (id) => {
+                events.push(`unregister:${id}`);
+            },
+            unsubscribeLocal: async (subscription) => {
+                events.push(`unsubscribe:${subscription.endpoint}`);
+                return true;
+            },
+        });
+
+        assert.deepEqual(events, [
+            'get-local',
+            `unregister:${subscriptionId}`,
+            'write:server-removed',
+            `unsubscribe:${endpoint}`,
+            'clear',
+        ]);
+        assert.deepEqual(result, {
+            status: 'complete',
+            phase: 'complete',
+            progress: {metadata: 'cleared', server: 'removed', local: 'unsubscribed'},
+        });
+        assert.equal(readPushSubscriptionMetadata(storage).status, 'missing');
+    });
+
+    test('server failure leaves the matching local subscription and registered record intact', async () => {
+        const storage = new MemoryStorage();
+        const metadata = await storeRegistered(storage);
+        const failure = new Error('NETWORK_ERROR');
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => {
+                throw failure;
+            },
+            unsubscribeLocal,
+        });
+
+        assert.deepEqual(result, {
+            status: 'incomplete',
+            phase: 'server-removal',
+            progress: {metadata: 'registered', server: 'registered', local: 'present'},
+            error: {code: 'server-unregister-failed', cause: failure},
+        });
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+        assert.deepEqual(readPushSubscriptionMetadata(storage), {status: 'found', metadata});
+    });
+
+    test('local failure after server success preserves the retryable server-removed phase', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const failure = new Error('PUSH_SUBSCRIPTION_CHANGED');
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => undefined,
+            unsubscribeLocal: async () => {
+                throw failure;
+            },
+        });
+
+        assert.deepEqual(result, {
+            status: 'incomplete',
+            phase: 'local-unsubscribe',
+            progress: {metadata: 'server-removed', server: 'removed', local: 'present'},
+            error: {code: 'local-unsubscribe-failed', cause: failure},
+        });
+        const restored = readPushSubscriptionMetadata(storage);
+        assert.equal(restored.status, 'found');
+        if (restored.status === 'found') {
+            assert.equal(restored.metadata.cleanupPhase, 'server-removed');
+        }
+    });
+
+    test('does not unsubscribe when the server-removed phase cannot be persisted', async () => {
+        const storage = new MemoryStorage();
+        const metadata = await storeRegistered(storage);
+        const failure = new Error('QUOTA_EXCEEDED');
+        storage.setItem = () => {
+            throw failure;
+        };
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => undefined,
+            unsubscribeLocal,
+        });
+
+        assert.equal(result.status, 'incomplete');
+        if (result.status === 'incomplete') {
+            assert.equal(result.phase, 'server-phase-persistence');
+            assert.equal(result.progress.server, 'removed');
+            assert.equal(result.progress.metadata, 'registered');
+        }
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+        assert.deepEqual(readPushSubscriptionMetadata(storage), {status: 'found', metadata});
+    });
+
+    test('retry from server-removed skips server deletion and finishes local cleanup', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const first = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => undefined,
+            unsubscribeLocal: async () => false,
+        });
+        assert.equal(first.status, 'incomplete');
+
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+        const retry = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.equal(unregisterServer.mock.calls.length, 0);
+        assert.equal(unsubscribeLocal.mock.calls.length, 1);
+        assert.deepEqual(retry, {
+            status: 'complete',
+            phase: 'complete',
+            progress: {metadata: 'cleared', server: 'removed', local: 'unsubscribed'},
+        });
+    });
+
+    test('treats authenticated not-found as confirmed removal after a delete/write crash gap', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => {
+                throw new Error('PUSH_SUBSCRIPTION_NOT_FOUND');
+            },
+            unsubscribeLocal: async () => true,
+        });
+
+        assert.equal(result.status, 'complete');
+        assert.equal(readPushSubscriptionMetadata(storage).status, 'missing');
+    });
+
+    test('removes a known server registration even when the local subscription is already absent', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => null,
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.equal(unregisterServer.mock.calls.length, 1);
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+        assert.deepEqual(result, {
+            status: 'complete',
+            phase: 'complete',
+            progress: {metadata: 'cleared', server: 'removed', local: 'absent'},
+        });
+    });
+
+    test('does not unsubscribe or claim success when a current local subscription lacks a record', async () => {
+        const storage = new MemoryStorage();
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.deepEqual(result, {
+            status: 'incomplete',
+            phase: 'registration-resolution',
+            progress: {metadata: 'missing', server: 'unknown', local: 'present'},
+            error: {code: 'registration-id-missing'},
+        });
+        assert.equal(unregisterServer.mock.calls.length, 0);
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+    });
+
+    test('reports no record and no local subscription as unverified, not complete', async () => {
+        const storage = new MemoryStorage();
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => null,
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.deepEqual(result, {
+            status: 'not-verified',
+            phase: 'no-registration-record',
+            reason: 'no-registration-record',
+            progress: {metadata: 'missing', server: 'unknown', local: 'absent'},
+        });
+        assert.equal(unregisterServer.mock.calls.length, 0);
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+    });
+
+    test('does not mutate either side when the current endpoint mismatches the registration', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () =>
+                localSubscription('https://push.example.com/subscriptions/replaced'),
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.equal(result.status, 'incomplete');
+        if (result.status === 'incomplete') {
+            assert.equal(result.error.code, 'endpoint-mismatch');
+        }
+        assert.equal(unregisterServer.mock.calls.length, 0);
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+    });
+
+    test('a false local unsubscribe result is incomplete and remains retryable', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => undefined,
+            unsubscribeLocal: async () => false,
+        });
+
+        assert.deepEqual(result, {
+            status: 'incomplete',
+            phase: 'local-unsubscribe',
+            progress: {metadata: 'server-removed', server: 'removed', local: 'present'},
+            error: {code: 'local-unsubscribe-rejected'},
+        });
+    });
+
+    test('does not complete when clearing metadata fails after both sides are removed', async () => {
+        const storage = new MemoryStorage();
+        await storeRegistered(storage);
+        const failure = new Error('STORAGE_DISABLED');
+        storage.removeItem = () => {
+            throw failure;
+        };
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => localSubscription(),
+            unregisterServer: async () => undefined,
+            unsubscribeLocal: async () => true,
+        });
+
+        assert.equal(result.status, 'incomplete');
+        if (result.status === 'incomplete') {
+            assert.equal(result.phase, 'metadata-clear');
+            assert.deepEqual(result.progress, {
+                metadata: 'server-removed',
+                server: 'removed',
+                local: 'unsubscribed',
+            });
+        }
+        const restored = readPushSubscriptionMetadata(storage);
+        assert.equal(restored.status, 'found');
+        if (restored.status === 'found') {
+            assert.equal(restored.metadata.cleanupPhase, 'server-removed');
+        }
+    });
+
+    test('corrupt metadata remains an incomplete cleanup even when no local subscription exists', async () => {
+        const storage = new MemoryStorage();
+        storage.setItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY, '{broken');
+        const unregisterServer = unregisterServerMock();
+        const unsubscribeLocal = unsubscribeLocalMock();
+
+        const result = await cleanupPushSubscription({
+            storage,
+            getLocalSubscription: async () => null,
+            unregisterServer,
+            unsubscribeLocal,
+        });
+
+        assert.deepEqual(result, {
+            status: 'incomplete',
+            phase: 'metadata-read',
+            progress: {metadata: 'invalid', server: 'unknown', local: 'absent'},
+            error: {code: 'metadata-read-invalid', error: {code: 'metadata-corrupt'}},
+        });
+        assert.equal(unregisterServer.mock.calls.length, 0);
+        assert.equal(unsubscribeLocal.mock.calls.length, 0);
+    });
+});

--- a/frontend/src/api/push-subscription-lifecycle.ts
+++ b/frontend/src/api/push-subscription-lifecycle.ts
@@ -1,0 +1,425 @@
+import {z} from 'zod';
+
+import {pushSubscriptionIdSchema} from './dashboard-account-contract';
+
+export const PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY = 'jungle-bell.push-subscription-lifecycle';
+export const PUSH_SUBSCRIPTION_METADATA_VERSION = 1 as const;
+
+const endpointFingerprintSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u);
+
+export const pushSubscriptionMetadataSchema = z.strictObject({
+    version: z.literal(PUSH_SUBSCRIPTION_METADATA_VERSION),
+    subscriptionId: pushSubscriptionIdSchema,
+    endpointFingerprint: endpointFingerprintSchema,
+    cleanupPhase: z.enum(['registered', 'server-removed']),
+});
+
+export type PushSubscriptionMetadata = z.infer<typeof pushSubscriptionMetadataSchema>;
+
+export interface PushSubscriptionLifecycleStorage {
+    getItem(key: string): string | null;
+    setItem(key: string, value: string): void;
+    removeItem(key: string): void;
+}
+
+export type PushSubscriptionMetadataInvalidError =
+    | {code: 'metadata-corrupt'}
+    | {code: 'metadata-version-unsupported'; version: unknown};
+
+export type PushSubscriptionMetadataStorageError =
+    | {code: 'storage-read-failed'; cause: unknown}
+    | {code: 'storage-write-failed'; cause: unknown}
+    | {code: 'storage-clear-failed'; cause: unknown};
+
+export type PushSubscriptionMetadataReadResult =
+    | {status: 'found'; metadata: PushSubscriptionMetadata}
+    | {status: 'missing'}
+    | {status: 'invalid'; error: PushSubscriptionMetadataInvalidError}
+    | {
+          status: 'failed';
+          error: Extract<PushSubscriptionMetadataStorageError, {code: 'storage-read-failed'}>;
+      };
+
+export type PushSubscriptionMetadataWriteResult =
+    | {status: 'written'}
+    | {status: 'invalid'; error: {code: 'metadata-invalid'}}
+    | {
+          status: 'failed';
+          error: Extract<PushSubscriptionMetadataStorageError, {code: 'storage-write-failed'}>;
+      };
+
+export type PushSubscriptionMetadataClearResult =
+    | {status: 'cleared'}
+    | {
+          status: 'failed';
+          error: Extract<PushSubscriptionMetadataStorageError, {code: 'storage-clear-failed'}>;
+      };
+
+export function readPushSubscriptionMetadata(
+    storage: PushSubscriptionLifecycleStorage,
+): PushSubscriptionMetadataReadResult {
+    let serialized: string | null;
+    try {
+        serialized = storage.getItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY);
+    } catch (cause) {
+        return {status: 'failed', error: {code: 'storage-read-failed', cause}};
+    }
+
+    if (serialized === null) return {status: 'missing'};
+
+    let value: unknown;
+    try {
+        value = JSON.parse(serialized);
+    } catch {
+        return {status: 'invalid', error: {code: 'metadata-corrupt'}};
+    }
+
+    if (!isRecord(value) || !Object.hasOwn(value, 'version')) {
+        return {status: 'invalid', error: {code: 'metadata-corrupt'}};
+    }
+    if (value.version !== PUSH_SUBSCRIPTION_METADATA_VERSION) {
+        return {
+            status: 'invalid',
+            error: {code: 'metadata-version-unsupported', version: value.version},
+        };
+    }
+
+    const parsed = pushSubscriptionMetadataSchema.safeParse(value);
+    if (!parsed.success) {
+        return {status: 'invalid', error: {code: 'metadata-corrupt'}};
+    }
+    return {status: 'found', metadata: parsed.data};
+}
+
+export function writePushSubscriptionMetadata(
+    storage: PushSubscriptionLifecycleStorage,
+    metadata: unknown,
+): PushSubscriptionMetadataWriteResult {
+    const parsed = pushSubscriptionMetadataSchema.safeParse(metadata);
+    if (!parsed.success) return {status: 'invalid', error: {code: 'metadata-invalid'}};
+
+    try {
+        storage.setItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY, JSON.stringify(parsed.data));
+        return {status: 'written'};
+    } catch (cause) {
+        return {status: 'failed', error: {code: 'storage-write-failed', cause}};
+    }
+}
+
+export function clearPushSubscriptionMetadata(
+    storage: PushSubscriptionLifecycleStorage,
+): PushSubscriptionMetadataClearResult {
+    try {
+        storage.removeItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY);
+        return {status: 'cleared'};
+    } catch (cause) {
+        return {status: 'failed', error: {code: 'storage-clear-failed', cause}};
+    }
+}
+
+export type PushSubscriptionDigest = Pick<SubtleCrypto, 'digest'>;
+
+export async function fingerprintPushSubscriptionEndpoint(
+    endpoint: string,
+    subtleCrypto?: PushSubscriptionDigest,
+): Promise<string> {
+    if (!endpoint) throw new Error('PUSH_SUBSCRIPTION_ENDPOINT_INVALID');
+    const digestProvider = subtleCrypto ?? globalThis.crypto?.subtle;
+    if (!digestProvider) throw new Error('PUSH_SUBSCRIPTION_CRYPTO_UNAVAILABLE');
+
+    const digest = await digestProvider.digest('SHA-256', new TextEncoder().encode(endpoint));
+    const hexadecimal = Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, '0'),
+    ).join('');
+    return `sha256:${hexadecimal}`;
+}
+
+export async function matchesPushSubscriptionEndpoint(
+    subscription: Pick<PushSubscriptionJSON, 'endpoint'>,
+    metadata: Pick<PushSubscriptionMetadata, 'endpointFingerprint'>,
+    subtleCrypto?: PushSubscriptionDigest,
+): Promise<boolean> {
+    if (
+        typeof subscription.endpoint !== 'string' ||
+        !subscription.endpoint ||
+        !endpointFingerprintSchema.safeParse(metadata.endpointFingerprint).success
+    ) {
+        return false;
+    }
+    return (
+        (await fingerprintPushSubscriptionEndpoint(subscription.endpoint, subtleCrypto)) ===
+        metadata.endpointFingerprint
+    );
+}
+
+export type PushSubscriptionReconciliation =
+    | {status: 'matched-registered'; metadata: PushSubscriptionMetadata}
+    | {status: 'matched-server-removed'; metadata: PushSubscriptionMetadata}
+    | {status: 'local-only'}
+    | {status: 'record-only'; metadata: PushSubscriptionMetadata}
+    | {status: 'mismatch'; metadata: PushSubscriptionMetadata}
+    | {status: 'none'; verification: 'not-verified'}
+    | {status: 'invalid'; error: PushSubscriptionMetadataInvalidError}
+    | {
+          status: 'failed';
+          error:
+              | Extract<PushSubscriptionMetadataStorageError, {code: 'storage-read-failed'}>
+              | {code: 'endpoint-verification-failed'; cause: unknown};
+      };
+
+export async function reconcilePushSubscriptionState(
+    metadataResult: PushSubscriptionMetadataReadResult,
+    localSubscription: PushSubscriptionJSON | null,
+    subtleCrypto?: PushSubscriptionDigest,
+): Promise<PushSubscriptionReconciliation> {
+    if (metadataResult.status === 'failed' || metadataResult.status === 'invalid') {
+        return metadataResult;
+    }
+    if (metadataResult.status === 'missing') {
+        return localSubscription
+            ? {status: 'local-only'}
+            : {status: 'none', verification: 'not-verified'};
+    }
+    if (!localSubscription) {
+        return {status: 'record-only', metadata: metadataResult.metadata};
+    }
+
+    let matches: boolean;
+    try {
+        matches = await matchesPushSubscriptionEndpoint(
+            localSubscription,
+            metadataResult.metadata,
+            subtleCrypto,
+        );
+    } catch (cause) {
+        return {status: 'failed', error: {code: 'endpoint-verification-failed', cause}};
+    }
+    if (!matches) return {status: 'mismatch', metadata: metadataResult.metadata};
+    return metadataResult.metadata.cleanupPhase === 'registered'
+        ? {status: 'matched-registered', metadata: metadataResult.metadata}
+        : {status: 'matched-server-removed', metadata: metadataResult.metadata};
+}
+
+export type PushSubscriptionCleanupProgress = {
+    metadata: 'unknown' | 'missing' | 'invalid' | 'registered' | 'server-removed' | 'cleared';
+    server: 'unknown' | 'registered' | 'removed';
+    local: 'unknown' | 'absent' | 'present' | 'unsubscribed';
+};
+
+export type PushSubscriptionCleanupError =
+    | {code: 'local-subscription-query-failed'; cause: unknown}
+    | {code: 'metadata-read-invalid'; error: PushSubscriptionMetadataInvalidError}
+    | {
+          code: 'metadata-read-failed';
+          error: Extract<PushSubscriptionMetadataStorageError, {code: 'storage-read-failed'}>;
+      }
+    | {code: 'registration-id-missing'}
+    | {code: 'endpoint-mismatch'}
+    | {code: 'endpoint-verification-failed'; cause: unknown}
+    | {code: 'server-unregister-failed'; cause: unknown}
+    | {code: 'server-phase-persist-failed'; error: PushSubscriptionMetadataWriteResult}
+    | {code: 'local-unsubscribe-rejected'}
+    | {code: 'local-unsubscribe-failed'; cause: unknown}
+    | {code: 'metadata-clear-failed'; error: PushSubscriptionMetadataClearResult};
+
+export type PushSubscriptionCleanupResult =
+    | {
+          status: 'complete';
+          phase: 'complete';
+          progress: PushSubscriptionCleanupProgress;
+      }
+    | {
+          status: 'not-verified';
+          phase: 'no-registration-record';
+          reason: 'no-registration-record';
+          progress: PushSubscriptionCleanupProgress;
+      }
+    | {
+          status: 'incomplete';
+          phase:
+              | 'local-query'
+              | 'metadata-read'
+              | 'registration-resolution'
+              | 'endpoint-verification'
+              | 'server-removal'
+              | 'server-phase-persistence'
+              | 'local-unsubscribe'
+              | 'metadata-clear';
+          progress: PushSubscriptionCleanupProgress;
+          error: PushSubscriptionCleanupError;
+      };
+
+export interface CleanupPushSubscriptionOptions {
+    storage: PushSubscriptionLifecycleStorage;
+    getLocalSubscription(): Promise<PushSubscriptionJSON | null>;
+    unregisterServer(subscriptionId: string): Promise<void>;
+    unsubscribeLocal(subscription: PushSubscriptionJSON): Promise<boolean>;
+    subtleCrypto?: PushSubscriptionDigest;
+}
+
+export async function cleanupPushSubscription(
+    options: CleanupPushSubscriptionOptions,
+): Promise<PushSubscriptionCleanupResult> {
+    let localSubscription: PushSubscriptionJSON | null;
+    try {
+        localSubscription = await options.getLocalSubscription();
+    } catch (cause) {
+        return incomplete(
+            'local-query',
+            {metadata: 'unknown', server: 'unknown', local: 'unknown'},
+            {code: 'local-subscription-query-failed', cause},
+        );
+    }
+
+    const metadataResult = readPushSubscriptionMetadata(options.storage);
+    const reconciliation = await reconcilePushSubscriptionState(
+        metadataResult,
+        localSubscription,
+        options.subtleCrypto,
+    );
+
+    if (reconciliation.status === 'invalid') {
+        return incomplete(
+            'metadata-read',
+            {
+                metadata: 'invalid',
+                server: 'unknown',
+                local: localSubscription ? 'present' : 'absent',
+            },
+            {code: 'metadata-read-invalid', error: reconciliation.error},
+        );
+    }
+    if (reconciliation.status === 'failed') {
+        const progress: PushSubscriptionCleanupProgress = {
+            metadata:
+                reconciliation.error.code === 'storage-read-failed'
+                    ? 'unknown'
+                    : metadataResult.status === 'found'
+                      ? metadataResult.metadata.cleanupPhase
+                      : 'unknown',
+            server:
+                metadataResult.status === 'found'
+                    ? metadataResult.metadata.cleanupPhase === 'server-removed'
+                        ? 'removed'
+                        : 'registered'
+                    : 'unknown',
+            local: localSubscription ? 'present' : 'absent',
+        };
+        return reconciliation.error.code === 'storage-read-failed'
+            ? incomplete('metadata-read', progress, {
+                  code: 'metadata-read-failed',
+                  error: reconciliation.error,
+              })
+            : incomplete('endpoint-verification', progress, reconciliation.error);
+    }
+    if (reconciliation.status === 'local-only') {
+        return incomplete(
+            'registration-resolution',
+            {metadata: 'missing', server: 'unknown', local: 'present'},
+            {code: 'registration-id-missing'},
+        );
+    }
+    if (reconciliation.status === 'none') {
+        return {
+            status: 'not-verified',
+            phase: 'no-registration-record',
+            reason: 'no-registration-record',
+            progress: {metadata: 'missing', server: 'unknown', local: 'absent'},
+        };
+    }
+    if (reconciliation.status === 'mismatch') {
+        return incomplete(
+            'endpoint-verification',
+            {
+                metadata: reconciliation.metadata.cleanupPhase,
+                server:
+                    reconciliation.metadata.cleanupPhase === 'server-removed'
+                        ? 'removed'
+                        : 'registered',
+                local: 'present',
+            },
+            {code: 'endpoint-mismatch'},
+        );
+    }
+
+    const metadata = reconciliation.metadata;
+    let progress: PushSubscriptionCleanupProgress = {
+        metadata: metadata.cleanupPhase,
+        server: metadata.cleanupPhase === 'server-removed' ? 'removed' : 'registered',
+        local: localSubscription ? 'present' : 'absent',
+    };
+
+    if (metadata.cleanupPhase === 'registered') {
+        try {
+            await options.unregisterServer(metadata.subscriptionId);
+        } catch (cause) {
+            if (!serverRegistrationAlreadyAbsent(cause)) {
+                return incomplete('server-removal', progress, {
+                    code: 'server-unregister-failed',
+                    cause,
+                });
+            }
+        }
+        progress = {...progress, server: 'removed'};
+
+        const phaseWrite = writePushSubscriptionMetadata(options.storage, {
+            ...metadata,
+            cleanupPhase: 'server-removed',
+        });
+        if (phaseWrite.status !== 'written') {
+            return incomplete('server-phase-persistence', progress, {
+                code: 'server-phase-persist-failed',
+                error: phaseWrite,
+            });
+        }
+        progress = {...progress, metadata: 'server-removed'};
+    }
+
+    if (localSubscription) {
+        let unsubscribed: boolean;
+        try {
+            unsubscribed = await options.unsubscribeLocal(localSubscription);
+        } catch (cause) {
+            return incomplete('local-unsubscribe', progress, {
+                code: 'local-unsubscribe-failed',
+                cause,
+            });
+        }
+        if (!unsubscribed) {
+            return incomplete('local-unsubscribe', progress, {
+                code: 'local-unsubscribe-rejected',
+            });
+        }
+        progress = {...progress, local: 'unsubscribed'};
+    }
+
+    const cleared = clearPushSubscriptionMetadata(options.storage);
+    if (cleared.status !== 'cleared') {
+        return incomplete('metadata-clear', progress, {
+            code: 'metadata-clear-failed',
+            error: cleared,
+        });
+    }
+
+    return {
+        status: 'complete',
+        phase: 'complete',
+        progress: {...progress, metadata: 'cleared'},
+    };
+}
+
+function incomplete(
+    phase: Extract<PushSubscriptionCleanupResult, {status: 'incomplete'}>['phase'],
+    progress: PushSubscriptionCleanupProgress,
+    error: PushSubscriptionCleanupError,
+): Extract<PushSubscriptionCleanupResult, {status: 'incomplete'}> {
+    return {status: 'incomplete', phase, progress, error};
+}
+
+function serverRegistrationAlreadyAbsent(error: unknown): boolean {
+    return error instanceof Error && error.message === 'PUSH_SUBSCRIPTION_NOT_FOUND';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/frontend/src/features/app-status/app-status-model.test.ts
+++ b/frontend/src/features/app-status/app-status-model.test.ts
@@ -1,0 +1,113 @@
+import {describe, expect, test} from 'vitest';
+
+import {appStatusRows, type AppStatusInput} from './app-status-model';
+
+function row(input: AppStatusInput, id: string) {
+    const found = appStatusRows(input).find((candidate) => candidate.id === id);
+    expect(found).toBeDefined();
+    return found!;
+}
+
+describe('app status rows', () => {
+    test('PC는 로그인, credential, 동기화, 모바일, OS 알림, 업데이트 상태를 구분한다', () => {
+        const input: AppStatusInput = {
+            surface: 'desktop',
+            lmsAuthentication: 'authenticated',
+            serverSession: 'stored',
+            lastSyncedAt: '2026-09-08T01:00:00.000Z',
+            mobileSessionCount: 2,
+            update: {kind: 'latest', checkedAt: '2026-09-08T01:01:00.000Z'},
+        };
+
+        expect(appStatusRows(input).map(({id}) => id)).toEqual([
+            'lms-authentication',
+            'server-credential',
+            'last-sync',
+            'mobile-sessions',
+            'os-notification',
+            'update',
+        ]);
+        expect(row(input, 'os-notification').status).toBe('unavailable');
+    });
+
+    test('서버가 stale로 표시한 출석 동기화를 준비 완료로 과장하지 않는다', () => {
+        const input: AppStatusInput = {
+            surface: 'desktop',
+            lmsAuthentication: 'authenticated',
+            serverSession: 'stored',
+            lastSyncedAt: {
+                kind: 'stale',
+                observedAt: '2026-09-08T01:00:00.000Z',
+            },
+            mobileSessionCount: 1,
+            update: {kind: 'latest'},
+        };
+
+        expect(row(input, 'last-sync')).toMatchObject({
+            status: 'attention',
+            statusText: '오래된 동기화',
+        });
+    });
+
+    test('이미 알려진 PC credential 복구 필요 상태를 확인 불가로 숨기지 않는다', () => {
+        const input: AppStatusInput = {
+            surface: 'desktop',
+            lmsAuthentication: 'authenticated',
+            serverSession: 'recovery-required',
+            lastSyncedAt: null,
+            mobileSessionCount: null,
+            update: {kind: 'unavailable'},
+        };
+
+        expect(row(input, 'server-credential')).toMatchObject({
+            status: 'error',
+            statusText: '복구 필요',
+            action: {tab: 'devices'},
+        });
+    });
+
+    test('PWA는 확인 계약이 없는 로컬 구독과 서버 등록을 준비됨으로 추정하지 않는다', () => {
+        const input: AppStatusInput = {
+            surface: 'pwa',
+            personalAccess: 'connected',
+            sessionExpiresAt: '2026-09-09T01:00:00.000Z',
+            notificationPermission: 'granted',
+        };
+
+        expect(row(input, 'local-push').status).toBe('unavailable');
+        expect(row(input, 'server-registration').status).toBe('unavailable');
+        expect(row(input, 'last-test').status).toBe('unavailable');
+        expect(row(input, 'service-worker').status).toBe('unavailable');
+    });
+
+    test('일반 Web은 공개 사용과 설치 지원/설치 여부만 표시한다', () => {
+        const input: AppStatusInput = {
+            surface: 'web',
+            installSupported: true,
+            installed: false,
+        };
+        expect(appStatusRows(input).map(({id}) => id)).toEqual([
+            'public-access',
+            'install-support',
+            'installation',
+        ]);
+        expect(row(input, 'public-access').status).toBe('ready');
+    });
+
+    test('일반 Web의 알려진 미지원·미설치 상태를 확인 불가로 숨기지 않는다', () => {
+        const input: AppStatusInput = {
+            surface: 'web',
+            installSupported: false,
+            installed: false,
+        };
+
+        expect(row(input, 'install-support')).toMatchObject({
+            status: 'attention',
+            statusText: '지원되지 않음',
+        });
+        expect(row(input, 'installation')).toMatchObject({
+            status: 'attention',
+            statusText: '설치되지 않음',
+        });
+    });
+});

--- a/frontend/src/features/app-status/app-status-model.ts
+++ b/frontend/src/features/app-status/app-status-model.ts
@@ -1,0 +1,507 @@
+import type {
+    LmsAuthenticationStatus,
+    PersonalAccessStatus,
+    ServerSessionStatus,
+} from '@/app/dashboard-account-state';
+import {dateTimeLabel} from '@/lib/format';
+
+export type AppStatusValue = 'attention' | 'checking' | 'error' | 'ready' | 'unavailable';
+
+export type AppStatusTab = 'devices' | 'notifications';
+
+export interface AppStatusAction {
+    href: string;
+    label: string;
+    tab?: AppStatusTab;
+}
+
+export interface AppStatusRowModel {
+    action: AppStatusAction;
+    description: string;
+    id: string;
+    label: string;
+    status: AppStatusValue;
+    statusText: string;
+}
+
+type ObservableValue<T> = T | 'checking' | 'unavailable';
+
+export type DesktopUpdateState =
+    | {kind: 'available'; availableVersion: string; checkedAt?: string | null; mandatory?: boolean}
+    | {kind: 'checking'}
+    | {kind: 'error'}
+    | {kind: 'latest'; checkedAt?: string | null}
+    | {kind: 'unavailable'};
+
+export interface DesktopSyncObservation {
+    kind: 'pending' | 'stale';
+    observedAt: string;
+}
+
+export interface DesktopAppStatusInput {
+    surface: 'desktop';
+    lmsAuthentication: LmsAuthenticationStatus;
+    serverSession: ServerSessionStatus;
+    lastSyncedAt: ObservableValue<DesktopSyncObservation | string | null>;
+    mobileSessionCount: ObservableValue<number | null>;
+    update: DesktopUpdateState;
+}
+
+export type AppNotificationPermission = NotificationPermission | 'unavailable';
+
+export interface PwaAppStatusInput {
+    surface: 'pwa';
+    personalAccess: PersonalAccessStatus;
+    sessionExpiresAt: ObservableValue<string | null>;
+    notificationPermission: AppNotificationPermission;
+}
+
+export interface WebAppStatusInput {
+    surface: 'web';
+    installSupported: boolean;
+    installed: boolean;
+}
+
+export type AppStatusInput = DesktopAppStatusInput | PwaAppStatusInput | WebAppStatusInput;
+
+const UNAVAILABLE_DESCRIPTION = '현재 계약에서 확인할 수 없습니다.';
+
+const DEVICE_ACTION: AppStatusAction = {
+    href: '#/connections?tab=devices',
+    label: '기기 연결 열기',
+    tab: 'devices',
+};
+
+const NOTIFICATION_ACTION: AppStatusAction = {
+    href: '#/connections?tab=notifications',
+    label: '알림 설정 열기',
+    tab: 'notifications',
+};
+
+const INSTALL_ACTION: AppStatusAction = {
+    href: '#/install',
+    label: '설치 안내 열기',
+};
+
+function unavailableRow(id: string, label: string, action: AppStatusAction): AppStatusRowModel {
+    return {
+        id,
+        label,
+        status: 'unavailable',
+        statusText: '확인 불가',
+        description: UNAVAILABLE_DESCRIPTION,
+        action,
+    };
+}
+
+function lmsAuthenticationRow(value: LmsAuthenticationStatus): AppStatusRowModel {
+    const base = {
+        id: 'lms-authentication',
+        label: 'Jungle Campus 로그인',
+        action: DEVICE_ACTION,
+    };
+    if (value === 'authenticated') {
+        return {
+            ...base,
+            status: 'ready',
+            statusText: '로그인됨',
+            description: 'PC 앱이 Jungle Campus 로그인 상태를 확인했습니다.',
+        };
+    }
+    if (value === 'required') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '로그인 필요',
+            description: '출석 동기화를 계속하려면 다시 로그인해야 합니다.',
+        };
+    }
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: 'PC 앱에서 로그인 상태를 확인하고 있습니다.',
+        };
+    }
+    return unavailableRow(base.id, base.label, base.action);
+}
+
+function serverCredentialRow(value: ServerSessionStatus): AppStatusRowModel {
+    const base = {
+        id: 'server-credential',
+        label: 'PC 서버 인증 정보',
+        action: DEVICE_ACTION,
+    };
+    if (value === 'stored') {
+        return {
+            ...base,
+            status: 'ready',
+            statusText: '안전하게 저장됨',
+            description: '앱을 다시 시작해도 서버 연결을 복구할 수 있습니다.',
+        };
+    }
+    if (value === 'memory-only') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '이번 실행에서만 유지',
+            description: '앱을 다시 시작하면 서버 연결 복구가 필요할 수 있습니다.',
+        };
+    }
+    if (value === 'missing') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '등록 필요',
+            description: '기기 연결에서 이 PC를 서버에 등록해 주세요.',
+        };
+    }
+    if (value === 'recovery-required') {
+        return {
+            ...base,
+            status: 'error',
+            statusText: '복구 필요',
+            description:
+                '저장된 credential과 서버 등록 identity가 일치하지 않습니다. 기기 연결에서 상태를 확인해 주세요.',
+        };
+    }
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '저장된 PC 인증 정보를 확인하고 있습니다.',
+        };
+    }
+    return unavailableRow(base.id, base.label, base.action);
+}
+
+function lastSyncRow(value: DesktopAppStatusInput['lastSyncedAt']): AppStatusRowModel {
+    const base = {
+        id: 'last-sync',
+        label: '최근 출석 동기화',
+        action: DEVICE_ACTION,
+    };
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '최근 출석 동기화 기록을 확인하고 있습니다.',
+        };
+    }
+    if (value === 'unavailable') return unavailableRow(base.id, base.label, base.action);
+    if (value === null) {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '동기화 기록 없음',
+            description: 'Jungle Campus 로그인과 PC 연결을 확인해 주세요.',
+        };
+    }
+    if (typeof value === 'object') {
+        const observedAt = dateTimeLabel(value.observedAt);
+        if (value.kind === 'stale') {
+            return {
+                ...base,
+                status: 'attention',
+                statusText: '오래된 동기화',
+                description:
+                    observedAt === '확인 기록 없음'
+                        ? '마지막 출석 동기화 시각을 신뢰할 수 없습니다.'
+                        : `${observedAt} 이후 최신 출석 동기화를 확인하지 못했습니다.`,
+            };
+        }
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '서버 반영 대기',
+            description:
+                observedAt === '확인 기록 없음'
+                    ? 'PC에서 새 출석 상태를 확인했지만 서버 반영은 아직 완료되지 않았습니다.'
+                    : `${observedAt}에 확인한 출석 상태를 서버에 반영하고 있습니다.`,
+        };
+    }
+    const label = dateTimeLabel(value);
+    if (label === '확인 기록 없음') return unavailableRow(base.id, base.label, base.action);
+    return {
+        ...base,
+        status: 'ready',
+        statusText: `마지막 동기화 ${label}`,
+        description: '서버에서 읽은 최신 출석 동기화 시각입니다.',
+    };
+}
+
+function mobileSessionsRow(value: DesktopAppStatusInput['mobileSessionCount']): AppStatusRowModel {
+    const base = {
+        id: 'mobile-sessions',
+        label: '연결된 모바일',
+        action: DEVICE_ACTION,
+    };
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '활성 모바일 세션을 확인하고 있습니다.',
+        };
+    }
+    if (value === 'unavailable' || value === null) {
+        return unavailableRow(base.id, base.label, base.action);
+    }
+    if (value === 0) {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '연결된 모바일 없음',
+            description: '모바일 푸시를 받으려면 PWA를 이 PC와 연결해야 합니다.',
+        };
+    }
+    return {
+        ...base,
+        status: 'ready',
+        statusText: `${value}대 연결됨`,
+        description: '서버가 반환한 활성 모바일 세션 수입니다.',
+    };
+}
+
+function desktopUpdateRow(value: DesktopUpdateState): AppStatusRowModel {
+    const action: AppStatusAction = {
+        href: '#/connections?tab=services',
+        label: '앱 업데이트 열기',
+    };
+    const base = {id: 'update', label: 'PC 앱 업데이트', action};
+    if (value.kind === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '업데이트 상태를 확인하고 있습니다.',
+        };
+    }
+    if (value.kind === 'error') {
+        return {
+            ...base,
+            status: 'error',
+            statusText: '확인 실패',
+            description: '네트워크를 확인한 뒤 업데이트 화면에서 다시 시도해 주세요.',
+        };
+    }
+    if (value.kind === 'unavailable') return unavailableRow(base.id, base.label, base.action);
+    const checkedAt = value.checkedAt ? dateTimeLabel(value.checkedAt) : null;
+    if (value.kind === 'available') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: `${value.availableVersion} 업데이트 가능`,
+            description: value.mandatory
+                ? '계속 사용하려면 최신 정식 버전을 설치해야 합니다.'
+                : `새 버전을 설치할 수 있습니다${checkedAt ? ` · ${checkedAt} 확인` : ''}.`,
+        };
+    }
+    return {
+        ...base,
+        status: 'ready',
+        statusText: '최신 버전',
+        description: checkedAt
+            ? `${checkedAt}에 업데이트를 확인했습니다.`
+            : '사용 가능한 업데이트가 없습니다.',
+    };
+}
+
+function desktopRows(input: DesktopAppStatusInput): AppStatusRowModel[] {
+    return [
+        lmsAuthenticationRow(input.lmsAuthentication),
+        serverCredentialRow(input.serverSession),
+        lastSyncRow(input.lastSyncedAt),
+        mobileSessionsRow(input.mobileSessionCount),
+        unavailableRow('os-notification', '운영체제 알림 표시', NOTIFICATION_ACTION),
+        desktopUpdateRow(input.update),
+    ];
+}
+
+function personalAccessRow(value: PersonalAccessStatus): AppStatusRowModel {
+    const base = {id: 'personal-access', label: 'PC 계정 연결', action: DEVICE_ACTION};
+    if (value === 'connected') {
+        return {
+            ...base,
+            status: 'ready',
+            statusText: '연결됨',
+            description: '이 PWA가 개인 기능을 사용할 수 있습니다.',
+        };
+    }
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '현재 모바일 세션을 확인하고 있습니다.',
+        };
+    }
+    if (value === 'unconnected') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '연결 필요',
+            description: 'PC 앱에서 새 연결 코드를 만들어 이 PWA를 연결해 주세요.',
+        };
+    }
+    if (value === 'error') {
+        return {
+            ...base,
+            status: 'error',
+            statusText: '확인 실패',
+            description: '네트워크를 확인한 뒤 기기 연결 화면에서 다시 시도해 주세요.',
+        };
+    }
+    return unavailableRow(base.id, base.label, base.action);
+}
+
+function sessionExpiryRow(
+    value: PwaAppStatusInput['sessionExpiresAt'],
+    now: number,
+): AppStatusRowModel {
+    const base = {id: 'session-expiry', label: '모바일 세션 만료', action: DEVICE_ACTION};
+    if (value === 'checking') {
+        return {
+            ...base,
+            status: 'checking',
+            statusText: '확인 중',
+            description: '현재 세션의 만료 시각을 확인하고 있습니다.',
+        };
+    }
+    if (value === 'unavailable') {
+        return unavailableRow(base.id, base.label, base.action);
+    }
+    if (value === null) {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '세션 없음',
+            description: '개인 기능을 사용하려면 PC와 연결해 새 모바일 세션을 만들어야 합니다.',
+        };
+    }
+    const expiresAt = Date.parse(value);
+    if (!Number.isFinite(expiresAt)) return unavailableRow(base.id, base.label, base.action);
+    if (expiresAt <= now) {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '만료됨',
+            description: '개인 기능을 다시 사용하려면 PC와 다시 연결해야 합니다.',
+        };
+    }
+    return {
+        ...base,
+        status: 'ready',
+        statusText: `${dateTimeLabel(value)}까지`,
+        description: '서버가 반환한 현재 모바일 세션 만료 시각입니다.',
+    };
+}
+
+function notificationPermissionRow(value: AppNotificationPermission): AppStatusRowModel {
+    const base = {
+        id: 'notification-permission',
+        label: '알림 권한',
+        action: NOTIFICATION_ACTION,
+    };
+    if (value === 'granted') {
+        return {
+            ...base,
+            status: 'ready',
+            statusText: '허용됨',
+            description: '브라우저 알림 권한이 허용된 상태입니다.',
+        };
+    }
+    if (value === 'denied') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '차단됨',
+            description: '브라우저 또는 운영체제 설정에서 Jungle Bell 알림을 허용해 주세요.',
+        };
+    }
+    if (value === 'default') {
+        return {
+            ...base,
+            status: 'attention',
+            statusText: '권한 선택 전',
+            description: '알림 설정에서 푸시 연결을 시작해 권한을 선택해 주세요.',
+        };
+    }
+    return unavailableRow(base.id, base.label, base.action);
+}
+
+function pwaRows(input: PwaAppStatusInput, now: number): AppStatusRowModel[] {
+    return [
+        personalAccessRow(input.personalAccess),
+        sessionExpiryRow(input.sessionExpiresAt, now),
+        notificationPermissionRow(input.notificationPermission),
+        unavailableRow('local-push', '로컬 푸시 구독', NOTIFICATION_ACTION),
+        unavailableRow('server-registration', '서버 푸시 등록', NOTIFICATION_ACTION),
+        unavailableRow('last-test', '마지막 테스트 알림', NOTIFICATION_ACTION),
+        unavailableRow('service-worker', '서비스 워커', NOTIFICATION_ACTION),
+    ];
+}
+
+function webRows(input: WebAppStatusInput): AppStatusRowModel[] {
+    const publicAccess: AppStatusRowModel = {
+        id: 'public-access',
+        label: '공개 기능',
+        status: 'ready',
+        statusText: '사용 가능',
+        description: '설치나 계정 연결 없이 공개 세탁실·식단 정보를 사용할 수 있습니다.',
+        action: {href: '#/home', label: '홈 열기'},
+    };
+    const installSupport: AppStatusRowModel = input.installSupported
+        ? {
+              id: 'install-support',
+              label: 'PWA 설치 지원',
+              status: 'ready',
+              statusText: '지원됨',
+              description: '이 브라우저에서 Jungle Bell 설치 안내를 사용할 수 있습니다.',
+              action: INSTALL_ACTION,
+          }
+        : {
+              id: 'install-support',
+              label: 'PWA 설치 지원',
+              status: 'attention',
+              statusText: '지원되지 않음',
+              description: '현재 브라우저에서는 PWA 설치 기능을 사용할 수 없습니다.',
+              action: INSTALL_ACTION,
+          };
+    const installation: AppStatusRowModel = input.installed
+        ? {
+              id: 'installation',
+              label: 'PWA 설치 상태',
+              status: 'ready',
+              statusText: '설치됨',
+              description: '현재 창은 홈 화면에 설치된 PWA로 실행 중입니다.',
+              action: INSTALL_ACTION,
+          }
+        : input.installSupported
+          ? {
+                id: 'installation',
+                label: 'PWA 설치 상태',
+                status: 'attention',
+                statusText: '설치되지 않음',
+                description: '개인 기능과 푸시를 사용하려면 PWA를 설치해 주세요.',
+                action: INSTALL_ACTION,
+            }
+          : {
+                id: 'installation',
+                label: 'PWA 설치 상태',
+                status: 'attention',
+                statusText: '설치되지 않음',
+                description: '현재 창은 설치된 PWA가 아닌 일반 웹으로 실행 중입니다.',
+                action: INSTALL_ACTION,
+            };
+    return [publicAccess, installSupport, installation];
+}
+
+export function appStatusRows(input: AppStatusInput, now = Date.now()): AppStatusRowModel[] {
+    if (input.surface === 'desktop') return desktopRows(input);
+    if (input.surface === 'pwa') return pwaRows(input, now);
+    return webRows(input);
+}

--- a/frontend/src/features/app-status/app-status-page.test.tsx
+++ b/frontend/src/features/app-status/app-status-page.test.tsx
@@ -2,7 +2,37 @@ import {readFileSync} from 'node:fs';
 
 import {describe, expect, test} from 'vitest';
 
+import type {DesktopUpdateStatus} from '@/platform/contracts';
+
+import {desktopUpdateState} from './app-status-page';
+
 const source = readFileSync(new URL('./app-status-page.tsx', import.meta.url), 'utf8');
+
+const checkedAtEpochMs = Date.parse('2026-09-08T01:00:00.000Z');
+
+function updateQuery(data: DesktopUpdateStatus) {
+    return {
+        data,
+        dataUpdatedAt: checkedAtEpochMs,
+        isError: false,
+        isPending: false,
+    };
+}
+
+function updateStatus(
+    status: DesktopUpdateStatus['status'],
+    overrides: Partial<DesktopUpdateStatus> = {},
+): DesktopUpdateStatus {
+    return {
+        currentVersion: '0.5.9',
+        availableVersion: '0.6.0',
+        status,
+        policy: 'optional',
+        progress: null,
+        errorCode: null,
+        ...overrides,
+    };
+}
 
 describe('AppStatusPage', () => {
     test('상태 행마다 상태 텍스트, 복구 동작, polite live feedback을 제공한다', () => {
@@ -16,4 +46,56 @@ describe('AppStatusPage', () => {
         expect(source).toContain('확인 불가');
         expect(source).toContain('현재 계약에서 확인할 수 없습니다.');
     });
+
+    test('canonical 업데이트의 checking과 failed를 각각 확인 중과 오류로 매핑한다', () => {
+        expect(
+            desktopUpdateState(
+                updateQuery(
+                    updateStatus('checking', {
+                        availableVersion: null,
+                        policy: null,
+                    }),
+                ),
+            ),
+        ).toEqual({kind: 'checking'});
+        expect(
+            desktopUpdateState(
+                updateQuery(updateStatus('failed', {errorCode: 'UPDATE_CHECK_FAILED'})),
+            ),
+        ).toEqual({kind: 'error'});
+    });
+
+    test('latest 또는 availableVersion이 없는 완료 상태를 최신으로 매핑한다', () => {
+        expect(
+            desktopUpdateState(
+                updateQuery(
+                    updateStatus('latest', {
+                        availableVersion: null,
+                        policy: null,
+                    }),
+                ),
+            ),
+        ).toEqual({kind: 'latest', checkedAt: '2026-09-08T01:00:00.000Z'});
+    });
+
+    test.each([
+        ['optional', 'optional', null, false],
+        ['mandatory', 'mandatory', null, true],
+        ['downloading', 'mandatory', {downloadedBytes: 10, totalBytes: 100}, true],
+        ['verifying', 'optional', {downloadedBytes: 100, totalBytes: 100}, false],
+        ['installing', 'mandatory', {downloadedBytes: 100, totalBytes: 100}, true],
+        ['restart-required', 'optional', {downloadedBytes: 100, totalBytes: 100}, false],
+    ] as const)(
+        '%s 업데이트를 available로 표시하고 mandatory는 policy에서 계산한다',
+        (status, policy, progress, mandatory) => {
+            expect(
+                desktopUpdateState(updateQuery(updateStatus(status, {policy, progress}))),
+            ).toEqual({
+                kind: 'available',
+                availableVersion: '0.6.0',
+                mandatory,
+                checkedAt: '2026-09-08T01:00:00.000Z',
+            });
+        },
+    );
 });

--- a/frontend/src/features/app-status/app-status-page.test.tsx
+++ b/frontend/src/features/app-status/app-status-page.test.tsx
@@ -1,0 +1,19 @@
+import {readFileSync} from 'node:fs';
+
+import {describe, expect, test} from 'vitest';
+
+const source = readFileSync(new URL('./app-status-page.tsx', import.meta.url), 'utf8');
+
+describe('AppStatusPage', () => {
+    test('상태 행마다 상태 텍스트, 복구 동작, polite live feedback을 제공한다', () => {
+        expect(source).toContain('aria-live="polite"');
+        expect(source).toContain('row.action');
+        expect(source).toContain('AppStatusRow');
+        expect(source).toContain('앱 상태');
+    });
+
+    test('현재 계약으로 확인할 수 없는 값은 확인 불가로 표시한다', () => {
+        expect(source).toContain('확인 불가');
+        expect(source).toContain('현재 계약에서 확인할 수 없습니다.');
+    });
+});

--- a/frontend/src/features/app-status/app-status-page.tsx
+++ b/frontend/src/features/app-status/app-status-page.tsx
@@ -1,0 +1,269 @@
+import {useQuery} from '@tanstack/react-query';
+import {
+    CheckCircle2,
+    CircleAlert,
+    CircleHelp,
+    LoaderCircle,
+    TriangleAlert,
+    type LucideIcon,
+} from 'lucide-react';
+
+import {useDashboardAccount} from '@/app/dashboard-account';
+import {serverSessionReady} from '@/app/dashboard-account-state';
+import {queryKeys, useDashboardEnvironment} from '@/app/dashboard-context';
+import {useDesktopUpdateQuery} from '@/app/desktop-update-query';
+import {useAttendanceQuery} from '@/app/use-dashboard-queries';
+import {Button} from '@/components/ui/button';
+import {Card} from '@/components/ui/card';
+
+import {
+    appStatusRows,
+    type AppStatusInput,
+    type AppStatusRowModel,
+    type AppStatusTab,
+    type AppStatusValue,
+    type DesktopAppStatusInput,
+    type DesktopUpdateState,
+    type PwaAppStatusInput,
+} from './app-status-model';
+
+const STATUS_PRESENTATION: Record<AppStatusValue, {badgeClassName: string; icon: LucideIcon}> = {
+    ready: {
+        badgeClassName:
+            'border-emerald-600/25 bg-emerald-500/10 text-emerald-800 dark:text-emerald-200',
+        icon: CheckCircle2,
+    },
+    attention: {
+        badgeClassName: 'border-amber-600/25 bg-amber-500/10 text-amber-900 dark:text-amber-100',
+        icon: TriangleAlert,
+    },
+    checking: {
+        badgeClassName: 'border-sky-600/25 bg-sky-500/10 text-sky-800 dark:text-sky-200',
+        icon: LoaderCircle,
+    },
+    error: {
+        badgeClassName: 'border-destructive/25 bg-destructive/10 text-destructive',
+        icon: CircleAlert,
+    },
+    unavailable: {
+        badgeClassName: 'border-border bg-muted text-muted-foreground',
+        icon: CircleHelp,
+    },
+};
+
+const SURFACE_DESCRIPTION: Record<AppStatusInput['surface'], string> = {
+    desktop: 'PC 로그인, 서버 연결, 동기화와 연결된 기기 상태를 확인합니다.',
+    pwa: '현재 PWA 세션과 알림 준비 상태를 확인합니다.',
+    web: '일반 웹에서 사용할 수 있는 기능과 PWA 설치 상태를 확인합니다.',
+};
+
+export interface AppStatusPageProps {
+    input?: AppStatusInput;
+    onOpenTab?: (tab: 'notifications' | 'devices') => void;
+}
+
+interface AppStatusRowProps {
+    onOpenTab?: (tab: AppStatusTab) => void;
+    row: AppStatusRowModel;
+}
+
+export function AppStatusRow({row, onOpenTab}: AppStatusRowProps) {
+    const presentation = STATUS_PRESENTATION[row.status];
+    const StatusIcon = presentation.icon;
+    const statusText = row.status === 'unavailable' ? '확인 불가' : row.statusText;
+    const description =
+        row.status === 'unavailable' ? '현재 계약에서 확인할 수 없습니다.' : row.description;
+    const actionTab = row.action.tab;
+
+    return (
+        <li
+            data-app-status={row.status}
+            className="grid gap-4 px-4 py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:px-5"
+        >
+            <div className="flex min-w-0 items-start gap-3">
+                <span className="mt-0.5 grid size-9 shrink-0 place-items-center rounded-full bg-muted text-muted-foreground">
+                    <StatusIcon
+                        aria-hidden="true"
+                        className={row.status === 'checking' ? 'size-4 animate-spin' : 'size-4'}
+                    />
+                </span>
+                <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="text-sm font-semibold">{row.label}</h3>
+                        <div aria-live="polite" aria-atomic="true">
+                            <span
+                                className={`inline-flex rounded-md border px-2 py-0.5 text-xs font-medium ${presentation.badgeClassName}`}
+                            >
+                                {statusText}
+                            </span>
+                        </div>
+                    </div>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">{description}</p>
+                </div>
+            </div>
+            {actionTab && onOpenTab ? (
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onOpenTab(actionTab)}
+                >
+                    {row.action.label}
+                </Button>
+            ) : (
+                <Button asChild size="sm" variant="outline">
+                    <a href={row.action.href}>{row.action.label}</a>
+                </Button>
+            )}
+        </li>
+    );
+}
+
+export function AppStatusPanel({
+    input,
+    onOpenTab,
+}: Required<Pick<AppStatusPageProps, 'input'>> & Pick<AppStatusPageProps, 'onOpenTab'>) {
+    const rows = appStatusRows(input);
+    return (
+        <section className="space-y-4" aria-labelledby="app-status-title">
+            <div>
+                <h2 id="app-status-title" className="text-lg font-semibold">
+                    앱 상태
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {SURFACE_DESCRIPTION[input.surface]}
+                </p>
+            </div>
+            <Card className="gap-0 overflow-hidden py-0">
+                <ul className="divide-y">
+                    {rows.map((row) => (
+                        <AppStatusRow key={row.id} row={row} onOpenTab={onOpenTab} />
+                    ))}
+                </ul>
+            </Card>
+        </section>
+    );
+}
+
+function desktopLastSyncedAt(
+    personalAccess: ReturnType<typeof useDashboardAccount>['personalAccess']['status'],
+    attendance: ReturnType<typeof useAttendanceQuery>,
+): DesktopAppStatusInput['lastSyncedAt'] {
+    if (attendance.data?.state === 'loaded') {
+        const value = attendance.data.attendance;
+        if (value.status !== 'available') return value.lastSyncedAt;
+        if (value.syncState === 'pending') {
+            return {kind: 'pending', observedAt: value.lastSyncedAt};
+        }
+        return value.freshness === 'stale'
+            ? {kind: 'stale', observedAt: value.lastSyncedAt}
+            : value.lastSyncedAt;
+    }
+    if (personalAccess !== 'connected') return 'unavailable';
+    if (attendance.isPending) return 'checking';
+    if (attendance.isError) return 'unavailable';
+    return null;
+}
+
+function desktopMobileSessionCount(
+    personalReady: boolean,
+    sessions: ReturnType<typeof useDesktopMobileSessions>,
+): DesktopAppStatusInput['mobileSessionCount'] {
+    if (sessions.data) return sessions.data.filter(({status}) => status === 'active').length;
+    if (!personalReady) return 'unavailable';
+    if (sessions.isPending) return 'checking';
+    return 'unavailable';
+}
+
+function desktopUpdateState(
+    query: ReturnType<typeof useDesktopUpdateQuery>['update'],
+): DesktopUpdateState {
+    if (query.data) {
+        const checkedAt =
+            query.dataUpdatedAt > 0 ? new Date(query.dataUpdatedAt).toISOString() : null;
+        if (!query.data.availableVersion) return {kind: 'latest', checkedAt};
+        return {
+            kind: 'available',
+            availableVersion: query.data.availableVersion,
+            mandatory: query.data.mandatory,
+            checkedAt,
+        };
+    }
+    if (query.isError) return {kind: 'error'};
+    if (query.isPending) return {kind: 'checking'};
+    return {kind: 'unavailable'};
+}
+
+function useDesktopMobileSessions(personalReady: boolean) {
+    const {api} = useDashboardEnvironment();
+    return useQuery({
+        queryKey: queryKeys.mobileSessions,
+        queryFn: () => api.listMobileSessions(),
+        enabled: personalReady,
+        staleTime: 60_000,
+        refetchInterval: 60_000,
+    });
+}
+
+function ConnectedDesktopStatus({onOpenTab}: Pick<AppStatusPageProps, 'onOpenTab'>) {
+    const account = useDashboardAccount();
+    const personalReady =
+        account.status.lmsAuthentication === 'authenticated' && serverSessionReady(account.status);
+    const attendance = useAttendanceQuery();
+    const sessions = useDesktopMobileSessions(personalReady);
+    const {update} = useDesktopUpdateQuery();
+    const input: DesktopAppStatusInput = {
+        surface: 'desktop',
+        lmsAuthentication: account.status.lmsAuthentication,
+        serverSession: account.status.serverSession,
+        lastSyncedAt: desktopLastSyncedAt(account.personalAccess.status, attendance),
+        mobileSessionCount: desktopMobileSessionCount(personalReady, sessions),
+        update: desktopUpdateState(update),
+    };
+    return <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+}
+
+function pwaSessionExpiry(
+    account: ReturnType<typeof useDashboardAccount>,
+): PwaAppStatusInput['sessionExpiresAt'] {
+    if (account.browserSessionQuery.data) return account.browserSessionQuery.data.expiresAt;
+    if (account.personalAccess.status === 'checking') return 'checking';
+    if (account.personalAccess.status === 'error') return 'unavailable';
+    return account.personalAccess.status === 'unconnected' ? null : 'unavailable';
+}
+
+function ConnectedPwaStatus({onOpenTab}: Pick<AppStatusPageProps, 'onOpenTab'>) {
+    const account = useDashboardAccount();
+    const input: PwaAppStatusInput = {
+        surface: 'pwa',
+        personalAccess: account.personalAccess.status,
+        sessionExpiresAt: pwaSessionExpiry(account),
+        // The platform adapter can start push setup but exposes no read contract for
+        // Notification.permission, an existing subscription, or service-worker readiness.
+        notificationPermission: 'unavailable',
+    };
+    return <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+}
+
+function ConnectedAppStatus({onOpenTab}: Pick<AppStatusPageProps, 'onOpenTab'>) {
+    const {platform} = useDashboardEnvironment();
+    if (platform.kind === 'desktop') return <ConnectedDesktopStatus onOpenTab={onOpenTab} />;
+    if (platform.accountAuthentication.kind === 'cookie') {
+        return <ConnectedPwaStatus onOpenTab={onOpenTab} />;
+    }
+    return (
+        <AppStatusPanel
+            input={{
+                surface: 'web',
+                installSupported: platform.capabilities.pwaInstall && platform.pwa.available,
+                installed: platform.pwa.installed,
+            }}
+            onOpenTab={onOpenTab}
+        />
+    );
+}
+
+export function AppStatusPage({input, onOpenTab}: AppStatusPageProps) {
+    if (input) return <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+    return <ConnectedAppStatus onOpenTab={onOpenTab} />;
+}

--- a/frontend/src/features/app-status/app-status-page.tsx
+++ b/frontend/src/features/app-status/app-status-page.tsx
@@ -175,19 +175,37 @@ function desktopMobileSessionCount(
     return 'unavailable';
 }
 
-function desktopUpdateState(
-    query: ReturnType<typeof useDesktopUpdateQuery>['update'],
-): DesktopUpdateState {
+type DesktopUpdateQueryState = Pick<
+    ReturnType<typeof useDesktopUpdateQuery>['update'],
+    'data' | 'dataUpdatedAt' | 'isError' | 'isPending'
+>;
+
+export function desktopUpdateState(query: DesktopUpdateQueryState): DesktopUpdateState {
     if (query.data) {
         const checkedAt =
             query.dataUpdatedAt > 0 ? new Date(query.dataUpdatedAt).toISOString() : null;
-        if (!query.data.availableVersion) return {kind: 'latest', checkedAt};
-        return {
-            kind: 'available',
-            availableVersion: query.data.availableVersion,
-            mandatory: query.data.mandatory,
-            checkedAt,
-        };
+        const {availableVersion, policy, status} = query.data;
+        switch (status) {
+            case 'checking':
+                return {kind: 'checking'};
+            case 'failed':
+                return {kind: 'error'};
+            case 'latest':
+                return {kind: 'latest', checkedAt};
+            case 'optional':
+            case 'mandatory':
+            case 'downloading':
+            case 'verifying':
+            case 'installing':
+            case 'restart-required':
+                if (availableVersion === null) return {kind: 'latest', checkedAt};
+                return {
+                    kind: 'available',
+                    availableVersion,
+                    mandatory: policy === 'mandatory',
+                    checkedAt,
+                };
+        }
     }
     if (query.isError) return {kind: 'error'};
     if (query.isPending) return {kind: 'checking'};

--- a/frontend/src/features/connections/companion-disconnect.test.ts
+++ b/frontend/src/features/connections/companion-disconnect.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, test, vi} from 'vitest';
+
+import {disconnectCompanionWithPushCleanup} from './companion-disconnect';
+
+describe('companion self-disconnect', () => {
+    test('서버 인증을 잃기 전에 푸시 정리를 끝낸다', async () => {
+        const order: string[] = [];
+        const cleanup = vi.fn<() => Promise<{status: 'complete'}>>(async () => {
+            order.push('push-cleanup');
+            return {status: 'complete' as const};
+        });
+        const disconnect = vi.fn<() => Promise<void>>(async () => {
+            order.push('session-disconnect');
+        });
+
+        await expect(
+            disconnectCompanionWithPushCleanup({
+                cleanupPush: cleanup,
+                disconnectSession: disconnect,
+            }),
+        ).resolves.toEqual({session: 'disconnected', pushCleanup: {status: 'complete'}});
+        expect(order).toEqual(['push-cleanup', 'session-disconnect']);
+    });
+
+    test('푸시 정리가 일부 실패해도 연결 해제 결과와 섞지 않는다', async () => {
+        const incomplete = {
+            status: 'incomplete' as const,
+            reason: 'server-unregister-failed',
+        };
+
+        await expect(
+            disconnectCompanionWithPushCleanup({
+                cleanupPush: async () => incomplete,
+                disconnectSession: async () => undefined,
+            }),
+        ).resolves.toEqual({session: 'disconnected', pushCleanup: incomplete});
+    });
+
+    test('연결 해제 실패 뒤 재시도에서는 이미 완료한 푸시 정리를 반복하지 않는다', async () => {
+        const complete = {status: 'complete' as const};
+        const cleanup = vi.fn<() => Promise<{status: 'complete'}>>(async () => complete);
+
+        const first = await disconnectCompanionWithPushCleanup({
+            cleanupPush: cleanup,
+            disconnectSession: async () => {
+                throw new Error('NETWORK_ERROR');
+            },
+        });
+        expect(first).toMatchObject({session: 'connected', pushCleanup: complete});
+
+        await expect(
+            disconnectCompanionWithPushCleanup({
+                cleanupPush: cleanup,
+                disconnectSession: async () => undefined,
+                previousCleanup: first.pushCleanup,
+            }),
+        ).resolves.toEqual({session: 'disconnected', pushCleanup: complete});
+        expect(cleanup).toHaveBeenCalledOnce();
+    });
+
+    test('예상하지 못한 정리 예외도 연결 해제 성공으로 둔갑시키지 않는다', async () => {
+        const result = await disconnectCompanionWithPushCleanup({
+            cleanupPush: async () => {
+                throw new Error('STORAGE_BLOCKED');
+            },
+            disconnectSession: async () => undefined,
+        });
+
+        expect(result).toMatchObject({
+            session: 'disconnected',
+            pushCleanup: {status: 'incomplete', reason: 'cleanup-failed'},
+        });
+    });
+});

--- a/frontend/src/features/connections/companion-disconnect.ts
+++ b/frontend/src/features/connections/companion-disconnect.ts
@@ -1,0 +1,55 @@
+export interface CompanionPushCleanupOutcome {
+    status: 'complete' | 'incomplete' | 'not-verified';
+    reason?: string;
+}
+
+export interface UnexpectedPushCleanupFailure extends CompanionPushCleanupOutcome {
+    status: 'incomplete';
+    reason: 'cleanup-failed';
+    error: unknown;
+}
+
+type NormalizedPushCleanup<TCleanup extends CompanionPushCleanupOutcome> =
+    | TCleanup
+    | UnexpectedPushCleanupFailure;
+
+export type CompanionDisconnectOutcome<TCleanup extends CompanionPushCleanupOutcome> =
+    | {session: 'disconnected'; pushCleanup: NormalizedPushCleanup<TCleanup>}
+    | {
+          session: 'connected';
+          pushCleanup: NormalizedPushCleanup<TCleanup>;
+          error: unknown;
+      };
+
+interface CompanionDisconnectOptions<TCleanup extends CompanionPushCleanupOutcome> {
+    cleanupPush: () => Promise<TCleanup>;
+    disconnectSession: () => Promise<void>;
+    previousCleanup?: TCleanup;
+}
+
+export async function disconnectCompanionWithPushCleanup<
+    TCleanup extends CompanionPushCleanupOutcome,
+>({
+    cleanupPush,
+    disconnectSession,
+    previousCleanup,
+}: CompanionDisconnectOptions<TCleanup>): Promise<CompanionDisconnectOutcome<TCleanup>> {
+    let pushCleanup: NormalizedPushCleanup<TCleanup>;
+    try {
+        pushCleanup =
+            previousCleanup?.status === 'complete' ? previousCleanup : await cleanupPush();
+    } catch (error) {
+        pushCleanup = {
+            status: 'incomplete',
+            reason: 'cleanup-failed',
+            error,
+        };
+    }
+
+    try {
+        await disconnectSession();
+        return {session: 'disconnected', pushCleanup};
+    } catch (error) {
+        return {session: 'connected', pushCleanup, error};
+    }
+}

--- a/frontend/src/features/connections/connections-page.test.tsx
+++ b/frontend/src/features/connections/connections-page.test.tsx
@@ -9,9 +9,12 @@ const notificationSettingsSource = readFileSync(
 );
 
 describe('ConnectionsPage settings information architecture', () => {
-    test('설정 제목 아래에 알림, 서비스, 기기 연결 탭을 둔다', () => {
+    test('설정 제목 아래에 앱 상태, 알림, 서비스, 기기 연결 탭을 둔다', () => {
         expect(source.match(/<PageHeader title="설정" \/>/gu)).toHaveLength(1);
-        expect(source).toContain('<Tabs defaultValue="notifications"');
+        expect(source).toContain('value={selectedTab}');
+        expect(source).toContain('onValueChange={selectTab}');
+        expect(source).toContain('renderAppStatus ? (');
+        expect(source).toContain('<TabsTrigger value="status">앱 상태</TabsTrigger>');
         expect(source).toContain('<TabsTrigger value="notifications">알림</TabsTrigger>');
         expect(source).toContain('<TabsTrigger value="services">서비스</TabsTrigger>');
         expect(source).toContain('<TabsTrigger value="devices">기기 연결</TabsTrigger>');
@@ -21,6 +24,13 @@ describe('ConnectionsPage settings information architecture', () => {
         expect(notificationSettingsSource).toContain('<MealPreferencesSection />');
         expect(source).toContain('<TabsContent value="services"');
         expect(source).toContain('<ServiceSettings />');
+        expect(source).toContain('<TabsContent value="status"');
+        expect(source).toContain('{renderAppStatus()}');
+        expect(source).not.toContain('앱 상태 연결 필요');
+    });
+
+    test('다른 feature를 직접 가져오지 않고 선택형 앱 상태 slot을 노출한다', () => {
+        expect(source).not.toMatch(/from ['"]\.\.\/(?:app-status|notifications)\//u);
     });
 
     test('기기 연결 기능은 보존하고 데스크톱 로컬 설정은 서비스 탭에만 둔다', () => {
@@ -40,9 +50,50 @@ describe('ConnectionsPage settings information architecture', () => {
         expect(source).toContain('PC 연결 정보를 초기화할까요?');
         expect(source).toContain('네, PC 초기화');
         expect(source).toContain('이 PC의 서버 계정과 인증 정보를 삭제하고 새로 만듭니다.');
-        expect(source).toContain('기존 모바일 정리는 운영자 확인이 필요할 수 있습니다.');
+        expect(source).toContain('기존 identity를 복원하는 별도');
         expect(source).toContain('onClick={() => reset.mutate()}');
         expect(source).not.toContain('window.confirm');
+    });
+
+    test('identity 복구는 비파괴 재확인, 초기화는 별도 파괴 동작으로 구분한다', () => {
+        expect(source).toContain('안전한 PC identity 복구는 현재 앱 계약에서 지원하지 않습니다.');
+        expect(source).toContain('복구 기능 준비 안 됨');
+        expect(source).toContain("setIdentityResetReason('reset')");
+        expect(source).toContain('reset.mutate()');
+        expect(source).toContain('네, PC 초기화');
+        expect(source).toContain("value.state !== 'connected'");
+        expect(source).not.toContain('recover.mutate()');
+    });
+
+    test('PC와 현재 모바일 연결 해제 모두 확인, 중복 방지, 성공과 실패 피드백을 제공한다', () => {
+        expect(source).toContain('연결을 해제할까요?');
+        expect(source).toContain('해제하면 이 기기의 출석과 개인 알림을 사용할 수 없습니다.');
+        expect(source).toContain('연결 해제 완료');
+        expect(source).toContain('연결 해제 실패');
+        expect(source).toContain('disconnectInFlight.current');
+        expect(source).toContain('revokeInFlight.current');
+        expect(source.match(/event\.preventDefault\(\)/gu)).toHaveLength(2);
+        expect(source).toContain('setDisconnectFeedback(result)');
+    });
+
+    test('현재 모바일은 인증을 없애기 전에 서버와 동일한 로컬 푸시를 순서대로 정리한다', () => {
+        expect(source).toContain('disconnectCompanionWithPushCleanup({');
+        expect(source).toContain('cleanupPushSubscription({');
+        expect(source).toContain('api.unregisterPushSubscription(subscriptionId)');
+        expect(source).toContain('platform.pwa.unsubscribePush(subscription.endpoint)');
+        expect(source).toContain('disconnectSession: () => api.disconnectMobileSession()');
+        expect(source).toContain('연결 해제 완료 · 푸시 정리 미확인');
+        expect(source).toContain('다시 시도할 때 완료한 정리는 반복하지 않습니다.');
+        expect(source).toContain('previousCleanup: completedPushCleanup.current');
+    });
+
+    test('양쪽 pairing 대기에 취소, 코드 변경, 만료 후 재생성, 재시작 복구를 제공한다', () => {
+        expect(source).toContain('연결 대기 취소');
+        expect(source).toContain('새 QR과 코드 만들기');
+        expect(source).toContain('코드 변경');
+        expect(source).toContain('window.localStorage');
+        expect(source).toContain('다시 연결');
+        expect(source).toContain('서버 만료 시 더 일찍 끝날 수 있습니다.');
     });
 
     test('작은 PC 창에서도 QR 옆 승인 영역과 버튼이 카드 안에서 줄어든다', () => {

--- a/frontend/src/features/connections/connections-page.tsx
+++ b/frontend/src/features/connections/connections-page.tsx
@@ -16,7 +16,7 @@ import {
     Smartphone,
     Trash2,
 } from 'lucide-react';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState, type ReactNode} from 'react';
 
 import type {
     MobilePairingCreated,
@@ -24,6 +24,11 @@ import type {
     MobileSession,
     PairingClaim,
 } from '@/api/dashboard-api';
+import {
+    cleanupPushSubscription,
+    type PushSubscriptionCleanupResult,
+    type PushSubscriptionLifecycleStorage,
+} from '@/api/push-subscription-lifecycle';
 import {useDashboardAccount} from '@/app/dashboard-account';
 import {
     assertLmsAuthenticated,
@@ -65,7 +70,18 @@ import {
 } from '@/domain/connections/manual-pairing-code';
 import {dateTimeLabel, relativeTimeLabel} from '@/lib/format';
 
+import {
+    disconnectCompanionWithPushCleanup,
+    type CompanionDisconnectOutcome,
+} from './companion-disconnect';
+import {
+    connectionsTabFromHash,
+    connectionsTabHref,
+    parseConnectionsTabSearch,
+    type ConnectionsTab,
+} from './connections-tabs';
 import {desktopConnectionUiState, type DesktopConnectionUiState} from './desktop-connection-state';
+import {releaseExclusiveAction, tryReserveExclusiveAction} from './exclusive-action';
 import {pairingQrDataUrl} from './lib/pairing-qr';
 import {
     clearPendingMobilePairing,
@@ -87,13 +103,26 @@ import {ServiceSettings} from './service-settings';
 interface PairingClaimStart {
     mode: 'handoff' | 'manual' | 'qr' | 'resume';
     resumePairingId?: string;
+    signal?: AbortSignal;
 }
 
-function pairingSessionStorage(): Storage | null {
+function pairingPersistentStorage(): Storage | null {
     try {
-        return window.sessionStorage;
+        return window.localStorage;
     } catch {
-        return null;
+        try {
+            return window.sessionStorage;
+        } catch {
+            return null;
+        }
+    }
+}
+
+function pushSubscriptionStorage(): PushSubscriptionLifecycleStorage {
+    try {
+        return window.localStorage;
+    } catch (error) {
+        throw new Error('PUSH_REGISTRATION_STORAGE_UNAVAILABLE', {cause: error});
     }
 }
 
@@ -111,9 +140,11 @@ type MobileSessionsQuery = Pick<
 
 interface MobilePairingCardProps {
     approve: MutationState<void, void>;
+    cancelPairing: () => void;
     connectionUi: DesktopConnectionUiState;
     createPairing: MutationState<MobilePairingCreated, void>;
     pairing: MobilePairingCreated | null;
+    pairingMessage: string;
     pairingStatus: PairingStatusQuery;
     personalReady: boolean;
     qr: string | null;
@@ -122,14 +153,17 @@ interface MobilePairingCardProps {
 
 function MobilePairingCard({
     approve,
+    cancelPairing,
     connectionUi,
     createPairing,
     pairing,
+    pairingMessage,
     pairingStatus,
     personalReady,
     qr,
     registersDesktop,
 }: MobilePairingCardProps) {
+    const pairingExpired = pairingStatus.data?.status === 'expired';
     return (
         <Card>
             <CardHeader>
@@ -163,6 +197,25 @@ function MobilePairingCard({
                             </p>
                         ) : null}
                     </div>
+                ) : pairingExpired ? (
+                    <Alert variant="destructive">
+                        <CircleAlert aria-hidden="true" />
+                        <AlertTitle>연결 코드가 만료됐습니다.</AlertTitle>
+                        <AlertDescription className="gap-3">
+                            <p>만료된 QR과 코드는 더 이상 사용할 수 없습니다.</p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => createPairing.mutate()}
+                                disabled={createPairing.isPending}
+                            >
+                                {createPairing.isPending
+                                    ? '새 코드 만드는 중'
+                                    : '새 QR과 코드 만들기'}
+                            </Button>
+                        </AlertDescription>
+                    </Alert>
                 ) : (
                     <div className="grid gap-4 sm:grid-cols-[9rem_minmax(0,1fr)]">
                         {qr ? (
@@ -190,10 +243,6 @@ function MobilePairingCard({
                                     className="text-sm text-emerald-700 dark:text-emerald-300"
                                 >
                                     연결이 완료됐습니다.
-                                </p>
-                            ) : pairingStatus.data?.status === 'expired' ? (
-                                <p aria-live="polite" className="text-sm text-destructive">
-                                    연결 코드가 만료됐습니다.
                                 </p>
                             ) : null}
                             {pairingStatus.data?.claim ? (
@@ -232,13 +281,28 @@ function MobilePairingCard({
                                     이 기기를 승인하지 못했습니다.
                                 </p>
                             ) : null}
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => createPairing.mutate()}
-                            >
-                                새 QR과 코드
-                            </Button>
+                            <div className="flex flex-wrap gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => createPairing.mutate()}
+                                    disabled={createPairing.isPending || approve.isPending}
+                                >
+                                    {createPairing.isPending ? '코드 변경 중' : '코드 변경'}
+                                </Button>
+                                {pairingStatus.data?.status !== 'completed' ? (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={cancelPairing}
+                                        disabled={createPairing.isPending || approve.isPending}
+                                    >
+                                        연결 대기 취소
+                                    </Button>
+                                ) : null}
+                            </div>
                             {createPairing.isError ? (
                                 <p className="text-sm text-destructive">
                                     새 연결 코드를 만들지 못했습니다.
@@ -247,6 +311,11 @@ function MobilePairingCard({
                         </div>
                     </div>
                 )}
+                {pairingMessage ? (
+                    <p aria-live="polite" className="text-sm text-muted-foreground">
+                        {pairingMessage}
+                    </p>
+                ) : null}
             </CardContent>
         </Card>
     );
@@ -263,6 +332,29 @@ function ConnectedMobileCard({
     revoke: MutationState<void, string>;
     sessions: MobileSessionsQuery;
 }) {
+    const [revokeTarget, setRevokeTarget] = useState<MobileSession | null>(null);
+    const [revokeFeedback, setRevokeFeedback] = useState<{
+        kind: 'success' | 'error';
+        session: MobileSession;
+    } | null>(null);
+    const revokeInFlight = useRef({inFlight: false});
+    const confirmRevoke = () => {
+        const target = revokeTarget;
+        if (!target || !tryReserveExclusiveAction(revokeInFlight.current)) return;
+        setRevokeFeedback(null);
+        revoke.mutate(target.deviceId, {
+            onSuccess: () => {
+                setRevokeTarget(null);
+                setRevokeFeedback({kind: 'success', session: target});
+            },
+            onError: () => {
+                setRevokeTarget(null);
+                setRevokeFeedback({kind: 'error', session: target});
+            },
+            onSettled: () => releaseExclusiveAction(revokeInFlight.current),
+        });
+    };
+
     return (
         <Card>
             <CardHeader>
@@ -297,7 +389,8 @@ function ConnectedMobileCard({
                                 variant="ghost"
                                 size="icon-sm"
                                 aria-label={`${session.deviceLabel} 연결 해제`}
-                                onClick={() => revoke.mutate(session.deviceId)}
+                                onClick={() => setRevokeTarget(session)}
+                                disabled={revoke.isPending}
                             >
                                 <Trash2 className="size-4" />
                             </Button>
@@ -306,10 +399,66 @@ function ConnectedMobileCard({
                 ) : (
                     <EmptyState title="연결된 모바일이 없습니다." />
                 )}
-                {revoke.isError ? (
-                    <p className="text-sm text-destructive">모바일 연결을 해제하지 못했습니다.</p>
+                {revokeFeedback?.kind === 'success' ? (
+                    <Alert aria-live="polite">
+                        <Smartphone aria-hidden="true" />
+                        <AlertTitle>연결 해제 완료</AlertTitle>
+                        <AlertDescription>
+                            {revokeFeedback.session.deviceLabel}의 개인 기능과 푸시를 해제했습니다.
+                        </AlertDescription>
+                    </Alert>
+                ) : revokeFeedback?.kind === 'error' ? (
+                    <Alert variant="destructive">
+                        <CircleAlert aria-hidden="true" />
+                        <AlertTitle>연결 해제 실패</AlertTitle>
+                        <AlertDescription className="gap-3">
+                            <p>
+                                {revokeFeedback.session.deviceLabel} 연결은 유지됩니다. 네트워크를
+                                확인하고 다시 시도하세요.
+                            </p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setRevokeTarget(revokeFeedback.session)}
+                                disabled={revoke.isPending}
+                            >
+                                다시 시도
+                            </Button>
+                        </AlertDescription>
+                    </Alert>
                 ) : null}
             </CardContent>
+            <AlertDialog
+                open={revokeTarget !== null}
+                onOpenChange={(open) => {
+                    if (!open && !revoke.isPending) setRevokeTarget(null);
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            {revokeTarget?.deviceLabel ?? '이 모바일'} 연결을 해제할까요?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            해제하면 이 기기의 출석과 개인 알림을 사용할 수 없습니다. 다시
+                            사용하려면 새 코드로 연결해야 합니다.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={revoke.isPending}>유지</AlertDialogCancel>
+                        <AlertDialogAction
+                            disabled={revoke.isPending}
+                            onClick={(event) => {
+                                event.preventDefault();
+                                confirmRevoke();
+                            }}
+                        >
+                            {revoke.isPending ? '해제 중' : '연결 해제'}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </Card>
     );
 }
@@ -319,9 +468,9 @@ function DesktopConnections() {
     const account = useDashboardAccount();
     const client = useQueryClient();
     const [pairing, setPairing] = useState<MobilePairingCreated | null>(null);
-    const [identityResetReason, setIdentityResetReason] = useState<'recovery' | 'reset' | null>(
-        null,
-    );
+    const [pairingMessage, setPairingMessage] = useState('');
+    const [identityMessage, setIdentityMessage] = useState('');
+    const [identityResetReason, setIdentityResetReason] = useState<'reset' | null>(null);
     const refreshAccount = useRefreshAttendanceMutation();
     const personalReady =
         account.status.lmsAuthentication === 'authenticated' && serverSessionReady(account.status);
@@ -375,6 +524,7 @@ function DesktopConnections() {
         },
         onSuccess: async (value) => {
             setPairing(value);
+            setPairingMessage('');
             await client.invalidateQueries({queryKey: queryKeys.desktopConnection});
         },
     });
@@ -397,19 +547,39 @@ function DesktopConnections() {
         onSuccess: () => void client.invalidateQueries({queryKey: queryKeys.mobileSessions}),
     });
     const reset = useMutation({
-        mutationFn: () => api.resetDesktopIdentity(),
+        mutationFn: async () => {
+            if (connection.data?.state !== 'connected') {
+                throw new Error('IDENTITY_RESET_NOT_AVAILABLE');
+            }
+            const value = await api.resetDesktopIdentity();
+            if (value.state !== 'connected') throw new Error('IDENTITY_RESET_INCOMPLETE');
+            return value;
+        },
         onMutate: () => {
             setPairing(null);
+            setIdentityMessage('');
             removeDesktopIdentityQueries(client);
         },
         onSuccess: async (value) => {
             client.setQueryData(queryKeys.desktopConnection, value);
+            setIdentityResetReason(null);
+            setIdentityMessage('PC 연결 정보를 초기화하고 새 서버 등록을 확인했습니다.');
             await client.invalidateQueries({queryKey: queryKeys.desktopConnection});
         },
     });
 
+    const cancelDesktopPairing = () => {
+        if (!pairing) return;
+        client.removeQueries({queryKey: ['pairing-status', pairing.pairingId], exact: true});
+        setPairing(null);
+        setPairingMessage(
+            '이 화면의 연결 대기를 중단했습니다. 발급한 코드는 서버 만료 전까지 유효할 수 있습니다. 새 코드를 만들면 이전 코드를 교체합니다.',
+        );
+    };
+
     const qr = useMemo(() => (pairing ? pairingQrDataUrl(pairing.qrPayload) : null), [pairing]);
     const connectionUi = desktopConnectionUiState(connection.data);
+    const identityBusy = reset.isPending;
     const activeSessions = sessions.data?.filter((item) => item.status === 'active') ?? [];
     const serverSessionLabel =
         account.status.serverSession === 'stored'
@@ -466,24 +636,15 @@ function DesktopConnections() {
                                 <AlertTitle>{connectionUi.label}</AlertTitle>
                                 <AlertDescription>
                                     <p>
-                                        {connectionUi.reason} 복구하면 연결된 모바일을 다시 연결해야
-                                        합니다.
+                                        {connectionUi.reason}{' '}
+                                        {
+                                            '안전한 PC identity 복구는 현재 앱 계약에서 지원하지 않습니다. 초기화와 달리 기존 identity를 복원하는 별도 native/backend 계약이 필요합니다.'
+                                        }
                                     </p>
-                                    <Button
-                                        className="mt-3"
-                                        size="sm"
-                                        variant="outline"
-                                        onClick={() => setIdentityResetReason('recovery')}
-                                        disabled={reset.isPending}
-                                    >
+                                    <Button className="mt-3" size="sm" variant="outline" disabled>
                                         <RotateCcw className="size-4" />
-                                        {reset.isPending ? '복구 중' : 'PC 연결 정보 복구'}
+                                        복구 기능 준비 안 됨
                                     </Button>
-                                    {reset.isError ? (
-                                        <p className="mt-2 text-sm text-destructive">
-                                            PC 연결 정보를 복구하지 못했습니다.
-                                        </p>
-                                    ) : null}
                                 </AlertDescription>
                             </Alert>
                         ) : connection.data?.state === 'disconnected' ? (
@@ -514,9 +675,11 @@ function DesktopConnections() {
             <div className="grid gap-6 lg:grid-cols-2">
                 <MobilePairingCard
                     approve={approve}
+                    cancelPairing={cancelDesktopPairing}
                     connectionUi={connectionUi}
                     createPairing={createPairing}
                     pairing={pairing}
+                    pairingMessage={pairingMessage}
                     pairingStatus={pairingStatus}
                     personalReady={personalReady}
                     qr={qr}
@@ -542,7 +705,7 @@ function DesktopConnections() {
                         <Button
                             variant="destructive"
                             onClick={() => setIdentityResetReason('reset')}
-                            disabled={reset.isPending}
+                            disabled={identityBusy}
                         >
                             <RotateCcw className="size-4" />
                             초기화
@@ -556,6 +719,14 @@ function DesktopConnections() {
                 </Card>
             ) : null}
 
+            {identityMessage ? (
+                <Alert aria-live="polite">
+                    <RotateCcw aria-hidden="true" />
+                    <AlertTitle>PC 연결 정보 처리 완료</AlertTitle>
+                    <AlertDescription>{identityMessage}</AlertDescription>
+                </Alert>
+            ) : null}
+
             <AlertDialog
                 open={identityResetReason !== null}
                 onOpenChange={(open) => {
@@ -564,29 +735,237 @@ function DesktopConnections() {
             >
                 <AlertDialogContent>
                     <AlertDialogHeader>
-                        <AlertDialogTitle>
-                            {identityResetReason === 'recovery'
-                                ? 'PC 연결 정보를 복구할까요?'
-                                : 'PC 연결 정보를 초기화할까요?'}
-                        </AlertDialogTitle>
+                        <AlertDialogTitle>PC 연결 정보를 초기화할까요?</AlertDialogTitle>
                         <AlertDialogDescription>
-                            {identityResetReason === 'recovery'
-                                ? '남아 있는 로컬 인증 정보를 새로 만듭니다. 이전 서버 credential이 이미 없으면 기존 모바일 정리는 운영자 확인이 필요할 수 있습니다.'
-                                : '이 PC의 서버 계정과 인증 정보를 삭제하고 새로 만듭니다. 연결된 모바일은 모두 해제되며 되돌릴 수 없습니다.'}
+                            이 PC의 서버 계정과 인증 정보를 삭제하고 새로 만듭니다. 연결된 모바일은
+                            모두 해제되며 되돌릴 수 없습니다.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel>아니요</AlertDialogCancel>
-                        <AlertDialogAction
-                            disabled={reset.isPending}
-                            onClick={() => reset.mutate()}
-                        >
+                        <AlertDialogCancel disabled={identityBusy}>아니요</AlertDialogCancel>
+                        <AlertDialogAction disabled={identityBusy} onClick={() => reset.mutate()}>
                             네, PC 초기화
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
         </div>
+    );
+}
+
+type CompanionDisconnectFeedback = CompanionDisconnectOutcome<PushSubscriptionCleanupResult> | null;
+
+interface CompanionConnectionCardProps {
+    checking: boolean;
+    claimPending: boolean;
+    confirmationCode: string;
+    connected: boolean;
+    disconnectFeedback: CompanionDisconnectFeedback;
+    disconnectPending: boolean;
+    manualCode: string;
+    message: string;
+    onCancelPairing: () => void;
+    onChangeCode: () => void;
+    onManualCodeChange: (value: string) => void;
+    onRequestDisconnect: () => void;
+    onStartManualPairing: () => void;
+    pendingPairingExpiresAt: string | null;
+}
+
+function CompanionConnectionCard({
+    checking,
+    claimPending,
+    confirmationCode,
+    connected,
+    disconnectFeedback,
+    disconnectPending,
+    manualCode,
+    message,
+    onCancelPairing,
+    onChangeCode,
+    onManualCodeChange,
+    onRequestDisconnect,
+    onStartManualPairing,
+    pendingPairingExpiresAt,
+}: CompanionConnectionCardProps) {
+    return (
+        <Card className="mx-auto max-w-xl">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <MonitorCheck className="size-5" />
+                    {connected
+                        ? '이 기기는 연결됨'
+                        : claimPending
+                          ? 'PC 승인 대기'
+                          : '연결 코드 입력'}
+                </CardTitle>
+                <CardDescription>
+                    {connected
+                        ? 'PC 앱이 출석 상태를 주기적으로 갱신합니다.'
+                        : '설치 QR 정보가 있으면 자동으로 연결하고, 없으면 PC 앱의 10자리 코드를 입력합니다.'}
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {checking ? (
+                    <LoadingState label="설치 QR 연결 정보를 확인하고 있습니다." />
+                ) : connected ? (
+                    <Button
+                        variant="outline"
+                        onClick={onRequestDisconnect}
+                        disabled={disconnectPending}
+                    >
+                        이 모바일 연결 해제
+                    </Button>
+                ) : claimPending ? null : (
+                    <>
+                        <div className="space-y-2">
+                            <Label htmlFor="pairing-code">10자리 연결 코드</Label>
+                            <Input
+                                id="pairing-code"
+                                value={manualCode}
+                                inputMode="text"
+                                maxLength={11}
+                                autoCapitalize="characters"
+                                placeholder="ABCDE-12345"
+                                onChange={(event) =>
+                                    onManualCodeChange(formatManualPairingCode(event.target.value))
+                                }
+                            />
+                        </div>
+                        <Button
+                            onClick={onStartManualPairing}
+                            disabled={!validManualPairingCode(manualCode)}
+                        >
+                            연결 요청
+                        </Button>
+                    </>
+                )}
+                {claimPending ? (
+                    <Alert>
+                        <KeyRound />
+                        <AlertTitle>PC에서 이 기기를 승인해 주세요.</AlertTitle>
+                        <AlertDescription className="gap-3">
+                            <p>
+                                PC 화면의 확인 코드가 <strong>{confirmationCode}</strong>인지
+                                확인하세요.
+                            </p>
+                            {pendingPairingExpiresAt ? (
+                                <PairingExpiryCountdown expiresAt={pendingPairingExpiresAt} />
+                            ) : null}
+                            <p className="text-xs text-muted-foreground">
+                                {
+                                    '이 시간은 기기에서 계산한 최대 10분입니다. 서버 만료 시 더 일찍 끝날 수 있습니다.'
+                                }
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={onCancelPairing}
+                                >
+                                    연결 대기 취소
+                                </Button>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={onChangeCode}
+                                >
+                                    코드 변경
+                                </Button>
+                            </div>
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+                {message ? (
+                    <p aria-live="polite" className="text-sm text-muted-foreground">
+                        {message}
+                    </p>
+                ) : null}
+                {disconnectFeedback?.session === 'disconnected' &&
+                disconnectFeedback.pushCleanup.status === 'complete' ? (
+                    <Alert aria-live="polite">
+                        <Smartphone aria-hidden="true" />
+                        <AlertTitle>연결 해제 완료</AlertTitle>
+                        <AlertDescription>
+                            서버 푸시와 이 기기의 로컬 구독을 정리했습니다. 이제 공개 정보만 사용할
+                            수 있습니다.
+                        </AlertDescription>
+                    </Alert>
+                ) : disconnectFeedback?.session === 'disconnected' ? (
+                    <Alert variant="destructive" aria-live="polite">
+                        <CircleAlert aria-hidden="true" />
+                        <AlertTitle>연결 해제 완료 · 푸시 정리 미확인</AlertTitle>
+                        <AlertDescription>
+                            연결 세션은 해제됐지만 푸시 정리는 모두 확인하지 못했습니다. 서버는
+                            해제된 세션으로 더 이상 푸시를 보내지 않으며, 다시 연결한 뒤 등록 상태를
+                            정리할 수 있습니다.
+                        </AlertDescription>
+                    </Alert>
+                ) : disconnectFeedback?.session === 'connected' ? (
+                    <Alert variant="destructive">
+                        <CircleAlert aria-hidden="true" />
+                        <AlertTitle>연결 해제 실패</AlertTitle>
+                        <AlertDescription className="gap-3">
+                            <p>
+                                {disconnectFeedback.pushCleanup.status === 'complete'
+                                    ? '푸시 정리는 완료됐지만 연결은 유지됩니다. 다시 시도할 때 완료한 정리는 반복하지 않습니다.'
+                                    : '푸시 정리를 모두 확인하지 못했고 연결도 유지됩니다. 인증이 남아 있을 때 다시 시도하세요.'}
+                            </p>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={onRequestDisconnect}
+                                disabled={disconnectPending}
+                            >
+                                다시 시도
+                            </Button>
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}
+
+function CompanionDisconnectDialog({
+    open,
+    pending,
+    onOpenChange,
+    onConfirm,
+}: {
+    open: boolean;
+    pending: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void;
+}) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>이 모바일 연결을 해제할까요?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        서버 푸시와 이 기기의 로컬 구독을 먼저 정리한 다음 연결 세션을 해제합니다.
+                        이후 출석과 개인 알림을 사용할 수 없고, 다시 사용하려면 새 코드로 연결해야
+                        합니다.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={pending}>유지</AlertDialogCancel>
+                    <AlertDialogAction
+                        disabled={pending}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            onConfirm();
+                        }}
+                    >
+                        {pending ? '해제 중' : '연결 해제'}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
     );
 }
 
@@ -601,22 +980,35 @@ export function CompanionConnections({
     const navigate = useNavigate();
     const [manualCode, setManualCode] = useState('');
     const [message, setMessage] = useState('');
+    const [disconnectConfirmationOpen, setDisconnectConfirmationOpen] = useState(false);
+    const [disconnectFeedback, setDisconnectFeedback] = useState<CompanionDisconnectFeedback>(null);
     const pairingStartGate = useRef({inFlight: false, automaticHandled: false});
+    const pairingAbortController = useRef<AbortController | null>(null);
+    const disconnectInFlight = useRef({inFlight: false});
+    const completedPushCleanup = useRef<
+        Extract<PushSubscriptionCleanupResult, {status: 'complete'}> | undefined
+    >(undefined);
     const [automaticPairingHandled, setAutomaticPairingHandled] = useState(false);
     const [initialPairing] = useState(readInitialPairingEntry);
     const pairingLink = initialPairing?.kind === 'companion' ? initialPairing.link : null;
-    const [restoredPairing] = useState(() => {
-        const storage = pairingSessionStorage();
+    const [restoredPairing, setRestoredPairing] = useState(() => {
+        const storage = pairingPersistentStorage();
         return storage ? readPendingMobilePairing(storage, Date.now()) : null;
     });
+    const [pendingPairingStartedAt, setPendingPairingStartedAt] = useState<number | null>(
+        restoredPairing?.createdAtEpochMs ?? null,
+    );
     const claim = useMutation({
-        mutationFn: async ({mode, resumePairingId}: PairingClaimStart) => {
+        onMutate: () => setMessage(''),
+        mutationFn: async ({mode, resumePairingId, signal}: PairingClaimStart) => {
             const installationId = mobileInstallationId();
             let request: PairingClaim | null = null;
             let pairingId: string;
+            let createdAtEpochMs = Date.now();
             if (mode === 'resume') {
                 if (!resumePairingId) throw new Error('PAIRING_ID_MISSING');
                 pairingId = resumePairingId;
+                createdAtEpochMs = restoredPairing?.createdAtEpochMs ?? createdAtEpochMs;
             } else if (mode === 'handoff') {
                 request = await api.claimPairingHandoff({
                     deviceLabel: mobileDeviceLabel(),
@@ -641,28 +1033,32 @@ export function CompanionConnections({
                 pairingId = request.claimId;
             }
             if (request) {
-                const storage = pairingSessionStorage();
+                const storage = pairingPersistentStorage();
                 if (storage) {
                     storePendingMobilePairing(storage, {
                         pairingId,
                         claimId: request.claimId,
-                        createdAtEpochMs: Date.now(),
+                        createdAtEpochMs,
                     });
                 }
             }
+            setPendingPairingStartedAt(createdAtEpochMs);
             await waitForPairingCompletion({
                 pairingId,
                 complete: (id) => api.completePairing(id),
                 pause: (milliseconds) =>
                     new Promise((resolve) => window.setTimeout(resolve, milliseconds)),
+                signal,
             });
-            const storage = pairingSessionStorage();
+            const storage = pairingPersistentStorage();
             if (storage) clearPendingMobilePairing(storage);
             return true;
         },
         onSuccess: async (completed) => {
             if (!completed) return;
             setMessage('연결이 완료됐습니다.');
+            setPendingPairingStartedAt(null);
+            setRestoredPairing(null);
             if (platform.accountAuthentication.kind === 'cookie') {
                 await finishCompanionPairing({
                     completionPath,
@@ -671,19 +1067,54 @@ export function CompanionConnections({
                 });
             }
         },
-        onError: () => {
-            const storage = pairingSessionStorage();
+        onError: (error) => {
+            const storage = pairingPersistentStorage();
             if (storage) clearPendingMobilePairing(storage);
-            setMessage('연결하지 못했습니다. PC에서 새 코드를 만든 뒤 다시 시도하세요.');
+            setPendingPairingStartedAt(null);
+            setRestoredPairing(null);
+            setMessage(
+                error.message === 'PAIRING_CANCELLED'
+                    ? '연결 대기를 취소했습니다. 서버의 요청은 만료될 때까지 남을 수 있습니다.'
+                    : /EXPIRED|NOT_FOUND|ALREADY_USED/u.test(error.message)
+                      ? '연결 코드가 만료되었거나 교체됐습니다. PC에서 새 코드를 만든 뒤 다시 연결하세요.'
+                      : '연결하지 못했습니다. 네트워크를 확인하거나 PC에서 새 코드를 만든 뒤 다시 시도하세요.',
+            );
         },
     });
     const disconnect = useMutation({
-        mutationFn: () => api.disconnectMobileSession(),
+        mutationFn: () =>
+            disconnectCompanionWithPushCleanup({
+                cleanupPush: () =>
+                    cleanupPushSubscription({
+                        storage: pushSubscriptionStorage(),
+                        getLocalSubscription: () => platform.pwa.getPushSubscription(),
+                        unregisterServer: (subscriptionId) =>
+                            api.unregisterPushSubscription(subscriptionId),
+                        unsubscribeLocal: (subscription) => {
+                            if (
+                                typeof subscription.endpoint !== 'string' ||
+                                !subscription.endpoint
+                            ) {
+                                throw new Error('PUSH_SUBSCRIPTION_ENDPOINT_INVALID');
+                            }
+                            return platform.pwa.unsubscribePush(subscription.endpoint);
+                        },
+                    }),
+                disconnectSession: () => api.disconnectMobileSession(),
+                previousCleanup: completedPushCleanup.current,
+            }),
         onMutate: () => client.cancelQueries({queryKey: queryKeys.accountSession, exact: true}),
-        onSuccess: () => {
-            removeBrowserPersonalQueries(client);
-            setAutomaticPairingHandled(true);
-            setMessage('이 모바일 연결을 해제했습니다.');
+        onSuccess: (result) => {
+            setDisconnectConfirmationOpen(false);
+            setDisconnectFeedback(result);
+            setMessage('');
+            if (result.pushCleanup.status === 'complete') {
+                completedPushCleanup.current = result.pushCleanup;
+            }
+            if (result.session === 'disconnected') {
+                removeBrowserPersonalQueries(client);
+                setAutomaticPairingHandled(true);
+            }
         },
     });
     const connected = account.personalAccess.status === 'connected';
@@ -691,15 +1122,42 @@ export function CompanionConnections({
     const startClaim = useCallback(
         (input: PairingClaimStart) => {
             if (!tryReservePairingStart(pairingStartGate.current)) return;
+            const controller = new AbortController();
+            pairingAbortController.current = controller;
             // Reservation is a pairing state-machine transition, not synchronization from props.
             // react-doctor-disable-next-line react-doctor/no-adjust-state-on-prop-change
             setAutomaticPairingHandled(true);
-            claim.mutate(input, {
-                onSettled: () => releasePairingStart(pairingStartGate.current),
-            });
+            claim.mutate(
+                {...input, signal: controller.signal},
+                {
+                    onSettled: () => {
+                        if (pairingAbortController.current === controller) {
+                            pairingAbortController.current = null;
+                        }
+                        releasePairingStart(pairingStartGate.current);
+                    },
+                },
+            );
         },
         [claim],
     );
+
+    const cancelPairingWait = () => {
+        pairingAbortController.current?.abort();
+        const storage = pairingPersistentStorage();
+        if (storage) clearPendingMobilePairing(storage);
+        setRestoredPairing(null);
+        setPendingPairingStartedAt(null);
+        setMessage('연결 대기를 취소하는 중입니다. 서버 요청은 만료 전까지 남을 수 있습니다.');
+    };
+
+    const confirmDisconnect = () => {
+        if (!tryReserveExclusiveAction(disconnectInFlight.current)) return;
+        setDisconnectFeedback(null);
+        disconnect.mutate(undefined, {
+            onSettled: () => releaseExclusiveAction(disconnectInFlight.current),
+        });
+    };
 
     useEffect(() => {
         const action = automaticPairingAction({
@@ -711,7 +1169,7 @@ export function CompanionConnections({
         });
         if (action === 'clear') {
             pairingStartGate.current.automaticHandled = true;
-            const storage = pairingSessionStorage();
+            const storage = pairingPersistentStorage();
             if (storage) clearPendingMobilePairing(storage);
             return;
         }
@@ -740,79 +1198,40 @@ export function CompanionConnections({
         !automaticPairingHandled &&
         (restoredPairing !== null || pairingLink !== null || platform.pwa.installed);
     const checking = account.personalAccess.status === 'checking' || automaticCheckPending;
+    const pendingPairingExpiresAt =
+        pendingPairingStartedAt === null
+            ? null
+            : new Date(pendingPairingStartedAt + 10 * 60_000).toISOString();
 
     return (
         <div className="space-y-6">
-            <Card className="mx-auto max-w-xl">
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                        <MonitorCheck className="size-5" />
-                        {connected
-                            ? '이 기기는 연결됨'
-                            : claim.isPending
-                              ? 'PC 승인 대기'
-                              : '연결 코드 입력'}
-                    </CardTitle>
-                    <CardDescription>
-                        {connected
-                            ? 'PC 앱이 출석 상태를 주기적으로 갱신합니다.'
-                            : '설치 QR 정보가 있으면 자동으로 연결하고, 없으면 PC 앱의 10자리 코드를 입력합니다.'}
-                    </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    {checking ? (
-                        <LoadingState label="설치 QR 연결 정보를 확인하고 있습니다." />
-                    ) : connected ? (
-                        <Button
-                            variant="outline"
-                            onClick={() => disconnect.mutate()}
-                            disabled={disconnect.isPending}
-                        >
-                            이 모바일 연결 해제
-                        </Button>
-                    ) : (
-                        <>
-                            {!claim.isPending ? (
-                                <>
-                                    <div className="space-y-2">
-                                        <Label htmlFor="pairing-code">10자리 연결 코드</Label>
-                                        <Input
-                                            id="pairing-code"
-                                            value={manualCode}
-                                            inputMode="text"
-                                            maxLength={11}
-                                            autoCapitalize="characters"
-                                            placeholder="ABCDE-12345"
-                                            onChange={(event) =>
-                                                setManualCode(
-                                                    formatManualPairingCode(event.target.value),
-                                                )
-                                            }
-                                        />
-                                    </div>
-                                    <Button
-                                        onClick={() => startClaim({mode: 'manual'})}
-                                        disabled={!validManualPairingCode(manualCode)}
-                                    >
-                                        연결 요청
-                                    </Button>
-                                </>
-                            ) : null}
-                        </>
-                    )}
-                    {claim.isPending ? (
-                        <Alert>
-                            <KeyRound />
-                            <AlertTitle>PC에서 이 기기를 승인해 주세요.</AlertTitle>
-                            <AlertDescription>
-                                PC 화면의 확인 코드가 <strong>{confirmationCode}</strong>인지
-                                확인하세요.
-                            </AlertDescription>
-                        </Alert>
-                    ) : null}
-                    {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
-                </CardContent>
-            </Card>
+            <CompanionConnectionCard
+                checking={checking}
+                claimPending={claim.isPending}
+                confirmationCode={confirmationCode}
+                connected={connected}
+                disconnectFeedback={disconnectFeedback}
+                disconnectPending={disconnect.isPending}
+                manualCode={manualCode}
+                message={message}
+                onCancelPairing={cancelPairingWait}
+                onChangeCode={() => {
+                    setManualCode('');
+                    cancelPairingWait();
+                }}
+                onManualCodeChange={setManualCode}
+                onRequestDisconnect={() => setDisconnectConfirmationOpen(true)}
+                onStartManualPairing={() => startClaim({mode: 'manual'})}
+                pendingPairingExpiresAt={pendingPairingExpiresAt}
+            />
+            <CompanionDisconnectDialog
+                open={disconnectConfirmationOpen}
+                pending={disconnect.isPending}
+                onOpenChange={(open) => {
+                    if (!disconnect.isPending) setDisconnectConfirmationOpen(open);
+                }}
+                onConfirm={confirmDisconnect}
+            />
         </div>
     );
 }
@@ -832,21 +1251,59 @@ function WebConnections() {
     );
 }
 
-export function ConnectionsPage() {
+export interface ConnectionsPageProps {
+    tab?: ConnectionsTab;
+    onTabChange?: (tab: ConnectionsTab) => void;
+    renderAppStatus?: () => ReactNode;
+}
+
+export function ConnectionsPage({tab, onTabChange, renderAppStatus}: ConnectionsPageProps = {}) {
     const {platform} = useDashboardEnvironment();
+    const [fallbackTab, setFallbackTab] = useState<ConnectionsTab>(() =>
+        typeof window === 'undefined'
+            ? 'notifications'
+            : connectionsTabFromHash(window.location.hash),
+    );
+    const requestedTab = tab ?? fallbackTab;
+    const selectedTab =
+        requestedTab === 'status' && !renderAppStatus ? 'notifications' : requestedTab;
+    const selectTab = (value: string) => {
+        const nextTab = parseConnectionsTabSearch({tab: value});
+        if (tab === undefined) {
+            setFallbackTab(nextTab);
+            if (
+                typeof window !== 'undefined' &&
+                window.location.hash !== connectionsTabHref(nextTab)
+            ) {
+                window.location.hash = connectionsTabHref(nextTab);
+            }
+        }
+        onTabChange?.(nextTab);
+    };
+
+    useEffect(() => {
+        if (tab !== undefined || typeof window === 'undefined') return undefined;
+        const syncTabFromUrl = () => setFallbackTab(connectionsTabFromHash(window.location.hash));
+        window.addEventListener('hashchange', syncTabFromUrl);
+        return () => window.removeEventListener('hashchange', syncTabFromUrl);
+    }, [tab]);
 
     return (
         <div className="space-y-6">
             <PageHeader title="설정" />
-            <Tabs defaultValue="notifications" className="gap-5">
+            <Tabs value={selectedTab} onValueChange={selectTab} className="gap-5">
                 <TabsList
                     aria-label="설정 구분"
-                    className="grid h-auto w-full grid-cols-3 sm:w-fit"
+                    className={`grid h-auto w-full sm:w-fit ${renderAppStatus ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'}`}
                 >
+                    {renderAppStatus ? <TabsTrigger value="status">앱 상태</TabsTrigger> : null}
                     <TabsTrigger value="notifications">알림</TabsTrigger>
                     <TabsTrigger value="services">서비스</TabsTrigger>
                     <TabsTrigger value="devices">기기 연결</TabsTrigger>
                 </TabsList>
+                {renderAppStatus ? (
+                    <TabsContent value="status">{renderAppStatus()}</TabsContent>
+                ) : null}
                 <TabsContent value="notifications">
                     <PersonalAccountGate>
                         <NotificationSettings />

--- a/frontend/src/features/connections/connections-tabs.test.ts
+++ b/frontend/src/features/connections/connections-tabs.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+    connectionsTabFromHash,
+    connectionsTabHref,
+    parseConnectionsTabSearch,
+    type ConnectionsTab,
+} from './connections-tabs';
+
+describe('connections tab search state', () => {
+    test.each<ConnectionsTab>(['status', 'notifications', 'services', 'devices'])(
+        '%s 탭을 URL search에서 복원한다',
+        (tab) => {
+            expect(parseConnectionsTabSearch({tab})).toBe(tab);
+            expect(connectionsTabFromHash(`#/connections?tab=${tab}`)).toBe(tab);
+        },
+    );
+
+    test('기기 연결 패널로 바로 가는 공개 href를 만든다', () => {
+        expect(connectionsTabHref('devices')).toBe('#/connections?tab=devices');
+    });
+
+    test('없거나 알 수 없는 값은 기존 알림 설정 탭으로 안전하게 보낸다', () => {
+        expect(parseConnectionsTabSearch({})).toBe('notifications');
+        expect(parseConnectionsTabSearch({tab: 'unknown'})).toBe('notifications');
+        expect(parseConnectionsTabSearch({tab: ['devices']})).toBe('notifications');
+        expect(connectionsTabFromHash('#/connections?tab=%')).toBe('notifications');
+    });
+});

--- a/frontend/src/features/connections/connections-tabs.ts
+++ b/frontend/src/features/connections/connections-tabs.ts
@@ -1,0 +1,35 @@
+export const CONNECTIONS_TABS = ['status', 'notifications', 'services', 'devices'] as const;
+
+export type ConnectionsTab = (typeof CONNECTIONS_TABS)[number];
+
+const DEFAULT_CONNECTIONS_TAB: ConnectionsTab = 'notifications';
+
+function isConnectionsTab(value: unknown): value is ConnectionsTab {
+    return typeof value === 'string' && CONNECTIONS_TABS.some((tab) => tab === value);
+}
+
+export function parseConnectionsTabSearch(search: unknown): ConnectionsTab {
+    if (search instanceof URLSearchParams) {
+        const tab = search.get('tab');
+        return isConnectionsTab(tab) ? tab : DEFAULT_CONNECTIONS_TAB;
+    }
+    if (typeof search !== 'object' || search === null || !('tab' in search)) {
+        return DEFAULT_CONNECTIONS_TAB;
+    }
+    const tab = (search as {tab?: unknown}).tab;
+    return isConnectionsTab(tab) ? tab : DEFAULT_CONNECTIONS_TAB;
+}
+
+export function connectionsTabFromHash(hash: string): ConnectionsTab {
+    const questionMark = hash.indexOf('?');
+    if (questionMark < 0) return DEFAULT_CONNECTIONS_TAB;
+    try {
+        return parseConnectionsTabSearch(new URLSearchParams(hash.slice(questionMark + 1)));
+    } catch {
+        return DEFAULT_CONNECTIONS_TAB;
+    }
+}
+
+export function connectionsTabHref(tab: ConnectionsTab): `#/connections?tab=${ConnectionsTab}` {
+    return `#/connections?tab=${tab}`;
+}

--- a/frontend/src/features/connections/desktop-connection-state.test.ts
+++ b/frontend/src/features/connections/desktop-connection-state.test.ts
@@ -47,7 +47,7 @@ describe('desktop connection state UI', () => {
         expect(resetRequired.reason).toContain('일치하지 않');
     });
 
-    test('연결 화면은 생성 mutation도 상태로 방어하고 identity 복구 CTA를 연결한다', () => {
+    test('연결 화면은 생성 mutation을 상태로 방어하고 지원하지 않는 identity 복구를 숨기지 않는다', () => {
         const source = readFileSync(new URL('./connections-page.tsx', import.meta.url), 'utf8');
         expect(source).toMatch(
             /connection\.data\?\.state !== 'connected'[\s\S]*connection\.data\?\.state !== 'disconnected'[\s\S]*DESKTOP_CONNECTION_REQUIRED/u,
@@ -55,7 +55,8 @@ describe('desktop connection state UI', () => {
         expect(source).toMatch(/!connectionUi\.canCreatePairing/u);
         expect(source).toMatch(/api\.resetDesktopIdentity\(\)/u);
         expect(source).toMatch(/invalidateQueries\(\{queryKey: queryKeys\.desktopConnection\}\)/u);
-        expect(source).toContain('PC 연결 정보 복구');
+        expect(source).toContain('복구 기능 준비 안 됨');
+        expect(source).toContain('안전한 PC identity 복구는 현재 앱 계약에서 지원하지 않습니다.');
         expect(source).toContain('서버 인증 정보');
         expect(source).toContain('LMS 계정');
         expect(source).toContain('useDashboardAccount()');

--- a/frontend/src/features/connections/exclusive-action.test.ts
+++ b/frontend/src/features/connections/exclusive-action.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, test} from 'vitest';
+
+import {releaseExclusiveAction, tryReserveExclusiveAction} from './exclusive-action';
+
+describe('exclusive destructive action gate', () => {
+    test('동기적인 연속 실행을 하나만 허용하고 완료 뒤 다시 열어 준다', () => {
+        const gate = {inFlight: false};
+
+        expect(tryReserveExclusiveAction(gate)).toBe(true);
+        expect(tryReserveExclusiveAction(gate)).toBe(false);
+        releaseExclusiveAction(gate);
+        expect(tryReserveExclusiveAction(gate)).toBe(true);
+    });
+});

--- a/frontend/src/features/connections/exclusive-action.ts
+++ b/frontend/src/features/connections/exclusive-action.ts
@@ -1,0 +1,13 @@
+export interface ExclusiveActionGate {
+    inFlight: boolean;
+}
+
+export function tryReserveExclusiveAction(gate: ExclusiveActionGate): boolean {
+    if (gate.inFlight) return false;
+    gate.inFlight = true;
+    return true;
+}
+
+export function releaseExclusiveAction(gate: ExclusiveActionGate): void {
+    gate.inFlight = false;
+}

--- a/frontend/src/features/connections/lib/pending-pairing.test.ts
+++ b/frontend/src/features/connections/lib/pending-pairing.test.ts
@@ -31,7 +31,7 @@ const pending = {
     createdAtEpochMs: 1_785_727_000_000,
 };
 
-test('pending pairing은 식별자와 생성 시각만 session storage에 보존한다', () => {
+test('pending pairing은 식별자와 생성 시각만 영속 저장소에 보존한다', () => {
     const storage = memoryStorage();
     storePendingMobilePairing(storage, pending);
 
@@ -45,6 +45,26 @@ test('pending pairing은 식별자와 생성 시각만 session storage에 보존
 
     clearPendingMobilePairing(storage);
     assert.equal(storage.values.has(PENDING_MOBILE_PAIRING_KEY), false);
+});
+
+test('새 브라우저 실행에서 같은 local storage를 읽어 승인 대기를 복구한다', () => {
+    const persistentValues = new Map<string, string>();
+    const firstRun = {
+        getItem: (key: string) => persistentValues.get(key) ?? null,
+        setItem: (key: string, value: string) => persistentValues.set(key, value),
+        removeItem: (key: string) => persistentValues.delete(key),
+    };
+    storePendingMobilePairing(firstRun, pending);
+
+    const restartedRun = {
+        getItem: firstRun.getItem,
+        setItem: firstRun.setItem,
+        removeItem: firstRun.removeItem,
+    };
+    assert.deepEqual(
+        readPendingMobilePairing(restartedRun, pending.createdAtEpochMs + 30_000),
+        pending,
+    );
 });
 
 test('pending pairing은 10분이 지나거나 필드가 위조되면 제거한다', () => {

--- a/frontend/src/features/connections/pairing-flow.test.ts
+++ b/frontend/src/features/connections/pairing-flow.test.ts
@@ -47,6 +47,26 @@ describe('mobile pairing flow', () => {
         expect(pause).not.toHaveBeenCalled();
     });
 
+    test('사용자가 승인 대기를 취소하면 추가 완료 확인을 시작하지 않는다', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const complete = vi
+            .fn<(pairingId: string) => Promise<'completed' | 'waiting'>>()
+            .mockResolvedValue('waiting');
+        const pause = vi.fn<(milliseconds: number) => Promise<void>>().mockResolvedValue(undefined);
+
+        await expect(
+            waitForPairingCompletion({
+                pairingId: 'pairing',
+                complete,
+                pause,
+                signal: controller.signal,
+            }),
+        ).rejects.toThrow('PAIRING_CANCELLED');
+        expect(complete).not.toHaveBeenCalled();
+        expect(pause).not.toHaveBeenCalled();
+    });
+
     test('기본 승인 대기는 10분 pairing 유효 시간에 맞춰 600회 확인한다', async () => {
         const complete = vi
             .fn<(pairingId: string) => Promise<'completed' | 'waiting'>>()

--- a/frontend/src/features/connections/pairing-flow.ts
+++ b/frontend/src/features/connections/pairing-flow.ts
@@ -3,6 +3,7 @@ export interface PairingCompletionOptions {
     complete(pairingId: string): Promise<'waiting' | 'completed'>;
     pause(milliseconds: number): Promise<void>;
     maximumAttempts?: number;
+    signal?: AbortSignal;
 }
 
 export type AccountInitializationState =
@@ -60,16 +61,25 @@ export function pairingCompletionErrorIsTerminal(error: unknown): boolean {
     return /EXPIRED|NOT_FOUND|CLAIM|ALREADY_USED|RECEIPT_(?:INVALID|MISSING)/u.test(message);
 }
 
+function throwIfPairingCancelled(signal: AbortSignal | undefined): void {
+    if (signal?.aborted) throw new Error('PAIRING_CANCELLED');
+}
+
 export async function waitForPairingCompletion(options: PairingCompletionOptions): Promise<void> {
     const maximumAttempts = options.maximumAttempts ?? 600;
     for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
+        throwIfPairingCancelled(options.signal);
         try {
             const result = await options.complete(options.pairingId);
+            throwIfPairingCancelled(options.signal);
             if (result === 'completed') return;
             await options.pause(1_000);
+            throwIfPairingCancelled(options.signal);
         } catch (error) {
+            throwIfPairingCancelled(options.signal);
             if (pairingCompletionErrorIsTerminal(error)) throw error;
             await options.pause(3_000);
+            throwIfPairingCancelled(options.signal);
         }
     }
     throw new Error('PAIRING_EXPIRED');

--- a/frontend/src/features/notifications/notification-delivery-setup.test.tsx
+++ b/frontend/src/features/notifications/notification-delivery-setup.test.tsx
@@ -24,11 +24,55 @@ describe('notification delivery setup', () => {
 
     test('모바일은 전송 대기열 등록과 실제 도착 확인을 구분하고 언제든 건너뛸 수 있다', () => {
         expect(source).toContain('알림 연결하고 테스트');
-        expect(source).toContain('1분 안에 도착합니다.');
+        expect(source).not.toContain('1분 안에 도착합니다.');
+        expect(source).toContain('최대 1분 정도 걸릴 수 있습니다.');
         expect(source).toContain('테스트 알림이 실제로 도착했나요?');
         expect(source).toContain('도착했어요');
         expect(source).toContain('도착하지 않았어요');
         expect(source).toContain('나중에');
+    });
+
+    test('권한, 로컬 구독, 서버 등록, 테스트 발송, 실제 도착을 단계별로 표시한다', () => {
+        for (const label of [
+            '알림 권한',
+            '로컬 푸시 구독',
+            '서버 등록',
+            '테스트 발송',
+            '실제 도착 확인',
+        ]) {
+            expect(source).toContain(label);
+        }
+        expect(source).toContain('pushDeliveryStepStates');
+        expect(source).toContain('assertMobileTestNotificationQueued');
+    });
+
+    test('미도착 복구의 다시 보내기는 실제 테스트 API를 다시 실행하고 재등록도 제공한다', () => {
+        expect(source).toContain('onClick={delivery.sendTestNotification}');
+        expect(source).toContain('테스트 다시 보내기');
+        expect(source).toContain('onClick={delivery.reregisterPush}');
+        expect(source).toContain('푸시 재등록');
+        expect(source).toContain('집중 모드');
+    });
+
+    test('푸시 끄기는 서버를 먼저 해제하고 같은 로컬 구독만 제거한다', () => {
+        expect(source).toContain('푸시 끄기');
+        expect(source).toContain('cleanupPushSubscription({');
+        expect(source).toContain('api.unregisterPushSubscription(subscriptionId)');
+        expect(source).toContain('platform.pwa.getPushSubscription()');
+        expect(source).toContain('platform.pwa.unsubscribePush(subscription.endpoint)');
+        expect(source).toContain(
+            '서버 등록을 먼저 해제한 뒤 같은 로컬 구독인지 다시 확인하고 제거합니다.',
+        );
+        expect(source).toContain('푸시 끄기 다시 시도');
+        expect(source).not.toMatch(/<Button[^>]*disabled[^>]*>\s*푸시 끄기/u);
+    });
+
+    test('재시작 때 저장 메타데이터와 실제 로컬 구독을 대조해 상태를 복구한다', () => {
+        expect(source).toContain('readPushSubscriptionMetadata(storage)');
+        expect(source).toContain('reconcilePushSubscriptionState(');
+        expect(source).toContain('restoredPushDeliveryState(');
+        expect(source).toContain('마지막으로 확인한 서버 등록과 일치합니다.');
+        expect(source).toContain('서버 등록 ID가 없어 푸시 정리 완료로 확인하지 않았습니다.');
     });
 
     test('푸시 준비 자체가 실패해도 사용자가 바로 다시 시도할 수 있다', () => {
@@ -40,5 +84,15 @@ describe('notification delivery setup', () => {
         expect(source).toContain('setShowSystemSettingsShortcut(!result.systemDelivered)');
         expect(source).toContain('운영체제 알림을 표시하지 못했습니다.');
         expect(source).toContain('<SystemNotificationSettingsButton />');
+    });
+
+    test('PC 운영체제 호출 성공도 사용자가 실제 표시를 확인해야 완료한다', () => {
+        expect(source).toContain(
+            "setDesktopArrival(result.systemDelivered ? 'confirming' : 'missing')",
+        );
+        expect(source).not.toContain('setDesktopDeliveryConfirmed(result.systemDelivered)');
+        expect(source).toContain('PC 테스트 알림이 실제로 보였나요?');
+        expect(source).toContain('보였어요');
+        expect(source).toContain('보이지 않았어요');
     });
 });

--- a/frontend/src/features/notifications/notification-delivery-setup.tsx
+++ b/frontend/src/features/notifications/notification-delivery-setup.tsx
@@ -2,6 +2,14 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {BellRing, Check, Send, Smartphone} from 'lucide-react';
 import {useState} from 'react';
 
+import {
+    cleanupPushSubscription,
+    readPushSubscriptionMetadata,
+    reconcilePushSubscriptionState,
+    type PushSubscriptionCleanupResult,
+    type PushSubscriptionLifecycleStorage,
+    type PushSubscriptionReconciliation,
+} from '@/api/push-subscription-lifecycle';
 import {useDashboardAccount} from '@/app/dashboard-account';
 import {queryKeys, useDashboardEnvironment} from '@/app/dashboard-context';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
@@ -15,10 +23,107 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 
-import {desktopTestNotificationMessage, mobilePushErrorMessage} from './notification-result';
+import {
+    assertMobileTestNotificationQueued,
+    desktopTestNotificationMessage,
+    mobilePushErrorMessage,
+} from './notification-result';
+import {
+    pushDeliveryStepStates,
+    reducePushDeliveryState,
+    restoredPushDeliveryState,
+    type PushDeliveryEvent,
+    type PushDeliveryState,
+    type PushDeliveryStepId,
+    type PushDeliveryStepStatus,
+} from './push-delivery-state';
+import {
+    preparePushSubscriptionRegistration,
+    storePushSubscriptionRegistration,
+} from './push-registration';
 import {SystemNotificationSettingsButton} from './system-notification-settings';
 
-type MobileArrivalState = 'idle' | 'confirming' | 'missing';
+type DesktopArrivalState = 'confirmed' | 'confirming' | 'idle' | 'missing';
+
+const PUSH_SUBSCRIPTION_LIFECYCLE_QUERY_KEY = ['push-subscription-lifecycle'] as const;
+
+const PUSH_DELIVERY_STEP_LABELS: Record<PushDeliveryStepId, string> = {
+    permission: '알림 권한',
+    'local-subscription': '로컬 푸시 구독',
+    'server-registration': '서버 등록',
+    'test-send': '테스트 발송',
+    arrival: '실제 도착 확인',
+};
+
+const PUSH_DELIVERY_STATUS_LABELS: Record<PushDeliveryStepStatus, string> = {
+    complete: '완료',
+    current: '현재 단계',
+    error: '확인 필요',
+    waiting: '대기',
+};
+
+function pushPermissionDenied(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        (error.message === 'PUSH_PERMISSION_DENIED' || error.name === 'NotAllowedError')
+    );
+}
+
+function pushSubscriptionStorage(): PushSubscriptionLifecycleStorage {
+    try {
+        return window.localStorage;
+    } catch (error) {
+        throw new Error('PUSH_REGISTRATION_STORAGE_UNAVAILABLE', {cause: error});
+    }
+}
+
+function pushReconciliationMessage(state: PushSubscriptionReconciliation | undefined): string {
+    switch (state?.status) {
+        case 'matched-registered':
+            return '현재 로컬 구독이 마지막으로 확인한 서버 등록과 일치합니다.';
+        case 'matched-server-removed':
+            return '서버 등록은 제거됐지만 로컬 구독 해제가 남았습니다. 푸시 끄기를 다시 시도하세요.';
+        case 'local-only':
+            return '현재 로컬 구독은 있지만 서버 등록 ID가 없습니다. 푸시를 재등록해 복구하세요.';
+        case 'record-only':
+            return '저장된 서버 등록은 있지만 현재 로컬 구독이 없습니다. 푸시 끄기로 서버 등록을 정리하세요.';
+        case 'mismatch':
+            return '현재 로컬 구독과 저장된 서버 등록이 다릅니다. 푸시를 재등록해 복구하세요.';
+        case 'invalid':
+            return '저장된 푸시 등록 정보를 검증하지 못했습니다. 재등록 전 과거 서버 정리는 확인할 수 없습니다.';
+        case 'failed':
+            return '푸시 등록 정보를 읽거나 현재 구독과 대조하지 못했습니다.';
+        default:
+            return '';
+    }
+}
+
+function pushCleanupMessage(result: PushSubscriptionCleanupResult): string {
+    if (result.status === 'complete') {
+        return '서버 푸시 등록과 이 기기의 로컬 구독을 모두 해제했습니다.';
+    }
+    if (result.status === 'not-verified') {
+        return '저장된 서버 등록 ID가 없어 푸시 정리 완료로 확인하지 않았습니다.';
+    }
+    switch (result.error.code) {
+        case 'registration-id-missing':
+            return '로컬 구독은 있지만 서버 등록 ID가 없습니다. 푸시를 재등록한 뒤 다시 끄세요.';
+        case 'endpoint-mismatch':
+        case 'endpoint-verification-failed':
+            return '현재 로컬 구독이 저장된 등록과 달라 중단했습니다. 푸시를 재등록한 뒤 다시 끄세요.';
+        case 'server-unregister-failed':
+            return '서버 등록을 해제하지 못해 로컬 구독은 유지했습니다. 네트워크를 확인하고 다시 시도하세요.';
+        case 'local-unsubscribe-failed':
+            return result.error.cause instanceof Error &&
+                result.error.cause.message === 'PUSH_SUBSCRIPTION_CHANGED'
+                ? '해제 도중 로컬 구독이 바뀌어 새 구독은 건드리지 않았습니다. 현재 상태를 확인한 뒤 다시 시도하세요.'
+                : '서버 등록은 해제했지만 로컬 구독 해제에 실패했습니다. 다시 시도하세요.';
+        case 'local-unsubscribe-rejected':
+            return '서버 등록은 해제했지만 브라우저가 로컬 구독 해제를 완료하지 못했습니다. 다시 시도하세요.';
+        default:
+            return '푸시 정리가 일부만 끝났습니다. 현재 상태를 확인한 뒤 다시 시도하세요.';
+    }
+}
 
 function useNotificationDeliverySetup() {
     const {api, platform} = useDashboardEnvironment();
@@ -27,8 +132,9 @@ function useNotificationDeliverySetup() {
     const desktop = platform.capabilities.localNotifications;
     const [deliveryMessage, setDeliveryMessage] = useState('');
     const [showSystemSettingsShortcut, setShowSystemSettingsShortcut] = useState(false);
-    const [desktopDeliveryConfirmed, setDesktopDeliveryConfirmed] = useState(false);
-    const [mobileArrival, setMobileArrival] = useState<MobileArrivalState>('idle');
+    const [desktopArrival, setDesktopArrival] = useState<DesktopArrivalState>('idle');
+    const [pushDeliveryState, setPushDeliveryState] = useState<PushDeliveryState | null>(null);
+    const [pushCleanupNeedsRetry, setPushCleanupNeedsRetry] = useState(false);
     const pushSetup = useQuery({
         queryKey: queryKeys.pushSetup,
         queryFn: async () => {
@@ -41,18 +147,109 @@ function useNotificationDeliverySetup() {
         enabled: !desktop && account.personalAccess.status === 'connected',
         staleTime: 5 * 60_000,
     });
+    const pushLifecycle = useQuery({
+        queryKey: PUSH_SUBSCRIPTION_LIFECYCLE_QUERY_KEY,
+        queryFn: async () => {
+            const storage = pushSubscriptionStorage();
+            const [localSubscription] = await Promise.all([
+                platform.pwa.getPushSubscription(),
+                platform.pwa.preparePush(),
+            ]);
+            return reconcilePushSubscriptionState(
+                readPushSubscriptionMetadata(storage),
+                localSubscription,
+            );
+        },
+        enabled: !desktop && account.personalAccess.status === 'connected',
+    });
+    const restoredState = restoredPushDeliveryState(pushLifecycle.data?.status ?? 'none');
+    const effectivePushDeliveryState = pushDeliveryState ?? restoredState;
+
+    const transitionPushDelivery = (event: PushDeliveryEvent) => {
+        setPushDeliveryState((state) => reducePushDeliveryState(state ?? restoredState, event));
+    };
 
     const registerStartedPush = async (subscriptionPromise: Promise<PushSubscriptionJSON>) => {
-        const subscription = await subscriptionPromise;
-        await api.registerPushSubscription(subscription);
+        let subscription: PushSubscriptionJSON;
+        try {
+            subscription = await subscriptionPromise;
+            transitionPushDelivery({type: 'local-subscribed'});
+        } catch (error) {
+            transitionPushDelivery({
+                type: pushPermissionDenied(error)
+                    ? 'permission-denied'
+                    : 'local-subscription-failed',
+            });
+            throw error;
+        }
+
+        try {
+            const storage = pushSubscriptionStorage();
+            const preparation = await preparePushSubscriptionRegistration({
+                storage,
+                subscription,
+                unregisterServer: (subscriptionId) =>
+                    api.unregisterPushSubscription(subscriptionId),
+            });
+            const subscriptionId = await api.registerPushSubscription(subscription);
+            const metadata = await storePushSubscriptionRegistration({
+                storage,
+                subscription,
+                subscriptionId,
+            });
+            client.setQueryData(PUSH_SUBSCRIPTION_LIFECYCLE_QUERY_KEY, {
+                status: 'matched-registered',
+                metadata,
+            } satisfies PushSubscriptionReconciliation);
+            transitionPushDelivery({type: 'server-registered'});
+            return preparation;
+        } catch (error) {
+            transitionPushDelivery({type: 'server-registration-failed'});
+            void client.invalidateQueries({queryKey: PUSH_SUBSCRIPTION_LIFECYCLE_QUERY_KEY});
+            throw error;
+        }
     };
 
     const push = useMutation({
-        onMutate: () => setDeliveryMessage(''),
+        onMutate: () => {
+            setDeliveryMessage('');
+            transitionPushDelivery({type: 'connection-started'});
+        },
         mutationFn: registerStartedPush,
-        onSuccess: async () => {
-            setDeliveryMessage('이 기기에서 푸시 알림을 받을 수 있습니다.');
+        onSuccess: async (result) => {
+            setPushCleanupNeedsRetry(false);
+            setDeliveryMessage(
+                result.priorCleanup === 'unverified'
+                    ? '현재 푸시 구독은 서버에 등록했습니다. 손상된 이전 등록 정보의 서버 정리 여부는 확인하지 못했습니다.'
+                    : '이 기기의 푸시 구독을 서버에 등록했습니다. 테스트 알림을 보내 실제 도착을 확인하세요.',
+            );
             await client.invalidateQueries({queryKey: queryKeys.mobileSessions});
+        },
+    });
+
+    const disablePush = useMutation({
+        onMutate: () => {
+            setDeliveryMessage('');
+            setPushCleanupNeedsRetry(false);
+        },
+        mutationFn: () =>
+            cleanupPushSubscription({
+                storage: pushSubscriptionStorage(),
+                getLocalSubscription: () => platform.pwa.getPushSubscription(),
+                unregisterServer: (subscriptionId) =>
+                    api.unregisterPushSubscription(subscriptionId),
+                unsubscribeLocal: (subscription) => {
+                    if (typeof subscription.endpoint !== 'string' || !subscription.endpoint) {
+                        throw new Error('PUSH_SUBSCRIPTION_ENDPOINT_INVALID');
+                    }
+                    return platform.pwa.unsubscribePush(subscription.endpoint);
+                },
+            }),
+        onSuccess: async (result) => {
+            setPushDeliveryState(null);
+            setPushCleanupNeedsRetry(result.status === 'incomplete');
+            setDeliveryMessage(pushCleanupMessage(result));
+            await pushLifecycle.refetch();
         },
     });
 
@@ -60,26 +257,32 @@ function useNotificationDeliverySetup() {
         onMutate: () => {
             setDeliveryMessage('');
             setShowSystemSettingsShortcut(false);
-            setDesktopDeliveryConfirmed(false);
-            setMobileArrival('idle');
+            setDesktopArrival('idle');
+            if (!desktop) transitionPushDelivery({type: 'test-started'});
         },
         mutationFn: async (subscriptionPromise: Promise<PushSubscriptionJSON> | undefined) => {
             if (desktop) return api.sendDesktopTestNotification();
             if (!subscriptionPromise) throw new Error('PUSH_SUBSCRIPTION_NOT_STARTED');
             await registerStartedPush(subscriptionPromise);
-            return api.sendMobileTestNotification();
+            transitionPushDelivery({type: 'test-started'});
+            try {
+                return assertMobileTestNotificationQueued(await api.sendMobileTestNotification());
+            } catch (error) {
+                transitionPushDelivery({type: 'test-failed'});
+                throw error;
+            }
         },
         onSuccess: async (result) => {
             if (desktop && typeof result === 'object' && result !== null && 'snapshot' in result) {
                 client.setQueryData(queryKeys.notifications('desktop'), result.snapshot);
                 setDeliveryMessage(desktopTestNotificationMessage(result));
                 setShowSystemSettingsShortcut(!result.systemDelivered);
-                setDesktopDeliveryConfirmed(result.systemDelivered);
+                setDesktopArrival(result.systemDelivered ? 'confirming' : 'missing');
             } else if (typeof result === 'number') {
+                transitionPushDelivery({type: 'test-queued', queued: result});
                 setDeliveryMessage(
-                    `연결된 모바일 ${result}대의 테스트 푸시를 전송 대기열에 추가했습니다. 1분 안에 도착합니다.`,
+                    `연결된 모바일 ${result}대의 테스트 푸시를 전송 대기열에 추가했습니다. 도착까지 최대 1분 정도 걸릴 수 있으며, 실제 도착을 아래에서 확인해야 합니다.`,
                 );
-                setMobileArrival('confirming');
                 await Promise.all([
                     client.invalidateQueries({queryKey: queryKeys.notifications('browser')}),
                     client.invalidateQueries({queryKey: queryKeys.mobileSessions}),
@@ -93,7 +296,6 @@ function useNotificationDeliverySetup() {
     const connectPush = () => {
         if (!pushSetup.data) return;
         testNotification.reset();
-        setMobileArrival('idle');
         // Start the browser subscription synchronously while this click still
         // owns the browser's transient user activation.
         push.mutate(platform.pwa.subscribePush(pushSetup.data));
@@ -114,21 +316,73 @@ function useNotificationDeliverySetup() {
         desktop,
         deliveryMessage,
         showSystemSettingsShortcut,
-        desktopDeliveryConfirmed,
-        mobileArrival,
-        setMobileArrival,
+        desktopArrival,
+        pushDeliveryState: effectivePushDeliveryState,
+        pushRegistered: effectivePushDeliveryState.serverRegistration === 'complete',
+        pushCleanupNeedsRetry,
+        confirmDesktopArrival: () => setDesktopArrival('confirmed'),
+        reportDesktopArrivalMissing: () => {
+            setDesktopArrival('missing');
+            setShowSystemSettingsShortcut(true);
+        },
+        confirmMobileArrival: () => transitionPushDelivery({type: 'arrival-confirmed'}),
+        reportMobileArrivalMissing: () => transitionPushDelivery({type: 'arrival-missing'}),
         connectPush,
+        reregisterPush: connectPush,
+        disablePush: () => disablePush.mutate(),
         sendTestNotification,
         retryPushSetup: () => void pushSetup.refetch(),
-        preparingPush: !desktop && pushSetup.isFetching,
+        preparingPush: !desktop && (pushSetup.isFetching || pushLifecycle.isFetching),
         pushSetupError: pushSetup.error,
         pushReady: desktop || Boolean(pushSetup.data),
-        busy: push.isPending || testNotification.isPending,
-        error: testNotification.error ?? push.error ?? pushSetup.error,
+        busy: push.isPending || testNotification.isPending || disablePush.isPending,
+        error: testNotification.error ?? push.error ?? disablePush.error ?? pushSetup.error,
+        pushLifecycleError: pushLifecycle.error,
+        pushLifecycleMessage: pushReconciliationMessage(pushLifecycle.data),
     };
 }
 
 type NotificationDelivery = ReturnType<typeof useNotificationDeliverySetup>;
+
+function PushDeliverySteps({state}: {state: PushDeliveryState}) {
+    const steps = pushDeliveryStepStates(state);
+
+    return (
+        <ol aria-label="푸시 알림 연결 단계" className="grid gap-2 sm:grid-cols-5">
+            {steps.map((step, index) => (
+                <li
+                    key={step.id}
+                    aria-current={step.status === 'current' ? 'step' : undefined}
+                    data-status={step.status}
+                    className="flex min-w-0 items-center gap-2 rounded-lg border bg-card px-3 py-2 text-xs sm:flex-col sm:items-start"
+                >
+                    <span
+                        aria-hidden="true"
+                        className={`grid size-5 shrink-0 place-items-center rounded-full text-[0.65rem] font-bold ${
+                            step.status === 'complete'
+                                ? 'bg-primary text-primary-foreground'
+                                : step.status === 'error'
+                                  ? 'bg-destructive text-white'
+                                  : step.status === 'current'
+                                    ? 'bg-primary/15 text-primary'
+                                    : 'bg-muted text-muted-foreground'
+                        }`}
+                    >
+                        {step.status === 'complete' ? <Check className="size-3" /> : index + 1}
+                    </span>
+                    <span className="min-w-0">
+                        <strong className="block leading-4">
+                            {PUSH_DELIVERY_STEP_LABELS[step.id]}
+                        </strong>
+                        <span className="text-muted-foreground">
+                            {PUSH_DELIVERY_STATUS_LABELS[step.status]}
+                        </span>
+                    </span>
+                </li>
+            ))}
+        </ol>
+    );
+}
 
 function NotificationTestButton({
     delivery,
@@ -152,21 +406,38 @@ function NotificationTestButton({
 }
 
 function NotificationDeliveryActions({delivery}: {delivery: NotificationDelivery}) {
+    if (delivery.desktop) {
+        return <NotificationTestButton delivery={delivery} label="테스트 알림" />;
+    }
+
     return (
-        <div className="flex flex-wrap gap-2">
-            {!delivery.desktop ? (
+        <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
                 <Button
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={delivery.connectPush}
+                    onClick={delivery.reregisterPush}
                     disabled={delivery.busy || !delivery.pushReady}
                 >
                     <Smartphone aria-hidden="true" className="size-4" />
-                    푸시 연결
+                    {delivery.pushRegistered ? '푸시 재등록' : '푸시 연결'}
                 </Button>
-            ) : null}
-            <NotificationTestButton delivery={delivery} label="테스트 알림" />
+                <NotificationTestButton delivery={delivery} label="테스트 알림" />
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={delivery.disablePush}
+                    disabled={delivery.busy}
+                >
+                    {delivery.pushCleanupNeedsRetry ? '푸시 끄기 다시 시도' : '푸시 끄기'}
+                </Button>
+            </div>
+            <div role="note" className="space-y-1 text-xs leading-5 text-muted-foreground">
+                <p>서버 등록을 먼저 해제한 뒤 같은 로컬 구독인지 다시 확인하고 제거합니다.</p>
+                <p>알림 권한은 브라우저 또는 기기 설정의 Jungle Bell 항목에서 변경하세요.</p>
+            </div>
         </div>
     );
 }
@@ -177,6 +448,15 @@ function NotificationDeliveryFeedback({delivery}: {delivery: NotificationDeliver
             <p aria-live="polite" className="text-sm text-muted-foreground">
                 푸시 기능을 준비하고 있습니다.
             </p>
+        );
+    }
+    if (delivery.pushLifecycleError && !delivery.error) {
+        return (
+            <Alert variant="destructive">
+                <Smartphone aria-hidden="true" />
+                <AlertTitle>푸시 상태를 확인하지 못했습니다.</AlertTitle>
+                <AlertDescription>페이지를 새로고침한 뒤 다시 시도하세요.</AlertDescription>
+            </Alert>
         );
     }
     if (delivery.error) {
@@ -204,24 +484,150 @@ function NotificationDeliveryFeedback({delivery}: {delivery: NotificationDeliver
             </Alert>
         );
     }
-    if (!delivery.deliveryMessage) return null;
-    if (delivery.showSystemSettingsShortcut) {
+    const message = delivery.deliveryMessage || delivery.pushLifecycleMessage;
+    if (!message) return null;
+    return (
+        <p aria-live="polite" className="text-sm text-muted-foreground">
+            {message}
+        </p>
+    );
+}
+
+function NotificationArrivalConfirmation({
+    delivery,
+    onComplete,
+}: {
+    delivery: NotificationDelivery;
+    onComplete?: () => void;
+}) {
+    if (delivery.desktop) {
+        if (delivery.desktopArrival === 'confirming') {
+            return (
+                <Alert>
+                    <BellRing aria-hidden="true" />
+                    <AlertTitle>PC 테스트 알림이 실제로 보였나요?</AlertTitle>
+                    <AlertDescription className="gap-3">
+                        <p>운영체제 표시 호출은 성공했습니다. 화면에서 본 결과를 선택하세요.</p>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                type="button"
+                                size="sm"
+                                onClick={() => {
+                                    delivery.confirmDesktopArrival();
+                                    onComplete?.();
+                                }}
+                            >
+                                보였어요
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={delivery.reportDesktopArrivalMissing}
+                            >
+                                보이지 않았어요
+                            </Button>
+                        </div>
+                    </AlertDescription>
+                </Alert>
+            );
+        }
+        if (delivery.desktopArrival === 'missing') {
+            return (
+                <Alert variant="destructive" aria-live="polite">
+                    <Send aria-hidden="true" />
+                    <AlertTitle>운영체제 알림을 표시하지 못했습니다.</AlertTitle>
+                    <AlertDescription className="gap-3">
+                        <p>알림 권한과 집중 모드를 확인한 뒤 테스트를 다시 보내세요.</p>
+                        {delivery.showSystemSettingsShortcut ? (
+                            <SystemNotificationSettingsButton />
+                        ) : null}
+                        <NotificationTestButton delivery={delivery} label="테스트 다시 보내기" />
+                    </AlertDescription>
+                </Alert>
+            );
+        }
+        if (delivery.desktopArrival === 'confirmed') {
+            return (
+                <p aria-live="polite" className="text-sm text-emerald-700 dark:text-emerald-300">
+                    PC 테스트 알림의 실제 도착을 확인했습니다.
+                </p>
+            );
+        }
+        return null;
+    }
+
+    if (delivery.pushDeliveryState.arrival === 'current') {
         return (
-            <Alert variant="destructive" aria-live="polite">
-                <Send aria-hidden="true" />
-                <AlertTitle>운영체제 알림을 표시하지 못했습니다.</AlertTitle>
+            <Alert>
+                <BellRing aria-hidden="true" />
+                <AlertTitle>테스트 알림이 실제로 도착했나요?</AlertTitle>
                 <AlertDescription className="gap-3">
-                    <p>{delivery.deliveryMessage}</p>
-                    <SystemNotificationSettingsButton />
+                    <p>최대 1분 정도 걸릴 수 있습니다. 화면을 닫아도 알림이 와야 합니다.</p>
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            type="button"
+                            size="sm"
+                            onClick={() => {
+                                delivery.confirmMobileArrival();
+                                onComplete?.();
+                            }}
+                        >
+                            도착했어요
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={delivery.reportMobileArrivalMissing}
+                        >
+                            도착하지 않았어요
+                        </Button>
+                    </div>
                 </AlertDescription>
             </Alert>
         );
     }
-    return (
-        <p aria-live="polite" className="text-sm text-muted-foreground">
-            {delivery.deliveryMessage}
-        </p>
-    );
+    if (delivery.pushDeliveryState.arrival === 'error') {
+        return (
+            <Alert variant="destructive">
+                <Smartphone aria-hidden="true" />
+                <AlertTitle>휴대폰 알림 설정을 확인해 주세요.</AlertTitle>
+                <AlertDescription className="gap-3">
+                    <p>
+                        Jungle Bell 알림 권한과 집중 모드를 확인하세요. 재등록을 먼저 시도하거나
+                        테스트 알림을 실제로 다시 보낼 수 있습니다.
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={delivery.sendTestNotification}
+                        >
+                            테스트 다시 보내기
+                        </Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            onClick={delivery.reregisterPush}
+                        >
+                            푸시 재등록
+                        </Button>
+                    </div>
+                </AlertDescription>
+            </Alert>
+        );
+    }
+    if (delivery.pushDeliveryState.arrival === 'complete') {
+        return (
+            <p aria-live="polite" className="text-sm text-emerald-700 dark:text-emerald-300">
+                테스트 푸시의 실제 도착을 확인했습니다.
+            </p>
+        );
+    }
+    return null;
 }
 
 export function NotificationDeliverySection() {
@@ -239,8 +645,10 @@ export function NotificationDeliverySection() {
                         : '이 기기에서 운영체제 푸시 알림을 받습니다.'}
                 </p>
             </div>
+            {!delivery.desktop ? <PushDeliverySteps state={delivery.pushDeliveryState} /> : null}
             <NotificationDeliveryActions delivery={delivery} />
             <NotificationDeliveryFeedback delivery={delivery} />
+            <NotificationArrivalConfirmation delivery={delivery} />
         </section>
     );
 }
@@ -263,11 +671,14 @@ export function NotificationOnboardingCard({
                 <CardTitle>알림 확인 (선택)</CardTitle>
                 <CardDescription>
                     {delivery.desktop
-                        ? '테스트 알림을 보내 PC의 운영체제 알림이 보이는지 확인합니다.'
+                        ? '테스트 알림을 보내 PC의 운영체제 알림이 실제로 보이는지 확인합니다.'
                         : '푸시를 연결하고 테스트 알림이 휴대폰에 실제로 도착하는지 확인합니다.'}
                 </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
+                {!delivery.desktop ? (
+                    <PushDeliverySteps state={delivery.pushDeliveryState} />
+                ) : null}
                 <div className="flex flex-wrap gap-2">
                     <NotificationTestButton
                         delivery={delivery}
@@ -275,57 +686,7 @@ export function NotificationOnboardingCard({
                     />
                 </div>
                 <NotificationDeliveryFeedback delivery={delivery} />
-
-                {delivery.desktopDeliveryConfirmed ? (
-                    <Button type="button" size="sm" onClick={onComplete}>
-                        <Check aria-hidden="true" className="size-4" />
-                        알림 확인 완료
-                    </Button>
-                ) : null}
-
-                {!delivery.desktop && delivery.mobileArrival === 'confirming' ? (
-                    <Alert>
-                        <BellRing aria-hidden="true" />
-                        <AlertTitle>테스트 알림이 실제로 도착했나요?</AlertTitle>
-                        <AlertDescription className="gap-3">
-                            <p>최대 1분 정도 걸릴 수 있습니다. 화면을 닫아도 알림이 와야 합니다.</p>
-                            <div className="flex flex-wrap gap-2">
-                                <Button type="button" size="sm" onClick={onComplete}>
-                                    도착했어요
-                                </Button>
-                                <Button
-                                    type="button"
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() => delivery.setMobileArrival('missing')}
-                                >
-                                    도착하지 않았어요
-                                </Button>
-                            </div>
-                        </AlertDescription>
-                    </Alert>
-                ) : null}
-
-                {!delivery.desktop && delivery.mobileArrival === 'missing' ? (
-                    <Alert variant="destructive">
-                        <Smartphone aria-hidden="true" />
-                        <AlertTitle>휴대폰 알림 설정을 확인해 주세요.</AlertTitle>
-                        <AlertDescription className="gap-2">
-                            <p>
-                                Jungle Bell 알림 권한과 집중 모드를 확인한 뒤 테스트 알림을 다시
-                                보내세요.
-                            </p>
-                            <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() => delivery.setMobileArrival('idle')}
-                            >
-                                다시 시도
-                            </Button>
-                        </AlertDescription>
-                    </Alert>
-                ) : null}
+                <NotificationArrivalConfirmation delivery={delivery} onComplete={onComplete} />
             </CardContent>
             <CardFooter>
                 <Button type="button" size="sm" variant="ghost" onClick={onSkip}>

--- a/frontend/src/features/notifications/notification-result.test.ts
+++ b/frontend/src/features/notifications/notification-result.test.ts
@@ -2,7 +2,11 @@ import {describe, expect, test} from 'vitest';
 
 import type {DesktopTestNotificationResult} from '@/api/dashboard-api';
 
-import {desktopTestNotificationMessage, mobilePushErrorMessage} from './notification-result';
+import {
+    assertMobileTestNotificationQueued,
+    desktopTestNotificationMessage,
+    mobilePushErrorMessage,
+} from './notification-result';
 
 const result = (
     systemDelivered: boolean,
@@ -24,9 +28,10 @@ describe('desktop test notification result', () => {
     });
 
     test('PC와 모바일 성공 범위를 구분한다', () => {
-        expect(desktopTestNotificationMessage(result(true, 0))).toContain(
-            '연결된 모바일 푸시는 없습니다',
-        );
+        const pcOnly = desktopTestNotificationMessage(result(true, 0));
+        expect(pcOnly).toContain('표시를 요청했습니다');
+        expect(pcOnly).not.toContain('표시했습니다');
+        expect(pcOnly).toContain('연결된 모바일 푸시는 없습니다');
         expect(desktopTestNotificationMessage(result(true, 2))).toContain('모바일 2대');
     });
 });
@@ -50,5 +55,22 @@ describe('mobile push error result', () => {
 
     test('알 수 없는 오류는 재시도 안내를 한다', () => {
         expect(mobilePushErrorMessage(new Error('NETWORK_ERROR'))).toContain('다시 시도');
+    });
+
+    test('등록 메타데이터 저장 실패를 서버 등록 성공으로 표시하지 않는다', () => {
+        expect(
+            mobilePushErrorMessage(new Error('PUSH_REGISTRATION_METADATA_WRITE_FAILED')),
+        ).toContain('등록 정보를 저장하지 못했습니다');
+        expect(
+            mobilePushErrorMessage(new Error('PUSH_PREVIOUS_REGISTRATION_CLEANUP_FAILED')),
+        ).toContain('이전 서버 등록을 정리하지 못했습니다');
+    });
+
+    test('테스트 대상 0대는 성공 결과로 통과시키지 않는다', () => {
+        expect(() => assertMobileTestNotificationQueued(0)).toThrow('PUSH_TEST_NO_TARGETS');
+        expect(assertMobileTestNotificationQueued(2)).toBe(2);
+        expect(mobilePushErrorMessage(new Error('PUSH_TEST_NO_TARGETS'))).toContain(
+            '전송할 기기가 없습니다',
+        );
     });
 });

--- a/frontend/src/features/notifications/notification-result.ts
+++ b/frontend/src/features/notifications/notification-result.ts
@@ -3,13 +3,13 @@ import type {DesktopTestNotificationResult} from '@/api/dashboard-api';
 export function desktopTestNotificationMessage(result: DesktopTestNotificationResult): string {
     if (result.systemDelivered && result.mobileQueued !== null) {
         return result.mobileQueued > 0
-            ? `PC와 연결된 모바일 ${result.mobileQueued}대에 테스트 알림을 보냈습니다.`
-            : 'PC 운영체제 알림을 표시했습니다. 연결된 모바일 푸시는 없습니다.';
+            ? `PC 운영체제에 표시를 요청했고, 연결된 모바일 ${result.mobileQueued}대의 테스트 푸시를 전송 대기열에 추가했습니다.`
+            : 'PC 운영체제에 알림 표시를 요청했습니다. 연결된 모바일 푸시는 없습니다.';
     }
     if (result.systemDelivered)
-        return 'PC 알림은 표시했지만 모바일 테스트 전송은 확인하지 못했습니다.';
+        return 'PC 운영체제에 알림 표시를 요청했지만 모바일 테스트 전송은 확인하지 못했습니다.';
     if (result.mobileQueued !== null && result.mobileQueued > 0) {
-        return `모바일 ${result.mobileQueued}대에는 보냈지만 PC 운영체제 알림은 실패했습니다.`;
+        return `모바일 ${result.mobileQueued}대의 전송 대기열에는 추가했지만 PC 운영체제 알림은 실패했습니다.`;
     }
     return '알림함에는 추가했지만 운영체제 알림을 표시하지 못했습니다. 알림 권한을 확인하세요.';
 }
@@ -29,8 +29,27 @@ export function mobilePushErrorMessage(error: unknown): string {
     if (code === 'WEB_PUSH_NOT_CONFIGURED') {
         return '서버의 Web Push 설정이 완료되지 않았습니다.';
     }
+    if (code === 'PUSH_TEST_NO_TARGETS' || code === 'PUSH_SUBSCRIPTION_REQUIRED') {
+        return '테스트 알림을 전송할 기기가 없습니다. 푸시를 재등록한 뒤 다시 보내세요.';
+    }
     if (code === 'AUTHENTICATION_REQUIRED' || code === 'SESSION_EXPIRED') {
         return 'PC 연결이 만료됐습니다. 기기를 다시 연결하세요.';
     }
+    if (
+        code === 'PUSH_REGISTRATION_STORAGE_UNAVAILABLE' ||
+        code === 'PUSH_REGISTRATION_METADATA_READ_FAILED' ||
+        code === 'PUSH_REGISTRATION_METADATA_WRITE_FAILED' ||
+        code === 'PUSH_REGISTRATION_METADATA_CLEAR_FAILED'
+    ) {
+        return '이 기기에 푸시 등록 정보를 저장하지 못했습니다. 브라우저 저장 공간을 확인한 뒤 다시 시도하세요.';
+    }
+    if (code === 'PUSH_PREVIOUS_REGISTRATION_CLEANUP_FAILED') {
+        return '이전 서버 등록을 정리하지 못했습니다. 네트워크를 확인하고 다시 시도하세요.';
+    }
     return '푸시 연결 중 오류가 발생했습니다. 네트워크를 확인하고 다시 시도하세요.';
+}
+
+export function assertMobileTestNotificationQueued(queued: number): number {
+    if (!Number.isSafeInteger(queued) || queued <= 0) throw new Error('PUSH_TEST_NO_TARGETS');
+    return queued;
 }

--- a/frontend/src/features/notifications/notifications-page.test.tsx
+++ b/frontend/src/features/notifications/notifications-page.test.tsx
@@ -39,6 +39,10 @@ const desktopNotification: NotificationInboxItem = {
 };
 
 describe('notification row navigation semantics', () => {
+    test('건너뛴 뒤에도 찾을 수 있는 푸시 설정 진입점을 알림 화면에 유지한다', () => {
+        expect(pageSource).toContain('<NotificationDeliverySection />');
+    });
+
     test('companion 알림 경로는 실제 링크로 렌더링한다', () => {
         const markup = renderToStaticMarkup(
             <NotificationRow
@@ -141,7 +145,7 @@ describe('notification center information architecture', () => {
     });
 
     test('새 푸시 연결이나 테스트를 시작할 때 이전 성공 문구를 지운다', () => {
-        expect(deliverySource.match(/setDeliveryMessage\(''\)/gu)).toHaveLength(2);
+        expect(deliverySource.match(/setDeliveryMessage\(''\)/gu)).toHaveLength(3);
         expect(deliverySource).toContain('setShowSystemSettingsShortcut(false)');
     });
 
@@ -158,7 +162,7 @@ describe('notification center information architecture', () => {
 
     test('테스트 Push는 Worker 전달 주기를 사용자에게 명확히 안내한다', () => {
         expect(deliverySource).toContain(
-            '테스트 푸시를 전송 대기열에 추가했습니다. 1분 안에 도착합니다.',
+            '테스트 푸시를 전송 대기열에 추가했습니다. 도착까지 최대 1분 정도 걸릴 수 있으며, 실제 도착을 아래에서 확인해야 합니다.',
         );
     });
 

--- a/frontend/src/features/notifications/push-delivery-state.test.ts
+++ b/frontend/src/features/notifications/push-delivery-state.test.ts
@@ -1,0 +1,105 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+    createPushDeliveryState,
+    pushDeliveryStepStates,
+    reducePushDeliveryState,
+    restoredPushDeliveryState,
+} from './push-delivery-state';
+
+describe('push delivery state machine', () => {
+    test('재시작 뒤 실제 로컬 구독과 저장된 등록이 일치할 때만 등록 단계를 복구한다', () => {
+        expect(restoredPushDeliveryState('matched-registered')).toEqual({
+            permission: 'complete',
+            localSubscription: 'complete',
+            serverRegistration: 'complete',
+            testSend: 'current',
+            arrival: 'waiting',
+        });
+
+        for (const status of [
+            'matched-server-removed',
+            'local-only',
+            'record-only',
+            'mismatch',
+            'invalid',
+            'failed',
+        ] as const) {
+            expect(restoredPushDeliveryState(status).serverRegistration).not.toBe('complete');
+        }
+    });
+
+    test('등록 기록과 로컬 구독이 모두 없어도 정리 성공으로 추론하지 않는다', () => {
+        expect(restoredPushDeliveryState('none')).toEqual(createPushDeliveryState('default'));
+    });
+
+    test('권한부터 실제 도착 확인까지 순서대로 한 단계만 활성화한다', () => {
+        let state = createPushDeliveryState('default');
+
+        expect(pushDeliveryStepStates(state).map(({status}) => status)).toEqual([
+            'current',
+            'waiting',
+            'waiting',
+            'waiting',
+            'waiting',
+        ]);
+
+        state = reducePushDeliveryState(state, {type: 'local-subscribed'});
+        expect(pushDeliveryStepStates(state).map(({status}) => status)).toEqual([
+            'complete',
+            'complete',
+            'current',
+            'waiting',
+            'waiting',
+        ]);
+
+        state = reducePushDeliveryState(state, {type: 'server-registered'});
+        expect(pushDeliveryStepStates(state).map(({status}) => status)).toEqual([
+            'complete',
+            'complete',
+            'complete',
+            'current',
+            'waiting',
+        ]);
+
+        state = reducePushDeliveryState(state, {type: 'test-queued', queued: 1});
+        expect(pushDeliveryStepStates(state).map(({status}) => status)).toEqual([
+            'complete',
+            'complete',
+            'complete',
+            'complete',
+            'current',
+        ]);
+
+        state = reducePushDeliveryState(state, {type: 'arrival-confirmed'});
+        expect(pushDeliveryStepStates(state).at(-1)?.status).toBe('complete');
+    });
+
+    test('테스트 대상 0대는 성공이나 실제 도착 확인 단계가 아니다', () => {
+        let state = createPushDeliveryState('granted');
+        state = reducePushDeliveryState(state, {type: 'local-subscribed'});
+        state = reducePushDeliveryState(state, {type: 'server-registered'});
+        state = reducePushDeliveryState(state, {type: 'test-queued', queued: 0});
+
+        const steps = pushDeliveryStepStates(state);
+        expect(steps.find(({id}) => id === 'test-send')?.status).toBe('error');
+        expect(steps.find(({id}) => id === 'arrival')?.status).toBe('waiting');
+    });
+
+    test('권한 거부와 미도착은 실패 지점을 보존해 해당 단계에서 복구한다', () => {
+        const denied = createPushDeliveryState('denied');
+        expect(pushDeliveryStepStates(denied)[0]?.status).toBe('error');
+
+        let missing = createPushDeliveryState('granted');
+        missing = reducePushDeliveryState(missing, {type: 'local-subscribed'});
+        missing = reducePushDeliveryState(missing, {type: 'server-registered'});
+        missing = reducePushDeliveryState(missing, {type: 'test-queued', queued: 1});
+        missing = reducePushDeliveryState(missing, {type: 'arrival-missing'});
+        expect(pushDeliveryStepStates(missing).at(-1)?.status).toBe('error');
+
+        missing = reducePushDeliveryState(missing, {type: 'test-started'});
+        expect(pushDeliveryStepStates(missing).find(({id}) => id === 'test-send')?.status).toBe(
+            'current',
+        );
+    });
+});

--- a/frontend/src/features/notifications/push-delivery-state.ts
+++ b/frontend/src/features/notifications/push-delivery-state.ts
@@ -1,0 +1,166 @@
+export type PushPermissionState = 'default' | 'denied' | 'granted';
+
+export type PushDeliveryStepId =
+    | 'permission'
+    | 'local-subscription'
+    | 'server-registration'
+    | 'test-send'
+    | 'arrival';
+
+export type PushDeliveryStepStatus = 'complete' | 'current' | 'error' | 'waiting';
+
+export interface PushDeliveryStepState {
+    id: PushDeliveryStepId;
+    status: PushDeliveryStepStatus;
+}
+
+export interface PushDeliveryState {
+    permission: PushDeliveryStepStatus;
+    localSubscription: PushDeliveryStepStatus;
+    serverRegistration: PushDeliveryStepStatus;
+    testSend: PushDeliveryStepStatus;
+    arrival: PushDeliveryStepStatus;
+}
+
+export type RestoredPushSubscriptionStatus =
+    | 'matched-registered'
+    | 'matched-server-removed'
+    | 'local-only'
+    | 'record-only'
+    | 'mismatch'
+    | 'none'
+    | 'invalid'
+    | 'failed';
+
+export type PushDeliveryEvent =
+    | {type: 'connection-started'}
+    | {type: 'permission-denied'}
+    | {type: 'local-subscription-failed'}
+    | {type: 'local-subscribed'}
+    | {type: 'server-registration-failed'}
+    | {type: 'server-registered'}
+    | {type: 'test-started'}
+    | {type: 'test-failed'}
+    | {type: 'test-queued'; queued: number}
+    | {type: 'arrival-confirmed'}
+    | {type: 'arrival-missing'};
+
+export function createPushDeliveryState(permission: PushPermissionState): PushDeliveryState {
+    return {
+        permission:
+            permission === 'granted' ? 'complete' : permission === 'denied' ? 'error' : 'current',
+        localSubscription: permission === 'granted' ? 'current' : 'waiting',
+        serverRegistration: 'waiting',
+        testSend: 'waiting',
+        arrival: 'waiting',
+    };
+}
+
+export function restoredPushDeliveryState(
+    status: RestoredPushSubscriptionStatus,
+): PushDeliveryState {
+    if (status === 'matched-registered') {
+        return {
+            permission: 'complete',
+            localSubscription: 'complete',
+            serverRegistration: 'complete',
+            testSend: 'current',
+            arrival: 'waiting',
+        };
+    }
+    if (status === 'matched-server-removed' || status === 'local-only' || status === 'mismatch') {
+        return {
+            permission: 'complete',
+            localSubscription: 'complete',
+            serverRegistration: 'error',
+            testSend: 'waiting',
+            arrival: 'waiting',
+        };
+    }
+    if (status === 'record-only') {
+        return {
+            permission: 'complete',
+            localSubscription: 'error',
+            serverRegistration: 'error',
+            testSend: 'waiting',
+            arrival: 'waiting',
+        };
+    }
+    if (status === 'invalid' || status === 'failed') {
+        return {
+            ...createPushDeliveryState('default'),
+            serverRegistration: 'error',
+        };
+    }
+    return createPushDeliveryState('default');
+}
+
+export function reducePushDeliveryState(
+    state: PushDeliveryState,
+    event: PushDeliveryEvent,
+): PushDeliveryState {
+    switch (event.type) {
+        case 'connection-started':
+            return createPushDeliveryState('default');
+        case 'permission-denied':
+            return createPushDeliveryState('denied');
+        case 'local-subscription-failed':
+            return {
+                ...state,
+                permission: 'complete',
+                localSubscription: 'error',
+                serverRegistration: 'waiting',
+                testSend: 'waiting',
+                arrival: 'waiting',
+            };
+        case 'local-subscribed':
+            return {
+                permission: 'complete',
+                localSubscription: 'complete',
+                serverRegistration: 'current',
+                testSend: 'waiting',
+                arrival: 'waiting',
+            };
+        case 'server-registration-failed':
+            return {
+                ...state,
+                serverRegistration: 'error',
+                testSend: 'waiting',
+                arrival: 'waiting',
+            };
+        case 'server-registered':
+            return {
+                permission: 'complete',
+                localSubscription: 'complete',
+                serverRegistration: 'complete',
+                testSend: 'current',
+                arrival: 'waiting',
+            };
+        case 'test-started':
+            if (state.serverRegistration !== 'complete') return state;
+            return {...state, testSend: 'current', arrival: 'waiting'};
+        case 'test-failed':
+            if (state.serverRegistration !== 'complete') return state;
+            return {...state, testSend: 'error', arrival: 'waiting'};
+        case 'test-queued':
+            if (event.queued <= 0) return {...state, testSend: 'error', arrival: 'waiting'};
+            return {...state, testSend: 'complete', arrival: 'current'};
+        case 'arrival-confirmed':
+            if (state.testSend !== 'complete') return state;
+            return {...state, arrival: 'complete'};
+        case 'arrival-missing':
+            if (state.testSend !== 'complete') return state;
+            return {...state, arrival: 'error'};
+    }
+    return state;
+}
+
+export function pushDeliveryStepStates(state: PushDeliveryState): PushDeliveryStepState[] {
+    return [
+        {id: 'permission', status: state.permission},
+        {id: 'local-subscription', status: state.localSubscription},
+        {id: 'server-registration', status: state.serverRegistration},
+        {id: 'test-send', status: state.testSend},
+        {id: 'arrival', status: state.arrival},
+    ];
+}

--- a/frontend/src/features/notifications/push-registration.test.ts
+++ b/frontend/src/features/notifications/push-registration.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, test, vi} from 'vitest';
+
+import {
+    PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY,
+    type PushSubscriptionLifecycleStorage,
+} from '@/api/push-subscription-lifecycle';
+
+import {
+    preparePushSubscriptionRegistration,
+    storePushSubscriptionRegistration,
+} from './push-registration';
+
+class MemoryStorage implements PushSubscriptionLifecycleStorage {
+    readonly values = new Map<string, string>();
+
+    getItem(key: string): string | null {
+        return this.values.get(key) ?? null;
+    }
+
+    setItem(key: string, value: string): void {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string): void {
+        this.values.delete(key);
+    }
+}
+
+const subscription = (endpoint: string): PushSubscriptionJSON => ({
+    endpoint,
+    expirationTime: null,
+    keys: {auth: 'auth', p256dh: 'p256dh'},
+});
+
+describe('push registration metadata', () => {
+    test('검증된 등록 ID와 endpoint 지문만 저장한다', async () => {
+        const storage = new MemoryStorage();
+        const endpoint = 'https://push.example/subscription/private';
+
+        const metadata = await storePushSubscriptionRegistration({
+            storage,
+            subscription: subscription(endpoint),
+            subscriptionId: `jbps_${'a'.repeat(64)}`,
+        });
+
+        expect(metadata.cleanupPhase).toBe('registered');
+        expect(metadata.endpointFingerprint).toMatch(/^sha256:[0-9a-f]{64}$/u);
+        expect(storage.getItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY)).not.toContain(endpoint);
+    });
+
+    test('같은 로컬 구독 재등록은 기존 서버 등록을 먼저 지우지 않는다', async () => {
+        const storage = new MemoryStorage();
+        const local = subscription('https://push.example/subscription/same');
+        await storePushSubscriptionRegistration({
+            storage,
+            subscription: local,
+            subscriptionId: `jbps_${'b'.repeat(64)}`,
+        });
+        const unregisterServer = vi.fn<(id: string) => Promise<void>>(async () => undefined);
+
+        await expect(
+            preparePushSubscriptionRegistration({storage, subscription: local, unregisterServer}),
+        ).resolves.toEqual({status: 'ready', priorCleanup: 'not-needed'});
+        expect(unregisterServer).not.toHaveBeenCalled();
+    });
+
+    test('바뀐 endpoint의 옛 서버 등록을 먼저 제거한 뒤 메타데이터를 비운다', async () => {
+        const storage = new MemoryStorage();
+        await storePushSubscriptionRegistration({
+            storage,
+            subscription: subscription('https://push.example/subscription/old'),
+            subscriptionId: `jbps_${'c'.repeat(64)}`,
+        });
+        const order: string[] = [];
+        const unregisterServer = vi.fn<(id: string) => Promise<void>>(async () => {
+            order.push('server');
+        });
+        const originalRemove = storage.removeItem.bind(storage);
+        storage.removeItem = (key) => {
+            order.push('metadata');
+            originalRemove(key);
+        };
+
+        await expect(
+            preparePushSubscriptionRegistration({
+                storage,
+                subscription: subscription('https://push.example/subscription/new'),
+                unregisterServer,
+            }),
+        ).resolves.toEqual({status: 'ready', priorCleanup: 'removed'});
+        expect(order).toEqual(['server', 'metadata']);
+    });
+
+    test('옛 서버 등록 제거 실패 시 새 등록으로 덮어쓰지 않도록 중단한다', async () => {
+        const storage = new MemoryStorage();
+        await storePushSubscriptionRegistration({
+            storage,
+            subscription: subscription('https://push.example/subscription/old'),
+            subscriptionId: `jbps_${'d'.repeat(64)}`,
+        });
+        const before = storage.getItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY);
+
+        await expect(
+            preparePushSubscriptionRegistration({
+                storage,
+                subscription: subscription('https://push.example/subscription/new'),
+                unregisterServer: async () => {
+                    throw new Error('NETWORK_ERROR');
+                },
+            }),
+        ).rejects.toThrow('PUSH_PREVIOUS_REGISTRATION_CLEANUP_FAILED');
+        expect(storage.getItem(PUSH_SUBSCRIPTION_LIFECYCLE_STORAGE_KEY)).toBe(before);
+    });
+});

--- a/frontend/src/features/notifications/push-registration.ts
+++ b/frontend/src/features/notifications/push-registration.ts
@@ -1,0 +1,76 @@
+import {
+    clearPushSubscriptionMetadata,
+    fingerprintPushSubscriptionEndpoint,
+    matchesPushSubscriptionEndpoint,
+    readPushSubscriptionMetadata,
+    writePushSubscriptionMetadata,
+    type PushSubscriptionLifecycleStorage,
+    type PushSubscriptionMetadata,
+} from '@/api/push-subscription-lifecycle';
+
+interface PushRegistrationStorageOptions {
+    storage: PushSubscriptionLifecycleStorage;
+    subscription: PushSubscriptionJSON;
+}
+
+export async function storePushSubscriptionRegistration({
+    storage,
+    subscription,
+    subscriptionId,
+}: PushRegistrationStorageOptions & {subscriptionId: string}): Promise<PushSubscriptionMetadata> {
+    if (typeof subscription.endpoint !== 'string' || !subscription.endpoint) {
+        throw new Error('PUSH_SUBSCRIPTION_ENDPOINT_INVALID');
+    }
+    const metadata: PushSubscriptionMetadata = {
+        version: 1,
+        subscriptionId,
+        endpointFingerprint: await fingerprintPushSubscriptionEndpoint(subscription.endpoint),
+        cleanupPhase: 'registered',
+    };
+    if (writePushSubscriptionMetadata(storage, metadata).status !== 'written') {
+        throw new Error('PUSH_REGISTRATION_METADATA_WRITE_FAILED');
+    }
+    return metadata;
+}
+
+export async function preparePushSubscriptionRegistration({
+    storage,
+    subscription,
+    unregisterServer,
+}: PushRegistrationStorageOptions & {
+    unregisterServer: (subscriptionId: string) => Promise<void>;
+}): Promise<{
+    status: 'ready';
+    priorCleanup: 'not-needed' | 'removed' | 'unverified';
+}> {
+    const stored = readPushSubscriptionMetadata(storage);
+    if (stored.status === 'failed') throw new Error('PUSH_REGISTRATION_METADATA_READ_FAILED');
+    if (stored.status === 'invalid') {
+        assertMetadataCleared(storage);
+        return {status: 'ready', priorCleanup: 'unverified'};
+    }
+    if (stored.status === 'missing') {
+        return {status: 'ready', priorCleanup: 'not-needed'};
+    }
+    if (await matchesPushSubscriptionEndpoint(subscription, stored.metadata)) {
+        return {status: 'ready', priorCleanup: 'not-needed'};
+    }
+
+    if (stored.metadata.cleanupPhase === 'registered') {
+        try {
+            await unregisterServer(stored.metadata.subscriptionId);
+        } catch (error) {
+            if (!(error instanceof Error && error.message === 'PUSH_SUBSCRIPTION_NOT_FOUND')) {
+                throw new Error('PUSH_PREVIOUS_REGISTRATION_CLEANUP_FAILED', {cause: error});
+            }
+        }
+    }
+    assertMetadataCleared(storage);
+    return {status: 'ready', priorCleanup: 'removed'};
+}
+
+function assertMetadataCleared(storage: PushSubscriptionLifecycleStorage): void {
+    if (clearPushSubscriptionMetadata(storage).status !== 'cleared') {
+        throw new Error('PUSH_REGISTRATION_METADATA_CLEAR_FAILED');
+    }
+}

--- a/frontend/src/platform/contracts.ts
+++ b/frontend/src/platform/contracts.ts
@@ -131,6 +131,8 @@ export interface PwaCapabilityAdapter {
     subscribeInstallPrompt(listener: (prompt: PwaInstallPrompt) => void): PlatformUnlisten;
     isMobileInstallClient(): boolean;
     subscribePush(applicationServerKey: string): Promise<PushSubscriptionJSON>;
+    getPushSubscription(): Promise<PushSubscriptionJSON | null>;
+    unsubscribePush(expectedEndpoint: string): Promise<boolean>;
 }
 
 export type UsagePreferenceScope = 'anonymous';
@@ -176,6 +178,12 @@ export function unavailablePwaAdapter(): PwaCapabilityAdapter {
         subscribeInstallPrompt: () => () => undefined,
         isMobileInstallClient: () => false,
         subscribePush: async () => {
+            throw new PlatformCapabilityUnavailableError('webPush');
+        },
+        getPushSubscription: async () => {
+            throw new PlatformCapabilityUnavailableError('webPush');
+        },
+        unsubscribePush: async () => {
             throw new PlatformCapabilityUnavailableError('webPush');
         },
     };

--- a/frontend/src/platform/platform-adapter.test.ts
+++ b/frontend/src/platform/platform-adapter.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, it, vi} from 'vitest';
 
 import type {NativeBridge, PwaCapabilityAdapter} from './contracts';
-import {PlatformCapabilityUnavailableError, unavailableEventAdapter} from './contracts';
+import {
+    PlatformCapabilityUnavailableError,
+    unavailableEventAdapter,
+    unavailablePwaAdapter,
+} from './contracts';
 import {createTauriPlatformAdapter} from './tauri/adapter';
 import {createWebPlatformAdapter} from './web/adapter';
 
@@ -42,10 +46,23 @@ function pwaAdapter(installed: boolean): PwaCapabilityAdapter {
         ),
         isMobileInstallClient: vi.fn<PwaCapabilityAdapter['isMobileInstallClient']>(() => false),
         subscribePush: vi.fn<PwaCapabilityAdapter['subscribePush']>(),
+        getPushSubscription: vi.fn<PwaCapabilityAdapter['getPushSubscription']>(),
+        unsubscribePush: vi.fn<PwaCapabilityAdapter['unsubscribePush']>(),
     };
 }
 
 describe('PlatformAdapter', () => {
+    it('사용할 수 없는 PWA Push 조회와 해제 계약은 capability 오류로 실패한다', async () => {
+        const pwa = unavailablePwaAdapter();
+
+        await expect(pwa.getPushSubscription()).rejects.toEqual(
+            new PlatformCapabilityUnavailableError('webPush'),
+        );
+        await expect(pwa.unsubscribePush('https://push.example/subscription')).rejects.toEqual(
+            new PlatformCapabilityUnavailableError('webPush'),
+        );
+    });
+
     it('일반 웹에서는 개인 인증과 Push를 주입하지 않는다', async () => {
         const platform = createWebPlatformAdapter(pwaAdapter(false));
 

--- a/frontend/src/platform/pwa/adapter.test.ts
+++ b/frontend/src/platform/pwa/adapter.test.ts
@@ -8,15 +8,24 @@ function browserObjects(
     options: {
         standalone?: boolean;
         iosStandalone?: boolean;
+        existingSubscription?: boolean;
     } = {},
 ) {
+    const unsubscribe = vi.fn<PushSubscription['unsubscribe']>(async () => true);
+    const toJSON = vi.fn<() => PushSubscriptionJSON>(() => ({
+        endpoint: 'https://push.example/subscription',
+    }));
     const subscription = {
-        toJSON: vi.fn<PushSubscription['toJSON']>(() => ({
-            endpoint: 'https://push.example/subscription',
-        })),
+        endpoint: 'https://push.example/subscription',
+        toJSON,
+        unsubscribe,
     } as unknown as PushSubscription;
+    const getSubscription = vi.fn<PushManager['getSubscription']>(async () =>
+        options.existingSubscription === false ? null : subscription,
+    );
     const pushManager = {
         subscribe: vi.fn<PushManager['subscribe']>(async () => subscription),
+        getSubscription,
     };
     const registration = {pushManager} as unknown as ServiceWorkerRegistration;
     const register = vi.fn<ServiceWorkerContainer['register']>(async () => registration);
@@ -35,7 +44,16 @@ function browserObjects(
         serviceWorker,
         standalone: options.iosStandalone ?? false,
     } as unknown as Navigator;
-    return {navigatorObject, pushManager, register, subscription, windowObject};
+    return {
+        navigatorObject,
+        getSubscription,
+        pushManager,
+        register,
+        subscription,
+        toJSON,
+        unsubscribe,
+        windowObject,
+    };
 }
 
 describe('PwaCapabilityAdapter', () => {
@@ -156,6 +174,114 @@ describe('PwaCapabilityAdapter', () => {
         });
     });
 
+    it('현재 로컬 Push 구독을 조회하고 직렬화한다', async () => {
+        const browser = browserObjects();
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        await expect(adapter.getPushSubscription()).resolves.toEqual({
+            endpoint: 'https://push.example/subscription',
+        });
+
+        expect(browser.register).toHaveBeenCalledOnce();
+        expect(browser.getSubscription).toHaveBeenCalledOnce();
+        expect(browser.toJSON).toHaveBeenCalledOnce();
+    });
+
+    it('현재 로컬 Push 구독이 없으면 null을 반환한다', async () => {
+        const browser = browserObjects({existingSubscription: false});
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        await expect(adapter.getPushSubscription()).resolves.toBeNull();
+    });
+
+    it('현재 로컬 Push 구독을 찾아 실제 브라우저 구독을 해제한다', async () => {
+        const browser = browserObjects();
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        await expect(adapter.unsubscribePush('https://push.example/subscription')).resolves.toBe(
+            true,
+        );
+
+        expect(browser.pushManager.getSubscription).toHaveBeenCalledOnce();
+        expect(browser.unsubscribe).toHaveBeenCalledOnce();
+    });
+
+    it('해제할 로컬 Push 구독이 없으면 false를 반환한다', async () => {
+        const browser = browserObjects({existingSubscription: false});
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        await expect(adapter.unsubscribePush('https://push.example/subscription')).resolves.toBe(
+            false,
+        );
+        expect(browser.unsubscribe).not.toHaveBeenCalled();
+    });
+
+    it('조회와 해제 전 과정에서 같은 서비스 워커 등록을 재사용한다', async () => {
+        const browser = browserObjects();
+        browser.getSubscription
+            .mockResolvedValueOnce(browser.subscription)
+            .mockResolvedValueOnce(browser.subscription)
+            .mockResolvedValueOnce(null);
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        await expect(adapter.getPushSubscription()).resolves.toEqual({
+            endpoint: 'https://push.example/subscription',
+        });
+        await expect(adapter.unsubscribePush('https://push.example/subscription')).resolves.toBe(
+            true,
+        );
+        await expect(adapter.getPushSubscription()).resolves.toBeNull();
+
+        expect(browser.register).toHaveBeenCalledOnce();
+        expect(browser.getSubscription).toHaveBeenCalledTimes(3);
+        expect(browser.unsubscribe).toHaveBeenCalledOnce();
+    });
+
+    it('조회 이후 구독 endpoint가 바뀌면 다른 구독을 해제하지 않는다', async () => {
+        const browser = browserObjects();
+        const replacementUnsubscribe = vi.fn<PushSubscription['unsubscribe']>(async () => true);
+        const replacement = {
+            endpoint: 'https://push.example/replacement',
+            unsubscribe: replacementUnsubscribe,
+        } as unknown as PushSubscription;
+        browser.getSubscription
+            .mockResolvedValueOnce(browser.subscription)
+            .mockResolvedValueOnce(replacement);
+        const adapter = createPwaCapabilityAdapter({
+            production: true,
+            windowObject: browser.windowObject,
+            navigatorObject: browser.navigatorObject,
+        });
+
+        const observed = await adapter.getPushSubscription();
+
+        await expect(adapter.unsubscribePush(observed?.endpoint ?? '')).rejects.toThrow(
+            'PUSH_SUBSCRIPTION_CHANGED',
+        );
+        expect(browser.unsubscribe).not.toHaveBeenCalled();
+        expect(replacementUnsubscribe).not.toHaveBeenCalled();
+    });
+
     it('지원되지 않는 브라우저에서는 Push 요청 전에 실패한다', async () => {
         const windowObject = new EventTarget() as unknown as Window;
         const navigatorObject = {userAgent: 'test'} as Navigator;
@@ -167,5 +293,9 @@ describe('PwaCapabilityAdapter', () => {
 
         await expect(adapter.preparePush()).rejects.toThrow('PUSH_UNSUPPORTED');
         await expect(adapter.subscribePush('AQ')).rejects.toThrow('PUSH_UNSUPPORTED');
+        await expect(adapter.getPushSubscription()).rejects.toThrow('PUSH_UNSUPPORTED');
+        await expect(adapter.unsubscribePush('https://push.example/subscription')).rejects.toThrow(
+            'PUSH_UNSUPPORTED',
+        );
     });
 });

--- a/frontend/src/platform/pwa/adapter.ts
+++ b/frontend/src/platform/pwa/adapter.ts
@@ -92,7 +92,29 @@ export function createPwaCapabilityAdapter(options: {
                 return Promise.reject(error);
             }
         },
+        async getPushSubscription() {
+            assertPushSupported(windowObject, navigatorObject);
+            const registration = await startServiceWorker();
+            const subscription = await registration.pushManager.getSubscription();
+            return subscription?.toJSON() ?? null;
+        },
+        async unsubscribePush(expectedEndpoint) {
+            assertPushSupported(windowObject, navigatorObject);
+            const registration = await startServiceWorker();
+            const subscription = await registration.pushManager.getSubscription();
+            if (!subscription) return false;
+            if (subscription.endpoint !== expectedEndpoint) {
+                throw new Error('PUSH_SUBSCRIPTION_CHANGED');
+            }
+            return subscription.unsubscribe();
+        },
     };
+}
+
+function assertPushSupported(windowObject: Window, navigatorObject: Navigator): void {
+    if (!('serviceWorker' in navigatorObject) || !('PushManager' in windowObject)) {
+        throw new Error('PUSH_UNSUPPORTED');
+    }
 }
 
 function installedPwa(windowObject: Window, navigatorObject: Navigator): boolean {


### PR DESCRIPTION
# 요약

앱 상태 화면과 푸시·페어링·기기 연결 해제 수명주기를 구현합니다.

- 권한 → 로컬 구독 → 서버 등록 → 발송 → 실제 도착 확인
- 서버/로컬 구독 해제의 부분 실패 복구와 재등록
- pairing TTL·취소·재생성·재수화
- 대상 확인·중복 방지·정리 후 기기 연결 해제

# 스택

8/9, base: `codex/issue-69-07-platform-lifecycle`

# 검증

- 독립 worktree: 성공
- `npm run check`: 125개 파일, 760개 테스트 통과
- `npm run build:web`: PWA 산출물 검증 통과
- 서버 Gradle 검사·실행 JAR 생성: 20개 작업 통과

Refs #69
