### PR TITLE
chore(release): bump version to 0.6.0-beta.2

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "jungle-bell"
-version = "0.6.0-beta.1"
+version = "0.6.0-beta.2"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jungle-bell"
-version = "0.6.0-beta.1"
+version = "0.6.0-beta.2"
 description = "Krafton Jungle attendance check reminder"
 authors = ["sijun-yang"]
 edition = "2021"

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Jungle Bell",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "identifier": "dev.sijun-yang.jungle-bell.v2",
   "build": {
     "beforeDevCommand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jungle-bell-frontend",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.0-beta.2",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.29",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "app.junglebell"
-    version = "0.6.0-beta.1"
+    version = "0.6.0-beta.2"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 변경 사항

- 프런트엔드, 서버, Tauri 데스크톱 앱 버전을 0.6.0-beta.2로 정합화
- npm 및 Cargo lockfile의 first-party 패키지 버전 갱신
- 간접 의존성 버전 변경 없음

## 검증

- 릴리즈 채널 계약 테스트 6개 통과
- push hook frontend check 통과
- push hook server check 통과
- push hook desktop test 및 clippy 통과