### PR TITLE
ci: mise로 개발 도구 버전 통일

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+      - name: Set up prek
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          prek-version: "0.4.14"
-          install-only: true
+          version: "2026.9.5"
+          install_args: prek
       - run: prek validate-config prek.toml
       - run: prek run --all-files --group hygiene --show-diff-on-failure
 
@@ -38,11 +39,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          version: "2026.9.5"
+          install_args: node
+      - name: Cache npm downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
       - run: npm ci
         working-directory: frontend
       - run: npm run verify:web
@@ -56,11 +64,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-java@v5
+      - name: Set up Java
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          distribution: temurin
-          java-version: 21
-          cache: gradle
+          version: "2026.9.5"
+          install_args: java
+      - name: Set up Gradle cache
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       - run: chmod +x server/gradlew
       - run: ./gradlew --no-daemon check :api:bootJar :worker:bootJar
         working-directory: server
@@ -98,14 +108,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js and Rust
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - uses: dtolnay/rust-toolchain@stable
+          version: "2026.9.5"
+          install_args: node rust
+          cache: false
+      - name: Ensure Rust components
+        run: rustup component add --toolchain stable rustfmt clippy
+      - name: Cache npm downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          components: clippy,rustfmt
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop -> target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          node-version: 24
+          version: "2026.9.5"
+          install_args: node
 
       - name: Validate tag, draft release, and exact-SHA CI
         id: info
@@ -146,21 +148,28 @@ jobs:
           ref: ${{ needs.prepare-release.outputs.sha }}
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Set up Node.js and Rust
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          version: "2026.9.5"
+          install_args: node rust
+          cache: false
+
+      - name: Cache npm downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+      - name: Install macOS Rust targets
+        if: runner.os == 'macOS'
+        run: rustup target add --toolchain stable aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,23 @@
 
 ## 준비
 
-- Node.js 24
-- Java 21
-- Rust stable과 `rustfmt`, `clippy`
-- prek 0.4.9 이상
+- mise 2025.8.11 이상
 - 서버를 로컬에서 실행할 경우 Docker
 - Tauri가 요구하는 운영체제별 빌드 도구
+
+Node.js 24, Temurin Java 21, Rust stable과 `rustfmt`·`clippy`, prek 0.4.14는
+저장소의 `mise.toml`에서 관리합니다. 저장소 루트에서 설치합니다.
+
+```bash
+mise install
+```
 
 ## Git 훅 설치
 
 저장소 루트에서 prek의 `pre-commit`, `pre-push` 훅을 설치합니다.
 
 ```bash
-prek install
+mise exec -- prek install
 ```
 
 `pre-commit`은 staged diff, 설정 파일, 프론트엔드 포맷·lint와 Rust 포맷을 빠르게 검사합니다. `main` 브랜치에는 직접 커밋할 수 없습니다. `pre-push`는 변경 경로에 따라 프론트엔드 check, 서버 Gradle check, 데스크톱 test·clippy를 실행합니다.
@@ -26,14 +30,14 @@ prek install
 설정과 기본 위생 검사를 수동으로 확인하려면 다음 명령을 실행합니다.
 
 ```bash
-prek validate-config prek.toml
-prek run --all-files --group hygiene
+mise exec -- prek validate-config prek.toml
+mise exec -- prek run --all-files --group hygiene
 ```
 
 모든 `pre-push` 검사를 수동으로 실행하려면 다음 명령을 사용합니다.
 
 ```bash
-prek run --all-files --stage pre-push
+mise exec -- prek run --all-files --stage pre-push
 ```
 
 ## 저장소 구조
@@ -53,13 +57,13 @@ prek run --all-files --stage pre-push
 
 ```bash
 cd frontend
-npm ci
+mise exec -- npm ci
 ```
 
 ### 웹·PWA
 
 ```bash
-npm run dev:web
+mise exec -- npm run dev:web
 ```
 
 ### PC 앱
@@ -68,14 +72,14 @@ macOS와 Linux에서는 다음과 같이 실행합니다.
 
 ```bash
 export JUNGLE_BELL_DATA_API_URL=https://jungle-bell.sijun-yang.com
-npm run desktop:dev
+mise exec -- npm run desktop:dev
 ```
 
 Windows PowerShell에서는 환경 변수를 먼저 설정합니다.
 
 ```powershell
 $env:JUNGLE_BELL_DATA_API_URL = "https://jungle-bell.sijun-yang.com"
-npm run desktop:dev
+mise exec -- npm run desktop:dev
 ```
 
 ### 서버
@@ -84,7 +88,7 @@ npm run desktop:dev
 
 ```bash
 cd server
-./gradlew check :api:bootJar :worker:bootJar
+mise exec -- ./gradlew check :api:bootJar :worker:bootJar
 ```
 
 PostgreSQL을 포함한 로컬 실행 방법은 [`server/README.md`](server/README.md)를 참고하세요.
