### PR TITLE
fix(ui): 세탁실 상태 경고 중복 제거

### DIFF
--- a/frontend/src/features/laundry/components/laundry-machine-list.test.tsx
+++ b/frontend/src/features/laundry/components/laundry-machine-list.test.tsx
@@ -227,19 +227,13 @@ describe('LaundryMachineList', () => {
         );
     });
 
-    it('stale 상세 카드마다 실시간 데이터가 아님을 표시한다', () => {
+    it('하위 상세 카드에서 페이지 단위 신뢰도 경고를 반복하지 않는다', () => {
         const markup = renderToStaticMarkup(
-            <LaundryMachineList
-                dataStale
-                machines={machines}
-                nowMs={NOW_MS}
-                staleLabel="오전 11:30"
-            />,
+            <LaundryMachineList machines={machines} nowMs={NOW_MS} />,
         );
 
-        expect(markup).toContain('실시간 정보가 아닙니다 · 마지막 정상 시각 오전 11:30');
-        expect(markup.match(/data-data-state="stale"/gu)).toHaveLength(2);
-        expect(markup).toMatch(/실시간 정보가 아닙니다[^<]*<\/p>/u);
-        expect(source).toContain('text-base leading-6');
+        expect(markup).not.toContain('실시간 정보가 아닙니다');
+        expect(markup).not.toContain('실시간 아님');
+        expect(markup).not.toContain('data-data-state');
     });
 });

