### PR TITLE
fix: beta.3 UI 밀도와 설정 상태 표시 개선

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "jungle-bell"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 dependencies = [
  "chrono",
  "dirs 6.0.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jungle-bell"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 description = "Krafton Jungle attendance check reminder"
 authors = ["sijun-yang"]
 edition = "2021"

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Jungle Bell",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "identifier": "dev.sijun-yang.jungle-bell.v2",
   "build": {
     "beforeDevCommand": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jungle-bell-frontend",
-      "version": "0.6.0-beta.2",
+      "version": "0.6.0-beta.3",
       "dependencies": {
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.29",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jungle-bell-frontend",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/app/dashboard-route-pages.test.tsx
+++ b/frontend/src/app/dashboard-route-pages.test.tsx
@@ -12,7 +12,10 @@ describe('connections production route wiring', () => {
     test('typed search를 실제 탭과 App Status slot에 연결한다', () => {
         expect(source).toContain("useSearch({from: '/connections'})");
         expect(source).toContain("useNavigate({from: '/connections'})");
-        expect(source).toContain('renderAppStatus={() =>');
+        expect(source).toContain('<AppStatusPage onOpenTab={selectTab}>');
+        expect(source).toContain('{({content, warningCount}) => (');
+        expect(source).toContain('appStatus={content}');
+        expect(source).toContain('appStatusWarningCount={warningCount}');
         expect(source).toContain('<AppStatusPage');
         expect(source).toContain('returnTo={search.returnTo}');
     });

--- a/frontend/src/app/dashboard-route-pages.tsx
+++ b/frontend/src/app/dashboard-route-pages.tsx
@@ -108,12 +108,17 @@ export function ConnectionsRoutePage() {
     );
 
     return (
-        <ConnectionsPage
-            tab={search.tab}
-            returnTo={search.returnTo}
-            onTabChange={selectTab}
-            renderAppStatus={() => <AppStatusPage onOpenTab={selectTab} />}
-        />
+        <AppStatusPage onOpenTab={selectTab}>
+            {({content, warningCount}) => (
+                <ConnectionsPage
+                    tab={search.tab}
+                    returnTo={search.returnTo}
+                    onTabChange={selectTab}
+                    appStatus={content}
+                    appStatusWarningCount={warningCount}
+                />
+            )}
+        </AppStatusPage>
     );
 }
 

--- a/frontend/src/app/settings/notification-settings.test.tsx
+++ b/frontend/src/app/settings/notification-settings.test.tsx
@@ -15,4 +15,9 @@ describe('notification settings', () => {
             settingsSource.indexOf('<MealPreferencesSection />'),
         );
     });
+
+    test('같은 레벨의 설정 카드는 서비스 설정과 같은 간격을 사용한다', () => {
+        expect(settingsSource).toContain('<div className="space-y-4">');
+        expect(settingsSource).not.toContain('space-y-6');
+    });
 });

--- a/frontend/src/app/settings/notification-settings.tsx
+++ b/frontend/src/app/settings/notification-settings.tsx
@@ -4,7 +4,7 @@ import {SystemNotificationSettingsCard} from '@/features/notifications/system-no
 
 export function NotificationSettings() {
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <AttendancePreferencesSection />
             <MealPreferencesSection />
             <SystemNotificationSettingsCard />

--- a/frontend/src/app/shell/DashboardShell.test.tsx
+++ b/frontend/src/app/shell/DashboardShell.test.tsx
@@ -205,6 +205,10 @@ describe('DashboardShell', () => {
         expect(shellSource).toContain('side="right"');
         expect(shellSource).toContain('overlayClassName="backdrop-blur-sm"');
         expect(shellSource).toContain('data-notification-panel="true"');
+        expect(shellSource).toContain('className="w-full gap-0 overflow-hidden sm:max-w-xl"');
+        expect(shellSource).toMatch(
+            /data-notification-panel-scroll="true"[\s\S]*className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"/u,
+        );
         expect(shellSource).toContain('<SheetTitle>알림</SheetTitle>');
         expect(shellSource).not.toContain('keyboardShortcut={null}');
     });

--- a/frontend/src/app/shell/DashboardShell.tsx
+++ b/frontend/src/app/shell/DashboardShell.tsx
@@ -469,7 +469,7 @@ export function DashboardShell({
                         side="right"
                         showCloseButton={false}
                         overlayClassName="backdrop-blur-sm"
-                        className="w-full gap-0 sm:max-w-xl"
+                        className="w-full gap-0 overflow-hidden sm:max-w-xl"
                         aria-describedby={undefined}
                         data-notification-panel="true"
                         onCloseAutoFocus={(event) => {
@@ -490,7 +490,10 @@ export function DashboardShell({
                                 </Button>
                             </SheetClose>
                         </SheetHeader>
-                        <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-5">
+                        <div
+                            data-notification-panel-scroll="true"
+                            className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-5"
+                        >
                             {notificationPanel.content}
                         </div>
                     </SheetContent>

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -46,12 +46,12 @@ function Calendar({
                 ),
                 button_previous: cn(
                     buttonVariants({variant: buttonVariant}),
-                    'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+                    'size-(--cell-size) min-h-(--cell-size) min-w-(--cell-size) p-0 select-none aria-disabled:opacity-50',
                     defaultClassNames.button_previous,
                 ),
                 button_next: cn(
                     buttonVariants({variant: buttonVariant}),
-                    'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+                    'size-(--cell-size) min-h-(--cell-size) min-w-(--cell-size) p-0 select-none aria-disabled:opacity-50',
                     defaultClassNames.button_next,
                 ),
                 month_caption: cn(
@@ -194,7 +194,7 @@ function CalendarDayButton({
             data-range-end={modifiers.range_end}
             data-range-middle={modifiers.range_middle}
             className={cn(
-                'flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70',
+                'flex aspect-square size-auto min-h-(--cell-size) w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70',
                 defaultClassNames.day,
                 className,
             )}

--- a/frontend/src/features/app-status/app-status-model.test.ts
+++ b/frontend/src/features/app-status/app-status-model.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, test} from 'vitest';
 
 import type {DesktopUpdateStatus} from '@/platform/contracts';
 
-import {appStatusRows, type AppStatusInput} from './app-status-model';
+import {appStatusRows, appStatusWarningCount, type AppStatusInput} from './app-status-model';
 
 function update(
     status: DesktopUpdateStatus['status'],
@@ -30,6 +30,18 @@ function row(input: AppStatusInput, id: string) {
 }
 
 describe('app status rows', () => {
+    test('조치가 필요한 attention과 error만 경고 개수에 포함한다', () => {
+        expect(
+            appStatusWarningCount([
+                {status: 'attention'},
+                {status: 'error'},
+                {status: 'checking'},
+                {status: 'ready'},
+                {status: 'unavailable'},
+            ]),
+        ).toBe(2);
+    });
+
     test('PC는 로그인, credential, 동기화, 모바일, OS 알림, 업데이트 상태를 구분한다', () => {
         const input: AppStatusInput = {
             surface: 'desktop',

--- a/frontend/src/features/app-status/app-status-model.ts
+++ b/frontend/src/features/app-status/app-status-model.ts
@@ -867,3 +867,7 @@ export function appStatusRows(input: AppStatusInput, now = Date.now()): AppStatu
     if (input.surface === 'pwa') return pwaRows(input, now);
     return webRows(input);
 }
+
+export function appStatusWarningCount(rows: readonly Pick<AppStatusRowModel, 'status'>[]): number {
+    return rows.filter(({status}) => status === 'attention' || status === 'error').length;
+}

--- a/frontend/src/features/app-status/app-status-page.test.tsx
+++ b/frontend/src/features/app-status/app-status-page.test.tsx
@@ -13,11 +13,14 @@ describe('AppStatusPage', () => {
         expect(rowSource).toContain('row.action');
         expect(panelSource).toContain('AppStatusRow');
         expect(panelSource).toContain('앱 상태');
+        expect(pageSource).toContain('appStatusWarningCount(appStatusRows(input))');
+        expect(pageSource).not.toContain('useEffect');
     });
 
     test('실제 입력이 없으면 producer에 연결된 상태를 렌더링한다', () => {
         expect(pageSource).toContain('if (input)');
         expect(pageSource).toContain('<ConnectedAppStatus');
+        expect(pageSource).toContain('{children}</ConnectedAppStatus>');
         expect(pwaSource).toContain('loadPushSubscriptionReconciliation({');
         expect(pwaSource).toContain('notificationPermissionFromRuntime');
         expect(pwaSource).toContain('readNotificationTestRecord');

--- a/frontend/src/features/app-status/app-status-page.tsx
+++ b/frontend/src/features/app-status/app-status-page.tsx
@@ -1,13 +1,21 @@
 import type {AppStatusInput, AppStatusTab} from './app-status-model';
+import {appStatusRows, appStatusWarningCount} from './app-status-model';
 import {AppStatusPanel} from './app-status-panel';
+import type {AppStatusRenderer} from './app-status-render';
 import {ConnectedAppStatus} from './connected-app-status';
 
 export interface AppStatusPageProps {
+    children?: AppStatusRenderer;
     input?: AppStatusInput;
     onOpenTab?: (tab: AppStatusTab) => void;
 }
 
-export function AppStatusPage({input, onOpenTab}: AppStatusPageProps) {
-    if (input) return <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
-    return <ConnectedAppStatus onOpenTab={onOpenTab} />;
+export function AppStatusPage({children, input, onOpenTab}: AppStatusPageProps) {
+    if (input) {
+        const content = <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+        return children
+            ? children({content, warningCount: appStatusWarningCount(appStatusRows(input))})
+            : content;
+    }
+    return <ConnectedAppStatus onOpenTab={onOpenTab}>{children}</ConnectedAppStatus>;
 }

--- a/frontend/src/features/app-status/app-status-render.ts
+++ b/frontend/src/features/app-status/app-status-render.ts
@@ -1,0 +1,8 @@
+import type {ReactNode} from 'react';
+
+export interface AppStatusRenderState {
+    content: ReactNode;
+    warningCount: number;
+}
+
+export type AppStatusRenderer = (state: AppStatusRenderState) => ReactNode;

--- a/frontend/src/features/app-status/connected-app-status.tsx
+++ b/frontend/src/features/app-status/connected-app-status.tsx
@@ -1,24 +1,37 @@
 import {useDashboardEnvironment} from '@/app/dashboard-context';
 
-import type {AppStatusTab} from './app-status-model';
+import {
+    appStatusRows,
+    appStatusWarningCount,
+    type AppStatusInput,
+    type AppStatusTab,
+} from './app-status-model';
 import {AppStatusPanel} from './app-status-panel';
+import type {AppStatusRenderer} from './app-status-render';
 import {ConnectedDesktopStatus} from './connected-desktop-status';
 import {ConnectedPwaStatus} from './connected-pwa-status';
 
-export function ConnectedAppStatus({onOpenTab}: {onOpenTab?: (tab: AppStatusTab) => void}) {
+export function ConnectedAppStatus({
+    children,
+    onOpenTab,
+}: {
+    children?: AppStatusRenderer;
+    onOpenTab?: (tab: AppStatusTab) => void;
+}) {
     const {platform} = useDashboardEnvironment();
-    if (platform.kind === 'desktop') return <ConnectedDesktopStatus onOpenTab={onOpenTab} />;
-    if (platform.accountAuthentication.kind === 'cookie') {
-        return <ConnectedPwaStatus onOpenTab={onOpenTab} />;
+    if (platform.kind === 'desktop') {
+        return <ConnectedDesktopStatus onOpenTab={onOpenTab}>{children}</ConnectedDesktopStatus>;
     }
-    return (
-        <AppStatusPanel
-            input={{
-                surface: 'web',
-                installSupported: platform.capabilities.pwaInstall && platform.pwa.available,
-                installed: platform.pwa.installed,
-            }}
-            onOpenTab={onOpenTab}
-        />
-    );
+    if (platform.accountAuthentication.kind === 'cookie') {
+        return <ConnectedPwaStatus onOpenTab={onOpenTab}>{children}</ConnectedPwaStatus>;
+    }
+    const input: AppStatusInput = {
+        surface: 'web',
+        installSupported: platform.capabilities.pwaInstall && platform.pwa.available,
+        installed: platform.pwa.installed,
+    };
+    const content = <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+    return children
+        ? children({content, warningCount: appStatusWarningCount(appStatusRows(input))})
+        : content;
 }

--- a/frontend/src/features/app-status/connected-desktop-status-state.test.ts
+++ b/frontend/src/features/app-status/connected-desktop-status-state.test.ts
@@ -7,6 +7,7 @@ import type {AttendanceDashboard} from '@/api/dashboard-api';
 import {
     desktopLastSyncedAt,
     desktopMobileSessionCount,
+    desktopStatusWarningCount,
     failedDesktopStatusProducers,
     retryFailedDesktopStatusProducers,
     type DesktopStatusProducer,
@@ -91,6 +92,7 @@ describe('desktop app-status query state', () => {
         const producers: DesktopStatusProducer[] = [
             {
                 label: 'PC 연결',
+                rowIds: ['lms-authentication', 'server-credential'],
                 data: {cached: true},
                 isError: true,
                 isFetching: false,
@@ -98,6 +100,7 @@ describe('desktop app-status query state', () => {
             },
             {
                 label: '출석 동기화',
+                rowIds: ['last-sync'],
                 data: {cached: true},
                 isError: true,
                 isFetching: false,
@@ -105,6 +108,7 @@ describe('desktop app-status query state', () => {
             },
             {
                 label: '모바일 세션',
+                rowIds: ['mobile-sessions'],
                 data: [],
                 isError: false,
                 isFetching: false,
@@ -120,5 +124,34 @@ describe('desktop app-status query state', () => {
         assert.equal(rejectedRefetch.mock.calls.length, 1);
         assert.equal(resolvedRefetch.mock.calls.length, 1);
         assert.equal(healthyRefetch.mock.calls.length, 0);
+    });
+
+    test('행에 드러나지 않은 producer 실패만 경고 개수에 추가한다', () => {
+        const refetch = vi.fn<() => Promise<void>>(async () => undefined);
+        const failures: DesktopStatusProducer[] = [
+            {
+                label: '출석 동기화',
+                rowIds: ['last-sync'],
+                data: attendance,
+                isError: true,
+                isFetching: false,
+                refetch,
+            },
+            {
+                label: '모바일 세션',
+                rowIds: ['mobile-sessions'],
+                data: [],
+                isError: true,
+                isFetching: false,
+                refetch,
+            },
+        ];
+        const rows = [
+            {id: 'last-sync', status: 'attention' as const},
+            {id: 'mobile-sessions', status: 'unavailable' as const},
+            {id: 'update', status: 'checking' as const},
+        ];
+
+        assert.equal(desktopStatusWarningCount(rows, failures), 2);
     });
 });

--- a/frontend/src/features/app-status/connected-desktop-status-state.ts
+++ b/frontend/src/features/app-status/connected-desktop-status-state.ts
@@ -1,7 +1,7 @@
 import type {AttendanceDashboard, MobileSession} from '@/api/dashboard-api';
 import type {PersonalAccessStatus} from '@/app/dashboard-account-state';
 
-import type {DesktopAppStatusInput} from './app-status-model';
+import type {AppStatusRowModel, DesktopAppStatusInput} from './app-status-model';
 
 interface QuerySnapshot<T> {
     data: T | undefined;
@@ -9,12 +9,21 @@ interface QuerySnapshot<T> {
     isPending: boolean;
 }
 
+export type DesktopStatusRowId =
+    | 'lms-authentication'
+    | 'server-credential'
+    | 'last-sync'
+    | 'mobile-sessions'
+    | 'os-notification'
+    | 'update';
+
 export interface DesktopStatusProducer {
     data: unknown;
     isError: boolean;
     isFetching: boolean;
     label: string;
     refetch: () => Promise<unknown>;
+    rowIds: readonly [DesktopStatusRowId, ...DesktopStatusRowId[]];
 }
 
 export function desktopLastSyncedAt(
@@ -57,6 +66,20 @@ export function failedDesktopStatusProducers(
     producers: readonly DesktopStatusProducer[],
 ): DesktopStatusProducer[] {
     return producers.filter(({isError}) => isError);
+}
+
+export function desktopStatusWarningCount(
+    rows: readonly Pick<AppStatusRowModel, 'id' | 'status'>[],
+    failures: readonly DesktopStatusProducer[],
+): number {
+    const warningRowIds = new Set<string>();
+    for (const {id, status} of rows) {
+        if (status === 'attention' || status === 'error') warningRowIds.add(id);
+    }
+    const unrepresentedFailureCount = failures.filter(
+        ({isError, rowIds}) => isError && rowIds.every((rowId) => !warningRowIds.has(rowId)),
+    ).length;
+    return warningRowIds.size + unrepresentedFailureCount;
 }
 
 export async function retryFailedDesktopStatusProducers(

--- a/frontend/src/features/app-status/connected-desktop-status.test.tsx
+++ b/frontend/src/features/app-status/connected-desktop-status.test.tsx
@@ -18,5 +18,7 @@ describe('ConnectedDesktopStatus', () => {
         expect(source).toContain('일부 앱 상태를 다시 확인하지 못했습니다.');
         expect(source).toContain('실패한 상태 다시 확인');
         expect(source).toContain('retryFailedDesktopStatusProducers(failures)');
+        expect(source).toContain("rowIds: ['mobile-sessions']");
+        expect(source).toContain('desktopStatusWarningCount(appStatusRows(input), failures)');
     });
 });

--- a/frontend/src/features/app-status/connected-desktop-status.tsx
+++ b/frontend/src/features/app-status/connected-desktop-status.tsx
@@ -15,11 +15,14 @@ import {
 } from '@/platform/notification-test-history';
 
 import type {AppStatusTab, DesktopAppStatusInput} from './app-status-model';
+import {appStatusRows} from './app-status-model';
 import {desktopUpdateObservationFromQuery} from './app-status-observations';
 import {AppStatusPanel} from './app-status-panel';
+import type {AppStatusRenderer} from './app-status-render';
 import {
     desktopLastSyncedAt,
     desktopMobileSessionCount,
+    desktopStatusWarningCount,
     failedDesktopStatusProducers,
     retryFailedDesktopStatusProducers,
     type DesktopStatusProducer,
@@ -80,7 +83,13 @@ function DesktopStatusRefreshFailure({failures}: {failures: readonly DesktopStat
     );
 }
 
-export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatusTab) => void}) {
+export function ConnectedDesktopStatus({
+    children,
+    onOpenTab,
+}: {
+    children?: AppStatusRenderer;
+    onOpenTab?: (tab: AppStatusTab) => void;
+}) {
     const account = useDashboardAccount();
     const personalReady =
         account.status.lmsAuthentication === 'authenticated' && serverSessionReady(account.status);
@@ -97,6 +106,7 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
     const failures = failedDesktopStatusProducers([
         {
             label: 'PC 연결',
+            rowIds: ['lms-authentication', 'server-credential'],
             data: account.connectionQuery.data,
             isError: account.connectionQuery.isError,
             isFetching: account.connectionQuery.isFetching,
@@ -104,6 +114,7 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
         },
         {
             label: '출석 동기화',
+            rowIds: ['last-sync'],
             data: attendance.data,
             isError: attendance.isError,
             isFetching: attendance.isFetching,
@@ -111,6 +122,7 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
         },
         {
             label: '모바일 세션',
+            rowIds: ['mobile-sessions'],
             data: sessions.data,
             isError: sessions.isError,
             isFetching: sessions.isFetching,
@@ -118,6 +130,7 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
         },
         {
             label: '알림 테스트 기록',
+            rowIds: ['os-notification'],
             data: notificationTest.data,
             isError: notificationTest.isError,
             isFetching: notificationTest.isFetching,
@@ -125,6 +138,7 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
         },
         {
             label: '앱 업데이트',
+            rowIds: ['update'],
             data: update.data,
             isError: update.isError,
             isFetching: update.isFetching,
@@ -144,10 +158,16 @@ export function ConnectedDesktopStatus({onOpenTab}: {onOpenTab?: (tab: AppStatus
               : restoredNotificationTest,
         update: desktopUpdateObservationFromQuery(update),
     };
-    return (
+    const content = (
         <div className="space-y-4">
             <DesktopStatusRefreshFailure failures={failures} />
             <AppStatusPanel input={input} onOpenTab={onOpenTab} />
         </div>
     );
+    return children
+        ? children({
+              content,
+              warningCount: desktopStatusWarningCount(appStatusRows(input), failures),
+          })
+        : content;
 }

--- a/frontend/src/features/app-status/connected-pwa-status.tsx
+++ b/frontend/src/features/app-status/connected-pwa-status.tsx
@@ -20,6 +20,7 @@ import type {
     PwaAppStatusInput,
     PwaPushLifecycleObservation,
 } from './app-status-model';
+import {appStatusRows, appStatusWarningCount} from './app-status-model';
 import {
     authenticationStateFromProducer,
     notificationPermissionFromRuntime,
@@ -27,6 +28,7 @@ import {
     serviceWorkerObservation,
 } from './app-status-observations';
 import {AppStatusPanel} from './app-status-panel';
+import type {AppStatusRenderer} from './app-status-render';
 
 function pushSubscriptionStorage(): PushSubscriptionLifecycleStorage {
     try {
@@ -67,7 +69,13 @@ function currentNotificationPermission() {
     );
 }
 
-export function ConnectedPwaStatus({onOpenTab}: {onOpenTab?: (tab: AppStatusTab) => void}) {
+export function ConnectedPwaStatus({
+    children,
+    onOpenTab,
+}: {
+    children?: AppStatusRenderer;
+    onOpenTab?: (tab: AppStatusTab) => void;
+}) {
     const account = useDashboardAccount();
     const {platform} = useDashboardEnvironment();
     const pushLifecycle = useQuery({
@@ -115,5 +123,8 @@ export function ConnectedPwaStatus({onOpenTab}: {onOpenTab?: (tab: AppStatusTab)
             ? 'checking'
             : (worker.data ?? {status: 'error', version: packageMetadata.version}),
     };
-    return <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+    const content = <AppStatusPanel input={input} onOpenTab={onOpenTab} />;
+    return children
+        ? children({content, warningCount: appStatusWarningCount(appStatusRows(input))})
+        : content;
 }

--- a/frontend/src/features/attendance/attendance-page.test.tsx
+++ b/frontend/src/features/attendance/attendance-page.test.tsx
@@ -36,4 +36,17 @@ describe('AttendancePage LMS gate', () => {
             "detail.source === 'desktop' ? '마지막 확인' : '마지막 동기화'",
         );
     });
+
+    test('출석 상태와 공식 서비스 카드는 한 화면에서 빠르게 훑을 수 있는 밀도로 표시한다', () => {
+        expect(source).toContain('data-attendance-card="today"');
+        expect(source).toContain('data-attendance-card="campus"');
+        expect(source).toContain('data-attendance-check={label}');
+        expect(normalizedSource).toContain(
+            'className="flex flex-wrap items-baseline justify-between gap-2"',
+        );
+        expect(source).toContain('className="gap-0 py-0"');
+        expect(source).toContain('lg:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.8fr)]');
+        expect(source).not.toContain('xl:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.8fr)]');
+        expect(source).not.toContain('<strong className="mt-3 block text-xl">');
+    });
 });

--- a/frontend/src/features/attendance/attendance-page.tsx
+++ b/frontend/src/features/attendance/attendance-page.tsx
@@ -51,21 +51,20 @@ function calendarDateLabel(value: string): string {
 function AttendanceCheck({label, checked}: {label: string; checked: boolean}) {
     return (
         <div
+            data-attendance-check={label}
             className={
                 checked
-                    ? 'rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-emerald-800 dark:text-emerald-200'
-                    : 'rounded-xl border border-amber-500/20 bg-amber-500/10 p-4 text-amber-900 dark:text-amber-200'
+                    ? 'flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-3 py-2.5 text-emerald-800 dark:text-emerald-200'
+                    : 'flex items-center gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2.5 text-amber-900 dark:text-amber-200'
             }
         >
-            <span className="flex items-center gap-2 text-sm font-medium">
-                {checked ? (
-                    <Check aria-hidden="true" className="size-4" />
-                ) : (
-                    <X aria-hidden="true" className="size-4" />
-                )}
-                {label}
-            </span>
-            <strong className="mt-3 block text-xl">{checked ? '완료' : '미완료'}</strong>
+            {checked ? (
+                <Check aria-hidden="true" className="size-4 shrink-0" />
+            ) : (
+                <X aria-hidden="true" className="size-4 shrink-0" />
+            )}
+            <span className="text-sm font-medium">{label}</span>
+            <strong className="ml-auto text-sm">{checked ? '완료' : '미완료'}</strong>
         </div>
     );
 }
@@ -74,21 +73,21 @@ function AttendanceDevicesCard({devices}: {devices: DesktopDevice[]}) {
     if (devices.length === 0) return null;
 
     return (
-        <Card>
-            <CardHeader>
+        <Card className="gap-0 py-0">
+            <CardHeader className="px-5 py-4">
                 <div>
                     <p className="text-xs font-medium text-muted-foreground">수집 기기</p>
                     <CardTitle className="mt-1">출석 확인 PC</CardTitle>
                 </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className="px-5 pb-4">
                 <ul className="divide-y rounded-xl border">
                     {devices.map((device) => {
                         const status = deviceStatus(device);
                         return (
                             <li
                                 key={device.id}
-                                className="flex items-center justify-between gap-4 p-4"
+                                className="flex items-center justify-between gap-4 p-3"
                             >
                                 <div className="flex min-w-0 items-center gap-3">
                                     <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-muted">
@@ -182,10 +181,10 @@ function AvailableAttendance({
     detail: Extract<AttendanceContentState, {kind: 'available'}>['detail'];
 }) {
     return (
-        <div className="space-y-4">
-            <div>
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
                 <p className="text-xs text-muted-foreground">출석 기준일</p>
-                <p className="mt-1 text-lg font-semibold">
+                <p className="text-sm font-semibold">
                     {calendarDateLabel(detail.snapshot.attendanceDate)}
                 </p>
             </div>
@@ -193,15 +192,17 @@ function AvailableAttendance({
                 <AttendanceCheck label="학습 시작" checked={detail.snapshot.morningChecked} />
                 <AttendanceCheck label="학습 종료" checked={detail.snapshot.eveningChecked} />
             </div>
-            <p className="text-xs text-muted-foreground">
-                {detail.source === 'desktop' ? '마지막 확인' : '마지막 동기화'} ·{' '}
-                {dateTimeLabel(detail.lastSyncedAt)}
-            </p>
-            {detail.syncState === 'pending' ? (
-                <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                    <RefreshCw aria-hidden="true" className="size-3" /> 다른 기기 동기화 대기 중
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                <p>
+                    {detail.source === 'desktop' ? '마지막 확인' : '마지막 동기화'} ·{' '}
+                    {dateTimeLabel(detail.lastSyncedAt)}
                 </p>
-            ) : null}
+                {detail.syncState === 'pending' ? (
+                    <p className="flex items-center gap-1">
+                        <RefreshCw aria-hidden="true" className="size-3" /> 다른 기기 동기화 대기 중
+                    </p>
+                ) : null}
+            </div>
             {detail.freshness === 'stale' ? (
                 <Alert className="border-amber-500/25 bg-amber-500/10 text-amber-900 dark:text-amber-200">
                     <RefreshCw aria-hidden="true" />
@@ -242,11 +243,16 @@ function TodayAttendanceCard({
     retryActions: RetryActions;
 }) {
     return (
-        <Card aria-live="polite" aria-busy={state.attendanceBusy}>
-            <CardHeader>
+        <Card
+            className="gap-0 py-0"
+            data-attendance-card="today"
+            aria-live="polite"
+            aria-busy={state.attendanceBusy}
+        >
+            <CardHeader className="px-5 py-4">
                 <CardTitle>오늘 출석</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="px-5 pb-4">
                 <AttendanceContent content={state.content} retryActions={retryActions} />
             </CardContent>
         </Card>
@@ -269,8 +275,8 @@ function JungleCampusCard({
     onOpen: () => void;
 }) {
     return (
-        <Card className="border-primary/20 bg-primary/5">
-            <CardHeader>
+        <Card className="gap-0 border-primary/20 bg-primary/5 py-0" data-attendance-card="campus">
+            <CardHeader className="px-5 py-4">
                 <div className="flex items-center gap-3">
                     <span className="grid size-10 place-items-center rounded-xl bg-primary/10 text-primary">
                         <CalendarCheck2 aria-hidden="true" className="size-5" />
@@ -281,8 +287,8 @@ function JungleCampusCard({
                     </div>
                 </div>
             </CardHeader>
-            <CardContent className="space-y-3">
-                <CardDescription className="leading-6">
+            <CardContent className="space-y-2 px-5 pb-4">
+                <CardDescription className="leading-5">
                     공식 정글캠퍼스에서 출석 원본 상태를 확인하거나 로그인하세요.
                     {lmsWindow ? ' LMS 세션은 이 PC의 앱에만 저장됩니다.' : ''}
                 </CardDescription>
@@ -298,7 +304,7 @@ function JungleCampusCard({
                     <p className="text-sm text-destructive">정글캠퍼스를 열지 못했습니다.</p>
                 ) : null}
             </CardContent>
-            <CardFooter className="border-t">
+            <CardFooter className="border-t px-5 py-3 [.border-t]:pt-3">
                 {lmsWindow ? (
                     <Button disabled={opening} onClick={onOpen}>
                         {opening ? '여는 중' : '정글캠퍼스 열기'} <ExternalLinkIcon />
@@ -355,7 +361,7 @@ function AttendancePageView({
             />
             <AttendanceRefreshError errorMessage={refreshErrorMessage} />
 
-            <section className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.8fr)]">
+            <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.8fr)]">
                 <TodayAttendanceCard state={state} retryActions={retryActions} />
                 <JungleCampusCard
                     campusNotice={campusNotice}

--- a/frontend/src/features/connections/connections-page.test.tsx
+++ b/frontend/src/features/connections/connections-page.test.tsx
@@ -17,8 +17,10 @@ describe('ConnectionsPage settings information architecture', () => {
         expect(source.match(/<PageHeader title="설정" \/>/gu)).toHaveLength(1);
         expect(source).toContain('value={selectedTab}');
         expect(source).toContain('onValueChange={selectTab}');
-        expect(source).toContain('renderAppStatus ? (');
-        expect(source).toContain('<TabsTrigger value="status">앱 상태</TabsTrigger>');
+        expect(source).toContain('appStatus ? (');
+        expect(source).toContain('<TabsTrigger value="status">');
+        expect(source).toContain('appStatusWarningCount > 0');
+        expect(source).toContain('확인이 필요한 앱 상태 ${appStatusWarningCount}개');
         expect(source).toContain('<TabsTrigger value="notifications">알림</TabsTrigger>');
         expect(source).toContain('<TabsTrigger value="services">서비스</TabsTrigger>');
         expect(source).toContain('<TabsTrigger value="devices">기기 연결</TabsTrigger>');
@@ -29,7 +31,8 @@ describe('ConnectionsPage settings information architecture', () => {
         expect(source).toContain('<TabsContent value="services"');
         expect(source).toContain('<ServiceSettings />');
         expect(source).toContain('<TabsContent value="status"');
-        expect(source).toContain('{renderAppStatus()}');
+        expect(source).toContain('{appStatus}');
+        expect(source).toContain('appStatusWarningCount?: number');
         expect(source).not.toContain('앱 상태 연결 필요');
     });
 

--- a/frontend/src/features/connections/connections-page.tsx
+++ b/frontend/src/features/connections/connections-page.tsx
@@ -1213,20 +1213,22 @@ function WebConnections() {
 }
 
 export interface ConnectionsPageProps {
+    appStatus?: ReactNode;
+    appStatusWarningCount?: number;
     tab?: ConnectionsTab;
     returnTo?: DashboardReturnTarget;
     onTabChange?: (tab: ConnectionsTab) => void;
-    renderAppStatus?: () => ReactNode;
 }
 
 export function ConnectionsPage({
+    appStatus,
+    appStatusWarningCount = 0,
     tab = 'status',
     returnTo,
     onTabChange,
-    renderAppStatus,
 }: ConnectionsPageProps = {}) {
     const {platform} = useDashboardEnvironment();
-    const selectedTab = tab === 'status' && !renderAppStatus ? 'notifications' : tab;
+    const selectedTab = tab === 'status' && !appStatus ? 'notifications' : tab;
     const selectTab = (value: string) => {
         const nextTab = normalizeConnectionsSearch({tab: value}).tab;
         onTabChange?.(nextTab);
@@ -1238,16 +1240,27 @@ export function ConnectionsPage({
             <Tabs value={selectedTab} onValueChange={selectTab} className="gap-5">
                 <TabsList
                     aria-label="설정 구분"
-                    className={`grid h-auto w-full sm:w-fit ${renderAppStatus ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'}`}
+                    className={`grid h-auto w-full sm:w-fit ${appStatus ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-3'}`}
                 >
-                    {renderAppStatus ? <TabsTrigger value="status">앱 상태</TabsTrigger> : null}
+                    {appStatus ? (
+                        <TabsTrigger value="status">
+                            앱 상태
+                            {appStatusWarningCount > 0 ? (
+                                <span
+                                    aria-label={`확인이 필요한 앱 상태 ${appStatusWarningCount}개`}
+                                    aria-live="polite"
+                                    className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-white tabular-nums dark:bg-destructive/60"
+                                >
+                                    {appStatusWarningCount}
+                                </span>
+                            ) : null}
+                        </TabsTrigger>
+                    ) : null}
                     <TabsTrigger value="notifications">알림</TabsTrigger>
                     <TabsTrigger value="services">서비스</TabsTrigger>
                     <TabsTrigger value="devices">기기 연결</TabsTrigger>
                 </TabsList>
-                {renderAppStatus ? (
-                    <TabsContent value="status">{renderAppStatus()}</TabsContent>
-                ) : null}
+                {appStatus ? <TabsContent value="status">{appStatus}</TabsContent> : null}
                 <TabsContent value="notifications">
                     <PersonalAccountGate>
                         <NotificationSettings />

--- a/frontend/src/features/connections/service-settings.test.tsx
+++ b/frontend/src/features/connections/service-settings.test.tsx
@@ -67,10 +67,9 @@ function switchRow(markup: string, label: string): string {
 describe('ServiceSettings', () => {
     test('데스크톱 로컬 기능을 실제 설정 컨트롤로 표시한다', () => {
         const markup = renderSettings();
-        expect(markup).not.toContain('aria-label="자동 업데이트"');
-        expect(source).not.toContain('자동 업데이트를 끌까요?');
-        expect(markup).toContain('항상 새 버전을 확인하며');
-        expect(markup).toContain('항상 사용');
+        expect(markup).not.toContain('자동 업데이트');
+        expect(source).not.toContain('자동 업데이트');
+        expect(source).not.toContain('autoUpdate');
         expect(markup).toContain('로그 폴더');
         expect(markup).toContain('앱 버전');
         expect(markup).toContain('v0.5.0-beta.1');

--- a/frontend/src/features/connections/service-settings.tsx
+++ b/frontend/src/features/connections/service-settings.tsx
@@ -274,17 +274,6 @@ function AppLaunchSettingsCard({
                     disabled={isSaving}
                     onCheckedChange={(checked) => update('autoStart', checked)}
                 />
-                <Separator />
-                <div className="flex items-center justify-between gap-4 py-4">
-                    <div className="min-w-0">
-                        <p className="text-sm font-medium">자동 업데이트</p>
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                            항상 새 버전을 확인하며, 사용 중에는 설치와 재시작을 다음 실행으로
-                            미룹니다.
-                        </p>
-                    </div>
-                    <p className="shrink-0 text-sm text-muted-foreground">항상 사용</p>
-                </div>
             </CardContent>
         </Card>
     );

--- a/frontend/src/features/home/jungle-campus-summary.test.tsx
+++ b/frontend/src/features/home/jungle-campus-summary.test.tsx
@@ -11,7 +11,10 @@ const normalizedSource = source.replace(/\s+/gu, ' ');
 
 describe('JungleCampusSummary', () => {
     it('keeps one fixed-size campus surface and changes only its attendance content', () => {
-        expect(source).toContain('h-[20rem]');
+        expect(source).toContain('h-60');
+        expect(source).not.toContain('h-[20rem]');
+        expect(source).toContain('min-h-16');
+        expect(source).toContain('min-h-11');
         expect(source).not.toContain("surface.kind === 'public'");
         expect(source).toContain('CalendarCheck');
         expect(source).toContain('data-home-campus-status-icon="true"');

--- a/frontend/src/features/home/jungle-campus-summary.tsx
+++ b/frontend/src/features/home/jungle-campus-summary.tsx
@@ -65,10 +65,10 @@ function AttendanceChecks({snapshot}: {snapshot: AttendanceSnapshot}) {
 function CampusCardFrame({children, footer}: {children: React.ReactNode; footer: React.ReactNode}) {
     return (
         <Card
-            className="h-[20rem] gap-0 overflow-hidden border-primary/20 py-0"
+            className="h-60 gap-0 overflow-hidden border-primary/20 py-0"
             data-home-campus-card="true"
         >
-            <CardHeader className="min-h-20 shrink-0 px-5 py-4 sm:px-6">
+            <CardHeader className="min-h-16 shrink-0 px-5 py-3 sm:px-6">
                 <div className="flex items-center gap-3">
                     <span
                         className="grid size-10 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary"
@@ -88,7 +88,7 @@ function CampusCardFrame({children, footer}: {children: React.ReactNode; footer:
             >
                 <div className="flex min-h-full flex-col justify-center gap-3">{children}</div>
             </CardContent>
-            <CardFooter className="min-h-14 shrink-0 flex-wrap gap-2 border-t px-5 py-3 sm:px-6">
+            <CardFooter className="min-h-11 shrink-0 flex-wrap gap-2 border-t px-5 py-1.5 sm:px-6 [.border-t]:pt-1.5">
                 {footer}
             </CardFooter>
         </Card>

--- a/frontend/src/features/laundry/pages/laundry-page.test.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.test.tsx
@@ -65,11 +65,12 @@ describe('LaundryPage capacity summary', () => {
         expect(source).not.toContain('에러 위험 요약');
     });
 
-    it('주요 설명과 이동 링크는 16px 본문·44px 조작·키보드 포커스 계약을 사용한다', () => {
+    it('주요 설명은 16px 본문 계약을 사용하고 중복 섹션 이동 링크를 두지 않는다', () => {
         expect(source).toMatch(/<CardDescription className="text-base leading-6">/u);
         expect(source).toMatch(/<span className="text-base leading-6 font-normal/u);
-        expect(source).toContain('min-h-11');
-        expect(source).toContain('focus-visible:ring-2');
+        expect(source).not.toContain('LAUNDRY_JUMPS');
+        expect(source).not.toContain('LaundryJumpNavigation');
+        expect(source).not.toContain('aria-label="세부 섹션 이동"');
     });
 
     it('페이지 헤더 밖의 local async boundary로 세탁 실패를 격리한다', () => {

--- a/frontend/src/features/laundry/pages/laundry-page.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.tsx
@@ -28,13 +28,6 @@ import {
 
 export {LaundryFeatureBoundary} from '../components/laundry-feature-boundary';
 
-const LAUNDRY_JUMPS = [
-    ['요약', 'laundry-capacity-title'],
-    ['워시타워', 'laundry-tower-title'],
-    ['기기 상세', 'laundry-detail-title'],
-    ['내 알림', 'laundry-watch-title'],
-] as const;
-
 type LaundryFailureKind = 'error' | 'offline' | 'stale';
 
 function isFailureKind(kind: LaundryPageStatus['kind']): kind is LaundryFailureKind {
@@ -184,22 +177,6 @@ function laundryPagePresentation(input: {
 }
 
 type LaundryPagePresentation = ReturnType<typeof laundryPagePresentation>;
-
-function LaundryJumpNavigation() {
-    return (
-        <nav aria-label="세부 섹션 이동" className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            {LAUNDRY_JUMPS.map(([label, anchor]) => (
-                <a
-                    key={anchor}
-                    className="min-h-11 rounded-md border border-border px-3 py-3 text-center text-base leading-6 outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    href={`#${anchor}`}
-                >
-                    {label}
-                </a>
-            ))}
-        </nav>
-    );
-}
 
 function LaundryCapacitySummary({presentation}: {presentation: LaundryPagePresentation}) {
     const {nowMs, snapshot, staleLabel, summaries} = presentation;
@@ -391,7 +368,6 @@ function LaundryPageContent({
                 status={presentation.status}
                 title={presentation.statusTitle}
             />
-            <LaundryJumpNavigation />
             <LaundryCapacitySummary presentation={presentation} />
             <LaundryTowerStatus
                 presentation={presentation}

--- a/frontend/src/features/meals/components/meal-history-calendar.test.tsx
+++ b/frontend/src/features/meals/components/meal-history-calendar.test.tsx
@@ -36,7 +36,16 @@ describe('MealHistoryCalendar', () => {
         expect(markup).toContain('이전 달');
         expect(markup).toContain('다음 달');
         expect(markup).toContain('aria-label="달력 월 이동"');
+        expect(markup).toContain('w-[15.75rem]');
+        expect(markup).toContain('sm:w-[17.5rem]');
+        expect(markup).toContain('overflow-hidden');
+        expect(markup).not.toContain('overflow-x-auto');
         expect(markup).not.toMatch(/<p(?:\s|>)/u);
+
+        const selectedDayButton = markup.match(/<button[^>]+data-day="8\/10\/2026"[^>]*>/u)?.[0];
+        expect(selectedDayButton).toContain('min-h-(--cell-size)');
+        expect(selectedDayButton).toContain('min-w-(--cell-size)');
+        expect(selectedDayButton).not.toContain('min-h-(--hit-area-min)');
     });
 
     it('공식 ShadCN Calendar에 날짜 선택과 월 이동을 위임한다', () => {
@@ -53,6 +62,10 @@ describe('MealHistoryCalendar', () => {
         expect(calendarSource.match(/buttonVariants\(\{variant: buttonVariant\}\)/gu)).toHaveLength(
             2,
         );
+        expect(calendarSource).toContain(
+            "'size-(--cell-size) min-h-(--cell-size) min-w-(--cell-size) p-0 select-none aria-disabled:opacity-50'",
+        );
+        expect(calendarSource).toContain('min-h-(--cell-size) min-w-(--cell-size)');
         expect(calendarSource).not.toContain('PreviousMonthButton:');
         expect(calendarSource).not.toContain('NextMonthButton:');
     });

--- a/frontend/src/features/meals/components/meal-history-calendar.tsx
+++ b/frontend/src/features/meals/components/meal-history-calendar.tsx
@@ -45,7 +45,7 @@ export function MealHistoryCalendar({
     return (
         <Calendar
             aria-label={`${formatMonth(selected)} 급식 기록 달력`}
-            className="w-full p-0 [--cell-size:2.25rem] sm:[--cell-size:2.5rem]"
+            className="w-[15.75rem] shrink-0 overflow-hidden p-0 [--cell-size:2.25rem] sm:w-[17.5rem] sm:[--cell-size:2.5rem]"
             month={visibleMonth}
             disabled={(date) => !hasMeal(date)}
             fixedWeeks

--- a/frontend/src/features/meals/components/meal-history-section.test.tsx
+++ b/frontend/src/features/meals/components/meal-history-section.test.tsx
@@ -83,6 +83,8 @@ describe('MealHistorySection', () => {
         expect(markup).toContain('data-meal-history-overview="true"');
         expect(markup).toContain('data-meal-history-weekly="true"');
         expect(source).toContain('lg:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)]');
+        expect(source).toContain('w-fit max-w-full');
+        expect(source).toContain('overflow-hidden');
         expect(source).toContain('className="grid gap-4 sm:grid-cols-2"');
         expect(source).not.toContain('lg:grid-cols-1');
         expect(source).toMatch(
@@ -115,9 +117,10 @@ describe('MealHistorySection', () => {
         expect(markup).toContain('data-meal-history-weekly="true"');
         expect(markup).toContain('lg:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)]');
         expect(markup).toContain('선택한 날짜 급식');
-        expect(markup).toContain('달력은 좌우로 스크롤해 모든 요일을 확인할 수 있습니다.');
+        expect(markup).not.toContain('달력은 좌우로 스크롤해 모든 요일을 확인할 수 있습니다.');
         expect(markup).toContain('min-w-0');
-        expect(markup).toContain('max-w-80');
+        expect(markup).toContain('w-fit');
+        expect(markup).toContain('max-w-full');
         expect(markup).toContain('이 달에 저장된 급식 기록이 없습니다.');
         expect(markup).toContain('저장된 주간 급식표가 없습니다.');
     });

--- a/frontend/src/features/meals/components/meal-history-section.tsx
+++ b/frontend/src/features/meals/components/meal-history-section.tsx
@@ -78,10 +78,7 @@ function MealHistoryMonth({
                 className="grid items-start gap-4 lg:grid-cols-[minmax(17rem,20rem)_minmax(0,1fr)]"
                 data-meal-history-overview="true"
             >
-                <Card className="mx-auto w-full max-w-80 min-w-0 gap-3 p-4 shadow-none lg:mx-0">
-                    <p className="text-base leading-6 text-muted-foreground sm:hidden">
-                        달력은 좌우로 스크롤해 모든 요일을 확인할 수 있습니다.
-                    </p>
+                <Card className="mx-auto w-fit max-w-full min-w-0 gap-3 overflow-hidden p-4 shadow-none lg:mx-0">
                     <MealHistoryCalendar
                         availableDates={availableDates}
                         month={visibleMonthKey}

--- a/frontend/src/features/meals/components/meal-preferences-section.test.tsx
+++ b/frontend/src/features/meals/components/meal-preferences-section.test.tsx
@@ -54,5 +54,7 @@ describe('MealPreferencesSection', () => {
         expect(markup).toContain('>석식<');
         expect(markup).toMatch(/role="switch"[^>]+aria-labelledby=/u);
         expect(markup).toContain('설정 저장');
+        expect(markup).toMatch(/data-slot="card" class="[^"]*gap-6/u);
+        expect(markup).not.toMatch(/data-slot="card" class="[^"]*gap-4/u);
     });
 });

--- a/frontend/src/features/meals/components/meal-preferences-section.tsx
+++ b/frontend/src/features/meals/components/meal-preferences-section.tsx
@@ -126,7 +126,7 @@ export function MealPreferencesSection() {
 
     return (
         <>
-            <Card className="gap-4">
+            <Card>
                 <CardHeader>
                     <CardTitle className="flex items-center gap-2">
                         <BellRing className="size-4 text-primary" />

--- a/frontend/src/features/meals/pages/meals-page.test.tsx
+++ b/frontend/src/features/meals/pages/meals-page.test.tsx
@@ -20,6 +20,12 @@ describe('MealsPage information architecture', () => {
         expect(historySource).not.toContain('MealHistoryLoadMore');
     });
 
+    it('급식 섹션 사이에 일관된 세로 여백을 둔다', () => {
+        expect(source).toMatch(
+            /<div className="space-y-6" data-meals-sections="true">[\s\S]*aria-labelledby="today-meals-title"[\s\S]*aria-labelledby="weekly-meal-title"[\s\S]*<MealHistorySection/u,
+        );
+    });
+
     it('오늘 급식에 주간 pinned fallback을 쓰지 않고 Badge나 그라데이션을 사용하지 않는다', () => {
         expect(source).not.toMatch(/todayMeals[\s\S]{0,200}pinnedMenus/u);
         expect(source).not.toMatch(/\bBadge\b|gradient/u);

--- a/frontend/src/features/meals/pages/meals-page.tsx
+++ b/frontend/src/features/meals/pages/meals-page.tsx
@@ -240,7 +240,7 @@ export function MealsPage() {
                         );
 
                         return (
-                            <>
+                            <div className="space-y-6" data-meals-sections="true">
                                 <MealsPageStatusBanner
                                     isRefreshing={featureRefreshing}
                                     lastCheckedAt={lastCheckedAt}
@@ -311,7 +311,7 @@ export function MealsPage() {
                                         />
                                     </section>
                                 )}
-                            </>
+                            </div>
                         );
                     }}
                 </MealsPageBoundary>

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 allprojects {
     group = "app.junglebell"
-    version = "0.6.0-beta.2"
+    version = "0.6.0-beta.3"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 변경 사항

- 세탁실 상단의 요약·워시타워·기기 상세·내 알림 점프 링크를 제거했습니다.
- 급식 섹션 제목 사이의 상단 여백을 복구하고 달력을 고정 크기·고정 6주 행으로 바꿔 양축 스크롤을 없앴습니다.
- 알림 패널의 스크롤 소유자를 본문 하나로 정리했습니다.
- 홈과 출석 화면의 카드 높이, 패딩, 상태 배치를 압축했습니다.
- 설정의 앱 상태 탭에 해결되지 않은 경고 수를 계속 표시합니다. 백그라운드 상태 조회 실패도 중복 없이 집계합니다.
- 자동 업데이트 설정을 UI에서 제거했습니다. 데스크톱은 기존 설정값과 무관하게 항상 업데이트를 확인하며, 레거시 설정 파일의 값은 마이그레이션 과정에서 제거됩니다.
- 동일 계층 설정 목록의 간격을 통일했습니다.
- 버전을 0.6.0-beta.3으로 정렬했습니다.

## 검증

- npm run check: 140 files, 859 tests
- npm run build:web
- npm run verify:desktop: Rust lib 241 tests + integration 2 tests, fmt, clippy
- React Doctor: 93/100, 발견 이슈 없음
- release channel contract: 6 tests
- 1180x780 시각 QA 및 달력 DOM 치수 검증