@@ -95,14 +99,14 @@ PostgreSQL을 포함한 로컬 실행 방법은 [`server/README.md`](server/READ
 
 ```bash
 cd frontend
-npm run verify
+mise exec -- npm run verify
 ```
 
 서버 전체 검증:
 
 ```bash
 cd server
-./gradlew --no-daemon check :api:bootJar :worker:bootJar
+mise exec -- ./gradlew --no-daemon check :api:bootJar :worker:bootJar
 ```
 
 문서만 변경했더라도 링크, 이미지 경로와 Markdown 렌더링을 확인하고 `git diff --check`를 실행합니다.
@@ -111,7 +115,8 @@ cd server
 
 Pull Request와 `main` push에서는 GitHub Actions의 `CI` 워크플로가 hygiene, 웹, 서버,
 macOS·Windows 데스크톱 검증을 실행합니다. 브랜치 규칙에는 고정 집계 잡인
-`CI / required`를 필수 체크로 사용합니다.
+`CI / required`를 필수 체크로 사용합니다. 각 잡은 `mise.toml`에서 필요한 도구만 설치해
+로컬과 같은 버전 정책을 사용합니다.
 
 서버 배포는 GitHub Actions에서 수행하지 않습니다. 운영망 접근 권한이 있는 로컬 환경에서
 [OCI 운영 서버 배포 가이드](server/deploy/guide_oci_production_deployment.md)를 따라 수동으로
@@ -131,7 +136,7 @@ macOS·Windows 데스크톱 검증을 실행합니다. 브랜치 규칙에는 �
 
 ## Pull Request 전 확인
 
-- `prek install`로 로컬 Git 훅을 설치합니다.
+- `mise exec -- prek install`로 로컬 Git 훅을 설치합니다.
 - 변경 범위에 해당하는 테스트와 검증 명령을 통과시킵니다.
 - 사용자 동작이나 플랫폼 계약이 바뀌면 관련 문서를 함께 수정합니다.
 - 비밀값, 개인 세션 파일, 로그와 캡처용 임시 파일을 커밋하지 않습니다.

--- a/frontend/src/tests/contracts/ci-prek-contract.test.ts
+++ b/frontend/src/tests/contracts/ci-prek-contract.test.ts
@@ -5,8 +5,10 @@ import {test} from 'vitest';
 
 const repoRoot = new URL('../../../../', import.meta.url);
 const repoSource = (path: string) => readFileSync(new URL(path, repoRoot), 'utf8');
+const miseConfig = repoSource('mise.toml');
 const prekConfig = repoSource('prek.toml');
 const ciWorkflow = repoSource('.github/workflows/ci.yml');
+const releaseWorkflow = repoSource('.github/workflows/release.yml');
 const prekHooks = prekConfig.split('[[repos.hooks]]').slice(1);
 const prekHook = (id: string) => {
     const hook = prekHooks.find((candidate) => candidate.includes(`id = "${id}"`));
@@ -15,18 +17,25 @@ const prekHook = (id: string) => {
 };
 
 test('prek는 빠른 pre-commit과 경로별 pre-push 검사를 설치한다', () => {
-    assert.match(prekConfig, /minimum_prek_version = "0\.4\.9"/u);
+    assert.match(prekConfig, /minimum_prek_version = "0\.4\.14"/u);
     assert.match(prekConfig, /default_install_hook_types = \["pre-commit", "pre-push"\]/u);
-    assert.match(prekHook('staged-diff-check'), /git diff --cached --check/u);
+    assert.match(prekHook('staged-diff-check'), /git --no-pager diff --cached --check/u);
     assert.match(prekHook('no-commit-to-branch'), /"--branch", "main"/u);
     assert.match(prekHook('frontend-format'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('frontend-format'), /entry = "mise exec -- npm/u);
     assert.match(prekHook('frontend-lint'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('frontend-lint'), /entry = "mise exec -- npm/u);
     assert.match(prekHook('desktop-rustfmt'), /stages = \["pre-commit"\]/u);
+    assert.match(prekHook('desktop-rustfmt'), /entry = "mise exec -- cargo/u);
     assert.match(prekHook('frontend-check'), /stages = \["pre-push"\]/u);
     assert.match(prekHook('frontend-check'), /files = "\^\(frontend\|desktop\)\/"/u);
+    assert.match(prekHook('frontend-check'), /entry = "mise exec -- npm/u);
     assert.match(prekHook('server-check'), /stages = \["pre-push"\]/u);
+    assert.match(prekHook('server-check'), /entry = "mise exec -- \.\/server\/gradlew/u);
     assert.match(prekHook('desktop-test'), /JUNGLE_BELL_DATA_API_URL/u);
+    assert.match(prekHook('desktop-test'), /entry = "mise exec -- cargo/u);
     assert.match(prekHook('desktop-clippy'), /JUNGLE_BELL_DATA_API_URL/u);
+    assert.match(prekHook('desktop-clippy'), /entry = "mise exec -- cargo/u);
     assert.doesNotMatch(prekConfig, /campus-observer/u);
 
     const localHooks = prekConfig.slice(prekConfig.indexOf('repo = "local"'));
@@ -38,12 +47,48 @@ test('prek는 빠른 pre-commit과 경로별 pre-push 검사를 설치한다', (
     }
 });
 
+test('mise는 로컬과 GitHub Actions의 개발 도구 버전 정책을 통일한다', () => {
+    assert.match(miseConfig, /^min_version = "2025\.8\.11"$/mu);
+    assert.match(miseConfig, /^node = "24"$/mu);
+    assert.match(miseConfig, /^java = "temurin-21"$/mu);
+    assert.match(miseConfig, /^prek = "0\.4\.14"$/mu);
+    assert.match(
+        miseConfig,
+        /^rust = \{ version = "stable", profile = "minimal", components = \[\s*"rustfmt",\s*"clippy",\s*\] \}$/mu,
+    );
+
+    assert.equal(ciWorkflow.match(/jdx\/mise-action@[0-9a-f]{40}/gu)?.length, 4);
+    assert.equal(releaseWorkflow.match(/jdx\/mise-action@[0-9a-f]{40}/gu)?.length, 2);
+    assert.equal(ciWorkflow.match(/version: "2026\.9\.5"/gu)?.length, 4);
+    assert.equal(releaseWorkflow.match(/version: "2026\.9\.5"/gu)?.length, 2);
+    assert.match(ciWorkflow, /^          install_args: prek$/mu);
+    assert.match(ciWorkflow, /^          install_args: node$/mu);
+    assert.match(ciWorkflow, /^          install_args: java$/mu);
+    assert.match(ciWorkflow, /^          install_args: node rust$/mu);
+    assert.match(releaseWorkflow, /^          install_args: node$/mu);
+    assert.match(releaseWorkflow, /^          install_args: node rust$/mu);
+
+    for (const workflow of [ciWorkflow, releaseWorkflow]) {
+        assert.doesNotMatch(workflow, /actions\/setup-node/u);
+        assert.doesNotMatch(workflow, /actions\/setup-java/u);
+        assert.doesNotMatch(workflow, /dtolnay\/rust-toolchain/u);
+        assert.doesNotMatch(workflow, /node-version:/u);
+        assert.doesNotMatch(workflow, /java-version:/u);
+    }
+    assert.doesNotMatch(ciWorkflow, /j178\/prek-action/u);
+    assert.doesNotMatch(ciWorkflow, /prek-version:/u);
+    assert.match(ciWorkflow, /gradle\/actions\/setup-gradle@[0-9a-f]{40} # v6\.3\.0/u);
+    assert.equal(ciWorkflow.match(/actions\/cache@[0-9a-f]{40} # v6\.1\.0/gu)?.length, 2);
+    assert.equal(releaseWorkflow.match(/actions\/cache@[0-9a-f]{40} # v6\.1\.0/gu)?.length, 1);
+    assert.match(ciWorkflow, /rustup component add --toolchain stable rustfmt clippy/u);
+    assert.match(
+        releaseWorkflow,
+        /rustup target add --toolchain stable aarch64-apple-darwin x86_64-apple-darwin/u,
+    );
+});
+
 test('CI는 hygiene와 제품 검증을 고정 required 잡으로 집계한다', () => {
     assert.match(ciWorkflow, /^  hygiene:\s*$/mu);
-    assert.match(
-        ciWorkflow,
-        /j178\/prek-action@[0-9a-f]{40}[\s\S]*prek-version: "0\.4\.14"[\s\S]*install-only: true/u,
-    );
     assert.match(ciWorkflow, /prek validate-config prek\.toml/u);
     assert.match(ciWorkflow, /prek run --all-files --group hygiene/u);
     assert.match(ciWorkflow, /^  web:\s*$/mu);

--- a/frontend/src/tests/contracts/release-channel.test.ts
+++ b/frontend/src/tests/contracts/release-channel.test.ts
@@ -153,7 +153,7 @@ test('데스크톱 릴리스는 exact SHA의 CI 통과 후 서명·공개 환경
     assert.match(releaseWorkflow, /headSha/u);
     assert.match(releaseWorkflow, /\.name == "required"/u);
     assert.match(releaseWorkflow, /ref:\s*\$\{\{ needs\.prepare-release\.outputs\.sha \}\}/u);
-    assert.match(releaseWorkflow, /node-version:\s*24/u);
+    assert.match(releaseWorkflow, /install_args:\s*node rust/u);
     assert.match(releaseWorkflow, /environment:\s*desktop-signing/u);
     assert.match(releaseWorkflow, /max-parallel:\s*1/u);
     assert.match(releaseWorkflow, /tauri-apps\/tauri-action@[0-9a-f]{40}/u);

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+min_version = "2025.8.11"
+
+[tools]
+node = "24"
+java = "temurin-21"
+rust = { version = "stable", profile = "minimal", components = [
+  "rustfmt",
+  "clippy",
+] }
+prek = "0.4.14"

--- a/prek.toml
+++ b/prek.toml
@@ -1,6 +1,6 @@
 #:schema https://www.schemastore.org/prek.json
 
-minimum_prek_version = "0.4.9"
+minimum_prek_version = "0.4.14"
 default_install_hook_types = ["pre-commit", "pre-push"]
 
 [[repos]]
@@ -59,7 +59,7 @@ repo = "local"
 [[repos.hooks]]
 id = "staged-diff-check"
 name = "staged diff check"
-entry = "git diff --cached --check"
+entry = "git --no-pager diff --cached --check"
 language = "system"
 pass_filenames = false
 always_run = true
@@ -68,7 +68,7 @@ stages = ["pre-commit"]
 [[repos.hooks]]
 id = "frontend-format"
 name = "frontend format"
-entry = "npm --prefix frontend run format:check"
+entry = "mise exec -- npm --prefix frontend run format:check"
 language = "system"
 pass_filenames = false
 files = "^frontend/"
@@ -77,7 +77,7 @@ stages = ["pre-commit"]
 [[repos.hooks]]
 id = "frontend-lint"
 name = "frontend lint"
-entry = "npm --prefix frontend run lint"
+entry = "mise exec -- npm --prefix frontend run lint"
 language = "system"
 pass_filenames = false
 files = "^frontend/"
@@ -86,7 +86,7 @@ stages = ["pre-commit"]
 [[repos.hooks]]
 id = "desktop-rustfmt"
 name = "desktop rustfmt"
-entry = "cargo fmt --manifest-path desktop/Cargo.toml --check"
+entry = "mise exec -- cargo fmt --manifest-path desktop/Cargo.toml --check"
 language = "system"
 pass_filenames = false
 files = "^desktop/.*\\.rs$"
@@ -95,7 +95,7 @@ stages = ["pre-commit"]
 [[repos.hooks]]
 id = "frontend-check"
 name = "frontend check"
-entry = "npm --prefix frontend run check"
+entry = "mise exec -- npm --prefix frontend run check"
 language = "system"
 pass_filenames = false
 files = "^(frontend|desktop)/"
@@ -104,7 +104,7 @@ stages = ["pre-push"]
 [[repos.hooks]]
 id = "server-check"
 name = "server check"
-entry = "./server/gradlew --no-daemon -p server check"
+entry = "mise exec -- ./server/gradlew --no-daemon -p server check"
 language = "system"
 pass_filenames = false
 files = "^server/"
@@ -113,7 +113,7 @@ stages = ["pre-push"]
 [[repos.hooks]]
 id = "desktop-test"
 name = "desktop test"
-entry = "cargo test --manifest-path desktop/Cargo.toml --all-targets"
+entry = "mise exec -- cargo test --manifest-path desktop/Cargo.toml --all-targets"
 language = "system"
 pass_filenames = false
 files = "^desktop/"
@@ -123,7 +123,7 @@ env = { JUNGLE_BELL_DATA_API_URL = "https://jungle-bell.sijun-yang.com" }
 [[repos.hooks]]
 id = "desktop-clippy"
 name = "desktop clippy"
-entry = "cargo clippy --manifest-path desktop/Cargo.toml --all-targets -- -D warnings"
+entry = "mise exec -- cargo clippy --manifest-path desktop/Cargo.toml --all-targets -- -D warnings"
 language = "system"
 pass_filenames = false
 files = "^desktop/"


### PR DESCRIPTION
## 변경 사항
- mise.toml에서 Node 24, Temurin 21, Rust stable, prek 0.4.14를 관리합니다.
- CI와 데스크톱 릴리스가 잡별로 필요한 mise 도구만 설치하도록 통일했습니다.
- npm, Gradle, Cargo 캐시는 유지하고 Rust가 포함된 mise 캐시는 비활성화했습니다.
- Git 훅과 기여 가이드, 관련 계약 테스트를 mise 기준으로 맞췄습니다.

## 검증
- mise fmt --check
- prek validate-config 및 전체 hygiene
- npm run verify:web: 140 files, 861 tests
- Gradle check 및 API/Worker bootJar
- npm run verify:desktop: Rust 243 tests, clippy
- pre-commit 및 pre-push 훅