### PR TITLE
chore(release): 0.6.0-beta.0 버전 반영

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "jungle-bell"
-version = "0.5.9"
+version = "0.6.0-beta.0"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jungle-bell"
-version = "0.5.9"
+version = "0.6.0-beta.0"
 description = "Krafton Jungle attendance check reminder"
 authors = ["sijun-yang"]
 edition = "2021"

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Jungle Bell",
-  "version": "0.5.9",
+  "version": "0.6.0-beta.0",
   "identifier": "dev.sijun-yang.jungle-bell.v2",
   "build": {
     "beforeDevCommand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.5.9",
+  "version": "0.6.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jungle-bell-frontend",
-      "version": "0.5.9",
+      "version": "0.6.0-beta.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.29",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.5.9",
+  "version": "0.6.0-beta.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "app.junglebell"
-    version = "0.5.9"
+    version = "0.6.0-beta.0"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 변경 사항
- 프론트엔드, 서버, 데스크톱 버전을 0.6.0-beta.0으로 정렬
- Cargo.lock의 애플리케이션 버전만 갱신

## 검증
- npm test -- src/tests/contracts/release-channel.test.ts
- cargo metadata --locked --no-deps --format-version 1
- pre-commit hooks