--- a/frontend/src/features/laundry/components/laundry-machine-list.tsx
+++ b/frontend/src/features/laundry/components/laundry-machine-list.tsx
@@ -25,8 +25,6 @@ export interface LaundryMachineListProps {
     machines: readonly DashboardLaundryMachine[];
     nowMs: number;
     showRiskWarnings?: boolean;
-    dataStale?: boolean;
-    staleLabel?: string | null;
 }
 
 const clockFormatter = new Intl.DateTimeFormat('ko-KR', {
@@ -203,13 +201,11 @@ function ApplianceDetail({
 }
 
 function LaundryMachineCard({
-    dataStale,
     index,
     machine,
     showRiskWarnings,
     titleId,
 }: {
-    dataStale: boolean;
     index: number;
     machine: LaundryMachineDetailView;
     showRiskWarnings: boolean;
@@ -218,17 +214,11 @@ function LaundryMachineCard({
     return (
         <Card
             className="h-full min-w-0 gap-0 overflow-hidden py-0 shadow-none"
-            data-data-state={dataStale ? 'stale' : 'current'}
             data-laundry-machine-card="true"
         >
             <CardHeader className="flex min-w-0 flex-row items-center justify-between gap-3 border-b px-4 py-3 [.border-b]:pb-3">
                 <h3 className="text-base leading-none font-semibold">{machine.title}</h3>
                 <div className="flex shrink-0 items-center gap-2">
-                    {dataStale ? (
-                        <span className="text-base leading-6 text-amber-700 dark:text-amber-300">
-                            실시간 아님
-                        </span>
-                    ) : null}
                     <LaundryZoneBadge zone={machine.zone} />
                 </div>
             </CardHeader>
@@ -256,8 +246,6 @@ export function LaundryMachineList({
     machines,
     nowMs,
     showRiskWarnings = false,
-    dataStale = false,
-    staleLabel,
 }: LaundryMachineListProps) {
     const titleId = useId();
     const views = sortWashTowers(machines).map((machine) => laundryMachineDetail(machine, nowMs));
@@ -268,16 +256,10 @@ export function LaundryMachineList({
             <h2 className="font-semibold" id={titleId}>
                 기기별 상세 상태
             </h2>
-            {dataStale ? (
-                <p className="text-base leading-6 text-amber-700 dark:text-amber-300">
-                    실시간 정보가 아닙니다 · 마지막 정상 시각 {staleLabel ?? '확인 기록 없음'}
-                </p>
-            ) : null}
             <TooltipProvider delayDuration={200}>
                 <div className="grid items-stretch gap-3 md:grid-cols-2 lg:grid-cols-3">
                     {views.map((machine, machineIndex) => (
                         <LaundryMachineCard
-                            dataStale={dataStale}
                             index={machineIndex}
                             key={machine.id}
                             machine={machine}

--- a/frontend/src/features/laundry/components/wash-tower-grid.test.tsx
+++ b/frontend/src/features/laundry/components/wash-tower-grid.test.tsx
@@ -217,19 +217,12 @@ describe('WashTowerGrid', () => {
         expect(markup).not.toContain('예상');
     });
 
-    it('모바일 가로 스크롤 안내와 stale 시각을 표 문맥 안에 표시한다', () => {
-        const markup = renderToStaticMarkup(
-            <WashTowerGrid
-                dataStale
-                dataStaleLabel="오전 11:30"
-                machines={machines}
-                nowMs={NOW_MS}
-            />,
-        );
+    it('모바일 가로 스크롤 안내만 표 문맥 안에 표시한다', () => {
+        const markup = renderToStaticMarkup(<WashTowerGrid machines={machines} nowMs={NOW_MS} />);
 
         expect(markup).toContain('좌우로 스크롤');
-        expect(markup).toContain('실시간 정보가 아닙니다 · 마지막 정상 시각 오전 11:30');
+        expect(markup).not.toContain('실시간 정보가 아닙니다');
         expect(markup).toContain('overflow-x-auto');
-        expect(markup.match(/text-base leading-6/gu)?.length).toBeGreaterThanOrEqual(2);
+        expect(markup.match(/text-base leading-6/gu)?.length).toBeGreaterThanOrEqual(1);
     });
 });

--- a/frontend/src/features/laundry/components/wash-tower-grid.tsx
+++ b/frontend/src/features/laundry/components/wash-tower-grid.tsx
@@ -16,17 +16,9 @@ export interface WashTowerGridProps {
     machines: readonly DashboardLaundryMachine[];
     nowMs: number;
     showRiskIndicators?: boolean;
-    dataStale?: boolean;
-    dataStaleLabel?: string | null;
 }
 
-export function WashTowerGrid({
-    machines,
-    nowMs,
-    showRiskIndicators = false,
-    dataStale = false,
-    dataStaleLabel,
-}: WashTowerGridProps) {
+export function WashTowerGrid({machines, nowMs, showRiskIndicators = false}: WashTowerGridProps) {
     const towers = sortWashTowers(machines);
     if (towers.length === 0) return null;
 
@@ -37,11 +29,6 @@ export function WashTowerGrid({
             role="region"
             tabIndex={0}
         >
-            {dataStale ? (
-                <p className="mb-2 text-base leading-6 text-amber-700 dark:text-amber-300">
-                    실시간 정보가 아닙니다 · 마지막 정상 시각 {dataStaleLabel ?? '확인 기록 없음'}
-                </p>
-            ) : null}
             <p className="mb-2 block text-base leading-6 text-muted-foreground sm:hidden">
                 표가 화면을 벗어나면 좌우로 스크롤해 자세히 확인하세요.
             </p>

--- a/frontend/src/features/laundry/pages/laundry-page.test.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.test.tsx
@@ -83,4 +83,11 @@ describe('LaundryPage capacity summary', () => {
         expect(boundarySource).toContain('regionLabel="세탁실 데이터"');
         expect(boundarySource).toContain('type="offline"');
     });
+
+    it('마지막 정상 시각을 페이지 데이터 범위에서 한 번만 안내한다', () => {
+        expect(source).toContain('<LaundryStatusNotice');
+        expect(source).toContain("data-data-state={presentation.dataStale ? 'stale' : 'current'}");
+        expect(source.match(/lastUpdatedAt=/gu)).toHaveLength(1);
+        expect(source).not.toContain('staleBanner');
+    });
 });

--- a/frontend/src/features/laundry/pages/laundry-page.tsx
+++ b/frontend/src/features/laundry/pages/laundry-page.tsx
@@ -39,11 +39,6 @@ function capacityTone(card: CapacityCardView): string {
     return laundryZonePresentation(card.access).surfaceClassName;
 }
 
-function staleBanner(status: LaundryPageStatus): string | null {
-    if (!isFailureKind(status.kind)) return null;
-    return `실시간 정보가 아닙니다. 마지막 정상 시각: ${status.lastKnownLabel}`;
-}
-
 const COLLECTOR_UNAVAILABLE_TITLE = '세탁실 수집 서버에 문제가 있습니다.';
 const COLLECTOR_UNAVAILABLE_MESSAGE =
     '실시간 상태를 확인할 수 없어 마지막 정상 데이터를 표시합니다.';
@@ -158,7 +153,6 @@ function laundryPagePresentation(input: {
     });
 
     const dataStale = collectorUnavailable || isFailureKind(status.kind);
-    const staleLabel = staleBanner(status);
     const statusTitle = collectorUnavailable ? COLLECTOR_UNAVAILABLE_TITLE : status.title;
     const statusMessage = collectorUnavailable ? COLLECTOR_UNAVAILABLE_MESSAGE : status.message;
     const summaries = capacityCards(snapshot.capacity, reliable);
@@ -168,7 +162,6 @@ function laundryPagePresentation(input: {
         dataStale,
         nowMs,
         snapshot,
-        staleLabel,
         status,
         statusMessage,
         statusTitle,
@@ -179,7 +172,7 @@ function laundryPagePresentation(input: {
 type LaundryPagePresentation = ReturnType<typeof laundryPagePresentation>;
 
 function LaundryCapacitySummary({presentation}: {presentation: LaundryPagePresentation}) {
-    const {nowMs, snapshot, staleLabel, summaries} = presentation;
+    const {nowMs, snapshot, summaries} = presentation;
 
     return (
         <section aria-labelledby="laundry-capacity-title">
@@ -191,11 +184,6 @@ function LaundryCapacitySummary({presentation}: {presentation: LaundryPagePresen
                     마지막 확인{' '}
                     {relativeTimeLabel(snapshot.quality.lastCheckedAt ?? snapshot.asOf, nowMs)}
                 </p>
-                {staleLabel ? (
-                    <p className="text-base leading-6 text-amber-700 dark:text-amber-300">
-                        {staleLabel}
-                    </p>
-                ) : null}
             </div>
             <div className="grid min-w-0 gap-3 sm:grid-cols-2">
                 {summaries.map((card) => (
@@ -262,7 +250,7 @@ function LaundryTowerStatus({
     showRisk: boolean;
     onShowRiskChange: (showRisk: boolean) => void;
 }) {
-    const {dataStale, nowMs, snapshot, staleLabel, status} = presentation;
+    const {nowMs, snapshot} = presentation;
 
     return (
         <Card className="min-w-0 gap-0 overflow-hidden py-0" id="laundry-tower-title">
@@ -286,18 +274,11 @@ function LaundryTowerStatus({
                 <LaundryRiskToggle checked={showRisk} onCheckedChange={onShowRiskChange} />
             ) : null}
             <CardContent className="px-4 pt-0 pb-3 sm:px-6">
-                {staleLabel ? (
-                    <p className="mb-2 text-base leading-6 text-amber-700 dark:text-amber-300">
-                        {staleLabel}
-                    </p>
-                ) : null}
                 {snapshot.machines.length > 0 ? (
                     <WashTowerGrid
                         machines={snapshot.machines}
                         nowMs={nowMs}
                         showRiskIndicators={showRisk}
-                        dataStale={dataStale}
-                        dataStaleLabel={status.lastKnownLabel}
                     />
                 ) : (
                     <p className="py-5 text-center text-base leading-6 text-muted-foreground">
@@ -316,15 +297,13 @@ function LaundryMachineDetails({
     presentation: LaundryPagePresentation;
     showRisk: boolean;
 }) {
-    const {dataStale, nowMs, snapshot, status} = presentation;
+    const {nowMs, snapshot} = presentation;
     return (
         <section aria-label="기기별 상세 상태" id="laundry-detail-title">
             <LaundryMachineList
                 machines={snapshot.machines}
                 nowMs={nowMs}
                 showRiskWarnings={showRisk}
-                dataStale={dataStale}
-                staleLabel={status.lastKnownLabel}
             />
         </section>
     );
@@ -361,7 +340,10 @@ function LaundryPageContent({
     onShowRiskChange: (showRisk: boolean) => void;
 }) {
     return (
-        <div className="min-w-0 space-y-6">
+        <div
+            className="min-w-0 space-y-6"
+            data-data-state={presentation.dataStale ? 'stale' : 'current'}
+        >
             <LaundryStatusNotice
                 manualRefresh={manualRefresh}
                 message={presentation.statusMessage}


### PR DESCRIPTION
## 변경 사항
- 세탁 stale/offline 안내를 페이지 상단 한 곳으로 통합
- 용량, 워시타워, 상세 카드의 반복 경고 제거
- 페이지 단위 데이터 상태와 회귀 테스트 유지

## 검증
- frontend check 통과
- 전체 Vitest 860개 통과
- React Doctor 100/100